### PR TITLE
fixed docstring typo in experimental/metric

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Type of Change
 
-feature or bug fix or documentation or others
+feature or bug fix or documentation or validation or others  
 API changed or not
 
 ## Description

--- a/neural_compressor/experimental/metric/evaluate_squad.py
+++ b/neural_compressor/experimental/metric/evaluate_squad.py
@@ -53,10 +53,12 @@ def metric_max_over_ground_truths(metric_fn, prediction, ground_truths):
 
     For each answer in ground_truths, evaluate the metric of prediction with
     this answer, and return the max metric.
+    
     Args:
         metric_fn: The function to calculate the metric.
         prediction: The prediction result.
         ground_truths: A list of correct answers.
+        
     Returns:
         The max metric. Float point number.
     """


### PR DESCRIPTION
## Type of Change

- bug fix  
- API changed or not: None

## Description
Fixed the docstring typo in experimental/metric

## Expected Behavior & Potential Risk

No

## How has this PR been tested?
Scan result by pydocstyle:
![image](https://user-images.githubusercontent.com/106061964/203704923-e7fdc6f4-24ef-4823-919c-d948ccf76519.png)


## Dependency Change?

None