### PR TITLE
Support QuantizedConv + BiasAdd + Activation + Dequantize fusion

### DIFF
--- a/.azure-pipelines/scripts/ut/env_setup.sh
+++ b/.azure-pipelines/scripts/ut/env_setup.sh
@@ -20,7 +20,7 @@ echo "mxnet version is $mxnet_version"
 if [[ "${tensorflow_version}" == *"-official" ]]; then
     pip install tensorflow==${tensorflow_version%-official}
 elif [[ "${tensorflow_version}" == "spr-base" ]]; then
-    pip install /tf_dataset/tf_binary/221125/tensorflow*.whl
+    pip install /tf_dataset/tf_binary/221204/tensorflow*.whl
     if [[ $? -ne 0 ]]; then
       exit 1
     fi

--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -351,7 +351,8 @@ class GraphConverter:
             model = self.bf16_convert()
 
         if self.new_api:
-            model.graph_def = FuseConvRedundantDequantizeTransformer(model.graph_def).do_transformation()
+            if self.performance_only:
+                model.graph_def = FuseConvRedundantDequantizeTransformer(model.graph_def).do_transformation()
             model.graph_def = FuseMatMulRedundantDequantizeTransformer(model.graph_def).do_transformation()
         post_cse_graph_def = PostCseOptimizer(model.graph_def).do_transformation()
         post_hostconst_graph_def = PostHostConstConverter(post_cse_graph_def).do_transformation()

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_redundant_dequantize.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_redundant_dequantize.py
@@ -34,11 +34,11 @@ class FuseConvRedundantDequantizeTransformer(GraphRewriterBase):
     ], ['Dequantize']]
 
     fuse_sum_op_types_str = (
-        str([b'BiasAdd', b'Sum']),
-        str([b'BiasAdd', b'Sum', b'Relu']),
-        str([b'BiasAdd', b'Sum', b'LeakyRelu']),
-        str([b'BiasAdd', b'Relu', b'Sum']),
-        str([b'BiasAdd', b'LeakyRelu', b'Sum'])
+        str([b'BiasAdd', b'Sum', b'Requantize']),
+        str([b'BiasAdd', b'Sum', b'Relu', b'Requantize']),
+        str([b'BiasAdd', b'Sum', b'LeakyRelu', b'Requantize']),
+        str([b'BiasAdd', b'Relu', b'Sum', b'Requantize']),
+        str([b'BiasAdd', b'LeakyRelu', b'Sum', b'Requantize'])
         )
 
     def __init__(self, model, device='cpu'):

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_redundant_dequantize.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_redundant_dequantize.py
@@ -64,11 +64,6 @@ class FuseConvRedundantDequantizeTransformer(GraphRewriterBase):
             if len(self.graph_info[quantized_node_name].outputs) > 3:
                 continue
 
-            # QuantizedConv only supports {"Dequantize"} and {"BiasAdd", "Dequantize"}
-            if str(quantized_node.attr['fused_ops'].list.s) != str([b"BiasAdd", b"Requantize"]) and \
-               str(quantized_node.attr['fused_ops'].list.s) != str([b"Requantize"]):
-                continue
-
             new_node = node_def_pb2.NodeDef()
             new_node.op = quantized_node.op
             fused_ops = str(quantized_node.attr['fused_ops'].list.s).replace("Requantize", "Dequantize")

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_redundant_dequantize.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_redundant_dequantize.py
@@ -52,7 +52,7 @@ class FuseConvRedundantDequantizeTransformer(GraphRewriterBase):
             dtypes.float32.as_datatype_enum: dtypes.float32,
             dtypes.qint32.as_datatype_enum: dtypes.qint32,
             dtypes.bfloat16.as_datatype_enum: dtypes.bfloat16
-        }    
+        }
         target_nodes = self.graph_analyzer.query_fusion_pattern_nodes(self.fuse_patterns)
 
         for i in target_nodes:
@@ -62,6 +62,10 @@ class FuseConvRedundantDequantizeTransformer(GraphRewriterBase):
             dequantize_node = self.graph_info[dequantize_node_name].node
 
             if len(self.graph_info[quantized_node_name].outputs) > 3:
+                continue
+
+            # QuantizedConv doesn't support {"BiasAdd", "Sum", "Dequantize"}
+            if str(quantized_node.attr['fused_ops'].list.s) == str([b"BiasAdd", b"Sum", b"Requantize"]):
                 continue
 
             new_node = node_def_pb2.NodeDef()

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_requantize.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_conv_requantize.py
@@ -593,8 +593,6 @@ class FuseConvRequantizeTransformer(GraphRewriterBase):
                     self.fused_ops = [b'BiasAdd', b'LeakyRelu', b'Sum', b'Requantize']
                 elif str(quantized_node.attr['fused_ops'].list.s) == str([b'BiasAdd', b'Relu', b'Sum']):
                     self.fused_ops = [b'BiasAdd', b'Relu', b'Sum', b'Requantize']
-                elif str(quantized_node.attr['fused_ops'].list.s) == str([b'BiasAdd', b'LeakyRelu', b'Sum']):
-                    self.fused_ops = [b'BiasAdd', b'LeakyRelu', b'Sum', b'Requantize']
                     #Current fusion requires summand has same dtype as output if output is qint8
                     Helper.set_attr_dtype(new_node, "Tsummand", \
                         dtype_map_dict[requantize_node.attr['out_type'].type])

--- a/test/tfnewapi/test_tensorflow_graph_conv_requantize_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_conv_requantize_fusion.py
@@ -217,7 +217,7 @@ class TestConvRequantizedFusionNewAPI(unittest.TestCase):
             self.assertNotEqual(output_graph, None)
             elu_fused = False
             for node in output_graph.graph_def.node:
-                if node.name == 'conv_eightbit_requantize':
+                if node.name == 'conv_eightbit_requantize_dequantize':
                     if b'Elu' in node.attr['fused_ops'].list.s:
                         elu_fused = True
             self.assertEqual(elu_fused, True)

--- a/test/tfnewapi/test_tensorflow_graph_qdq_bn_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_bn_fusion.py
@@ -135,7 +135,7 @@ class TestTensorflowQdqConvFusion(unittest.TestCase):
         self.assertEqual(conv_input_type, True)
         self.assertEqual(found_fusion, True)
         self.assertEqual(qbn_num, 1)
-        self.assertEqual(dq_num, 1)
+        self.assertEqual(dq_num, 0)
 
     @disable_random()
     def test_training_bn_relu_depthwiseconv_biasadd_relu6_fusion(self):
@@ -174,7 +174,7 @@ class TestTensorflowQdqConvFusion(unittest.TestCase):
                 dq_num += 1
         self.assertEqual(bn_num, 1)
         self.assertEqual(qbn_num, 0)
-        self.assertEqual(dq_num, 1)
+        self.assertEqual(dq_num, 0)
         bf16_enabled = bool(CpuInfo().bf16 or os.getenv('FORCE_BF16') == '1')
         if bf16_enabled:
             self.assertEqual(bf16_bn_num, 1)
@@ -231,7 +231,7 @@ class TestTensorflowQdqConvFusion(unittest.TestCase):
         self.assertEqual(conv_input_type, True)
         self.assertEqual(found_fusion, True)
         self.assertEqual(qbn_num, 1)
-        self.assertEqual(dq_num, 1)
+        self.assertEqual(dq_num, 0)
         self.assertEqual(is_offset_const, True)
         self.assertEqual(is_mean_const, True)
         self.assertEqual(round(qbn_alpha, 7), 0.3)
@@ -289,7 +289,7 @@ class TestTensorflowQdqConvFusion(unittest.TestCase):
         self.assertEqual(conv_input_type, True)
         self.assertEqual(found_fusion, True)
         self.assertEqual(qbn_num, 1)
-        self.assertEqual(dq_num, 1)
+        self.assertEqual(dq_num, 0)
         self.assertEqual(is_offset_const, True)
         self.assertEqual(is_mean_const, True)
         self.assertEqual(frozen_qbn_output_max, qbn_output_max_name)

--- a/test/tfnewapi/test_tensorflow_graph_qdq_conv3d_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_conv3d_fusion.py
@@ -204,7 +204,7 @@ class TestTensorflowQdqConvFusion(unittest.TestCase):
             for i in output_graph.graph_def.node:
                 if i.op == '_FusedQuantizedConv3D':
                     found_conv_fusion = True
-                if str(i.attr['fused_ops'].list.s) == str([b'BiasAdd', b'Relu', b'Requantize']):
+                if str(i.attr['fused_ops'].list.s) == str([b'BiasAdd', b'Relu', b'Dequantize']):
                     found_requantize_fusion = True
             self.assertEqual(found_conv_fusion, True)
             self.assertEqual(found_requantize_fusion, True)
@@ -479,7 +479,7 @@ class TestTensorflowQdqConvFusion(unittest.TestCase):
 
             for i in output_graph.graph_def.node:
                 if i.op == '_FusedQuantizedConv3D' and \
-                   i.attr['fused_ops'].list.s == [b'BiasAdd', b'LeakyRelu', b'Requantize']:
+                   i.attr['fused_ops'].list.s == [b'BiasAdd', b'LeakyRelu', b'Dequantize']:
                     found_conv_fusion = True
                     break
             self.assertEqual(found_conv_fusion, True)


### PR DESCRIPTION
Signed-off-by: Lv, Liang1 <liang1.lv@intel.com>

## Type of Change

feature
API not changed

## Description

detail description 
JIRA ticket: ILITV-2475
Support QuantizedConv + BiasAdd + Activation + Dequantize fusion

## Expected Behavior & Potential Risk

The _FusedQuantizedConv3D/_FusedQuantizedConv2D/_FusedQuantizedDepthwiseConv2D/_FusedQuantizedDeconv2D/_FusedQuantizedDeconv3D + Dequantize can be fused as bf16 output to improve the performance.

## How has this PR been tested?

UT, Pre-CI and OOB extension test.

## Dependency Change?

No.
