### PR TITLE
ONNX mask_rcnn_qdq failed with AssertionError

### DIFF
--- a/neural_compressor/model/onnx_model.py
+++ b/neural_compressor/model/onnx_model.py
@@ -403,7 +403,8 @@ class ONNXModel(BaseModel):
                 q = copy.deepcopy(wait)
                 wait.clear()
         nodes = [i[1] for i in all_nodes.items()]
-        assert len(nodes) == len(self.model.graph.node)
+        assert len(list(set([n.name for n in nodes]))) == \
+            len(list(set([n.name for n in self.model.graph.node])))
         self.model.graph.ClearField('node')
         self.model.graph.node.extend(nodes)
 


### PR DESCRIPTION
## Type of Change

bug fix

## Description

**Defect/regression:** 

File "/home/tensorflow/miniconda3/envs/onnxrt-1.13.1-3.8-clx8280/lib/python3.8/site-packages/neural_compressor/model/onnx_model.py", line 406, in topological_sort assert len(nodes) == len(self.model.graph.node) AssertionError

**Profile:** log: 

https://inteltf-jenk.sh.intel.com/blue/rest/organizations/jenkins/pipelines/intel-lpot-validation/runs/216404/nodes/114/log/?start=0

**report:**  https://inteltf-jenk.sh.intel.com/job/intel-lpot-validation-top-mr-extension/3406/artifact/report.html

**commit id ：** 

0b7134309ed1ded5fde9905e5686b70edef4b9ad failed

71b056b53015e05b7ab9289d31edaf4200dca628 pass

**Framework:** onnxrt

**Framework version:** 1.13.1

JIRA ticket: [ILITV-2434](https://jira.devtools.intel.com/browse/ILITV-2434)

## How has this PR been tested?

extension test: mask-rcnn-qdq

## Dependency Change?

 no