### PR TITLE
[Strategy] Adjust the hints for import hyperopt and sigopt

### DIFF
--- a/neural_compressor/contrib/strategy/sigopt.py
+++ b/neural_compressor/contrib/strategy/sigopt.py
@@ -88,7 +88,13 @@ class SigOptTuneStrategy(TuneStrategy):
             try:
                 import sigopt
             except ImportError:
-                ImportError(f"Please install sigopt for using {strategy_name} strategy.")
+                try:
+                    import subprocess
+                    import sys
+                    subprocess.check_call([sys.executable, "-m", "pip", "install", "sigopt"])
+                    import sigopt
+                except:
+                    assert False, "Unable to import sigopt from the local environment."
         else:
             pass
         # SigOpt init

--- a/neural_compressor/contrib/strategy/sigopt.py
+++ b/neural_compressor/contrib/strategy/sigopt.py
@@ -92,7 +92,7 @@ class SigOptTuneStrategy(TuneStrategy):
                     import subprocess
                     import sys
                     subprocess.check_call([sys.executable, "-m", "pip", "install", "sigopt"])
-                    import sigopt
+                    import sigopt # pylint: disable=import-error
                 except:
                     assert False, "Unable to import sigopt from the local environment."
         else:

--- a/neural_compressor/contrib/strategy/tpe.py
+++ b/neural_compressor/contrib/strategy/tpe.py
@@ -95,7 +95,7 @@ class TpeTuneStrategy(TuneStrategy):
                     import subprocess
                     import sys
                     subprocess.check_call([sys.executable, "-m", "pip", "install", "hyperopt"])
-                    import hyperopt
+                    import hyperopt # pylint: disable=import-error
                 except:
                     assert False, "Unable to import hyperopt from the local environment."
         else:

--- a/neural_compressor/contrib/strategy/tpe.py
+++ b/neural_compressor/contrib/strategy/tpe.py
@@ -91,7 +91,13 @@ class TpeTuneStrategy(TuneStrategy):
             try:
                 import hyperopt
             except ImportError:
-                raise ImportError(f"Please install hyperopt for using {strategy_name} strategy.")
+                try:
+                    import subprocess
+                    import sys
+                    subprocess.check_call([sys.executable, "-m", "pip", "install", "hyperopt"])
+                    import hyperopt
+                except:
+                    assert False, "Unable to import hyperopt from the local environment."
         else:
             pass
         self.hpopt_search_space = None

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -13,8 +13,6 @@ pillow>=8.2.0
 transformers<=4.12.3; python_version < '3.10'
 transformers==4.16.0; python_version == '3.10'
 tensorflow_model_optimization
-sigopt
-hyperopt
 horovod
 tensorflow-addons
 onnxruntime-extensions; python_version < '3.10'


### PR DESCRIPTION
Signed-off-by: yiliu30 <yi4.liu@intel.com>

## Type of Change

- Others: Optimize user experience
- API changed or not: None

## Description
Try to import `hyperopt` and `sigopt` from the local environment when user specify the strategy as `tpe` or `sigopt`


## How has this PR been tested?
Pre-CI

## Dependency Change?

Remove `hyperopt` and `sigopt` from the test requirements list.
