### PR TITLE
Turn off ITEX optimization pass

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -160,6 +160,11 @@ class GraphConverter:
         Args:
             model(TensorflowBaseModel): input TensorflowBaseModel
         """
+        # ITEX optimization has broken INC calibration process.
+        # INC needs turn off ITEX optimization pass in calibration stage.
+        # TODO ITEX will provide API to replace setting environment variable.
+        if self.itex_mode:
+            os.environ["ITEX_REMAPPER"] = "0"
         sess = model.sess
         iter_op = model.iter_op
         input_tensor = model.input_tensor
@@ -238,6 +243,8 @@ class GraphConverter:
                     feed_dict, output_tensor, self.calib_iteration)
             if idx + 1 == self.calib_iteration:
                 break
+        if self.itex_mode:
+            os.environ["ITEX_REMAPPER"] = "1"
 
     def _check_tf_version(self):
         is_supported_version = False

--- a/neural_compressor/model/model.py
+++ b/neural_compressor/model/model.py
@@ -265,8 +265,6 @@ def graph_session(model, input_tensor_names, output_tensor_names, **kwargs):
         from tensorflow.core.protobuf import rewriter_config_pb2
         config.graph_options.rewrite_options.constant_folding = \
                   rewriter_config_pb2.RewriterConfig.OFF
-        config.graph_options.rewrite_options.use_plugin_optimizers = \
-                 rewriter_config_pb2.RewriterConfig.OFF
     sess = tf.compat.v1.Session(graph=model, config=config)
 
     input_tensor_names, output_tensor_names = validate_and_inference_input_output(\
@@ -355,8 +353,6 @@ def load_saved_model(model, saved_model_tags, input_tensor_names, output_tensor_
         from tensorflow.core.protobuf import rewriter_config_pb2
         config.graph_options.rewrite_options.constant_folding = \
                     rewriter_config_pb2.RewriterConfig.OFF
-        config.graph_options.rewrite_options.use_plugin_optimizers = \
-                 rewriter_config_pb2.RewriterConfig.OFF
     if not os.listdir(os.path.join(model,'variables')):
         sess = tf.compat.v1.Session(graph=tf.Graph(), config=config)
         loader = tf.compat.v1.saved_model.loader.load(sess, ["serve"], model)
@@ -653,8 +649,6 @@ def checkpoint_session(model, input_tensor_names, output_tensor_names, **kwargs)
     if get_backend() == 'tensorflow_itex':
         from tensorflow.core.protobuf import rewriter_config_pb2
         config.graph_options.rewrite_options.constant_folding = \
-                 rewriter_config_pb2.RewriterConfig.OFF
-        config.graph_options.rewrite_options.use_plugin_optimizers = \
                  rewriter_config_pb2.RewriterConfig.OFF
     graph = tf.Graph()
     sess = tf.compat.v1.Session(graph=graph, config=config)

--- a/neural_compressor/model/model.py
+++ b/neural_compressor/model/model.py
@@ -265,6 +265,8 @@ def graph_session(model, input_tensor_names, output_tensor_names, **kwargs):
         from tensorflow.core.protobuf import rewriter_config_pb2
         config.graph_options.rewrite_options.constant_folding = \
                   rewriter_config_pb2.RewriterConfig.OFF
+        config.graph_options.rewrite_options.use_plugin_optimizers = \
+                 rewriter_config_pb2.RewriterConfig.OFF
     sess = tf.compat.v1.Session(graph=model, config=config)
 
     input_tensor_names, output_tensor_names = validate_and_inference_input_output(\
@@ -353,6 +355,8 @@ def load_saved_model(model, saved_model_tags, input_tensor_names, output_tensor_
         from tensorflow.core.protobuf import rewriter_config_pb2
         config.graph_options.rewrite_options.constant_folding = \
                     rewriter_config_pb2.RewriterConfig.OFF
+        config.graph_options.rewrite_options.use_plugin_optimizers = \
+                 rewriter_config_pb2.RewriterConfig.OFF
     if not os.listdir(os.path.join(model,'variables')):
         sess = tf.compat.v1.Session(graph=tf.Graph(), config=config)
         loader = tf.compat.v1.saved_model.loader.load(sess, ["serve"], model)
@@ -649,6 +653,8 @@ def checkpoint_session(model, input_tensor_names, output_tensor_names, **kwargs)
     if get_backend() == 'tensorflow_itex':
         from tensorflow.core.protobuf import rewriter_config_pb2
         config.graph_options.rewrite_options.constant_folding = \
+                 rewriter_config_pb2.RewriterConfig.OFF
+        config.graph_options.rewrite_options.use_plugin_optimizers = \
                  rewriter_config_pb2.RewriterConfig.OFF
     graph = tf.Graph()
     sess = tf.compat.v1.Session(graph=graph, config=config)


### PR DESCRIPTION
Signed-off-by: Lv, Liang1 <liang1.lv@intel.com>

## Type of Change

feature
API not changed

## Description

detail description 
JIRA ticket: ILITV-2471
Turn off ITEX optimization pass

## Expected Behavior & Potential Risk

ITEX optimization has broken INC calibration process. INC should turn off ITEX optimization pass in calibration stage.

## How has this PR been tested?

UT, Pre-CI and ITEX OOB extension test.


## Dependency Change?

No.
