### PR TITLE
Adjust the hyperopt and sigopt as extras requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ scikit-image
 matplotlib
 schema
 py-cpuinfo
-hyperopt
 contextlib2
 requests
 Flask
@@ -20,7 +19,6 @@ Pillow
 pycocotools-windows; sys_platform != 'linux'
 pycocotools; sys_platform == 'linux'
 opencv-python
-sigopt
 prettytable
 cryptography
 sqlalchemy==1.4.27

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ ux_package_data = {
 
 # define install requirements
 install_requires_list = [
-        'numpy', 'pyyaml', 'scikit-learn', 'schema', 'py-cpuinfo', 'hyperopt', 'pandas', 'pycocotools',
-        'opencv-python', 'requests', 'psutil', 'Pillow', 'sigopt', 'prettytable', 'cryptography', 'Cython',
+        'numpy', 'pyyaml', 'scikit-learn', 'schema', 'py-cpuinfo', 'pandas', 'pycocotools',
+        'opencv-python', 'requests', 'psutil', 'Pillow', 'prettytable', 'cryptography', 'Cython',
         'deprecated']
 ux_install_requires_list = [
         'Flask-Cors', 'Flask-SocketIO', 'Flask', 'gevent-websocket', 'gevent','sqlalchemy==1.4.27', 'alembic==1.7.7']

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -14,6 +14,7 @@ transformers<=4.12.3; python_version < '3.10'
 transformers==4.16.0; python_version == '3.10'
 tensorflow_model_optimization
 sigopt
+hyperopt
 horovod
 tensorflow-addons
 onnxruntime-extensions; python_version < '3.10'


### PR DESCRIPTION
Signed-off-by: yiliu30 <yi4.liu@intel.com>

## Type of Change

- bug fix
- API changed or not: None

## Description

Adjust the `hyperopt` and `sigopt` as extras requirements.
JIRA ticket: [ILITV-2452](https://jira.devtools.intel.com/browse/ILITV-2452)

## Expected Behavior & Potential Risk
`hyperopt` and `sigopt`  are not hard dependencies.

## How has this PR been tested?

Pre-CI

## Dependency Change?

Any library dependency introduced or removed:
- `hyperopt` is required only when the user uses `tpe` strategy.
- `sigopt` is required only when the user uses `sigopt` strategy.
