### PR TITLE
Add op-wise configs back to densenet models

### DIFF
--- a/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/densenet121.yaml
+++ b/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/densenet121.yaml
@@ -38,6 +38,14 @@ quantization:                                        # optional. tuning constrai
       algorithm: minmax
     weight:
       granularity: per_channel
+  op_wise: {
+             'densenet121/MaxPool2D/MaxPool': {
+               'activation':  {'dtype': ['fp32']}
+             },
+             'densenet121/transition_block[1-3]/AvgPool2D/AvgPool': {
+               'activation':  {'dtype': ['fp32']},
+             }
+           }
 
 evaluation:                                          # optional. required if user doesn't provide eval_func in neural_compressor.Quantization.
   accuracy:                                          # optional. required if user doesn't provide eval_func in neural_compressor.Quantization.

--- a/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/densenet161.yaml
+++ b/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/densenet161.yaml
@@ -38,6 +38,14 @@ quantization:                                        # optional. tuning constrai
       algorithm: minmax
     weight:
       granularity: per_channel
+  op_wise: {
+             'densenet161/MaxPool2D/MaxPool': {
+               'activation':  {'dtype': ['fp32']}
+             },
+             'densenet161/transition_block[1-3]/AvgPool2D/AvgPool': {
+               'activation':  {'dtype': ['fp32']},
+             }
+           }
 
 evaluation:                                          # optional. required if user doesn't provide eval_func in neural_compressor.Quantization.
   accuracy:                                          # optional. required if user doesn't provide eval_func in neural_compressor.Quantization.

--- a/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/densenet169.yaml
+++ b/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/densenet169.yaml
@@ -38,6 +38,14 @@ quantization:                                        # optional. tuning constrai
       algorithm: minmax
     weight:
       granularity: per_channel
+  op_wise: {
+             'densenet169/MaxPool2D/MaxPool': {
+               'activation':  {'dtype': ['fp32']}
+             },
+             'densenet169/transition_block[1-3]/AvgPool2D/AvgPool': {
+               'activation':  {'dtype': ['fp32']},
+             }
+           }
 
 evaluation:                                          # optional. required if user doesn't provide eval_func in neural_compressor.Quantization.
   accuracy:                                          # optional. required if user doesn't provide eval_func in neural_compressor.Quantization.


### PR DESCRIPTION
## Type of Change

bugfix

## Description

Add op-wise configs back to densenet models, since removing them leads to failures in tuning with TF spr-base.
JIRA ticket: [ILITV-2444](https://jira.devtools.intel.com/browse/ILITV-2444)

## Expected Behavior & Potential Risk

Tuning failure reported in https://jira.devtools.intel.com/browse/ILITV-2444 will be fixed.

## How has this PR been tested?

https://inteltf-jenk.sh.intel.com/job/intel-lpot-validation-top-mr-extension/3554/

## Dependency Change?

No dependency changed.