### PR TITLE
Disable inserting QDQ for DepthwiseConv2dNative in ITEX mode

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
@@ -568,22 +568,23 @@ class GenerateGraphWithQDQPattern(GraphRewriterBase):
             self.g_weight.add_node(reshape_3to4_node, dequant_node.name, [computational_node.name])
             computational_node.input[1] = reshape_3to4_node.name
         else:
-            if weight_node.name in self.g.parent_frame_details and self.g.parent_frame_details[weight_node.name]:
+            if computational_node.name in self.g.parent_frame_details and \
+               self.g.parent_frame_details[computational_node.name]:
                 min_enter_node = Helper.create_node('Enter', min_name + '_enter', [min_name])
                 Helper.set_attr_string(min_enter_node, 'frame_name',
-                    self.g.parent_frame_details[weight_node.name].attr['frame_name'].s)
+                    self.g.parent_frame_details[computational_node.name].attr['frame_name'].s)
                 Helper.set_attr_dtype(min_enter_node, 'T', dtypes.float32)
                 Helper.set_attr_bool(min_enter_node, 'is_constant', True)
                 Helper.set_attr_int(min_enter_node, 'parallel_iterations', \
-                 self.g.parent_frame_details[weight_node.name].attr['parallel_iterations'].i)
+                 self.g.parent_frame_details[computational_node.name].attr['parallel_iterations'].i)
 
                 max_enter_node = Helper.create_node('Enter', max_name + '_enter', [max_name])
                 Helper.set_attr_string(max_enter_node, 'frame_name',
-                    self.g.parent_frame_details[weight_node.name].attr['frame_name'].s)
+                    self.g.parent_frame_details[computational_node.name].attr['frame_name'].s)
                 Helper.set_attr_dtype(max_enter_node, 'T', dtypes.float32)
                 Helper.set_attr_bool(max_enter_node, 'is_constant', True)
                 Helper.set_attr_int(max_enter_node, 'parallel_iterations',\
-                    self.g.parent_frame_details[weight_node.name].attr['parallel_iterations'].i)
+                    self.g.parent_frame_details[computational_node.name].attr['parallel_iterations'].i)
 
                 self.g_weight.add_node(quant_node, weight_name, [])
                 self.g_weight.add_node(min_node, None, [min_enter_node.name])

--- a/neural_compressor/adaptor/tf_utils/quantize_graph/qdq/fuse_qdq_conv.py
+++ b/neural_compressor/adaptor/tf_utils/quantize_graph/qdq/fuse_qdq_conv.py
@@ -1795,6 +1795,10 @@ class FuseNodeStartWithConv2d(QuantizeNodeBase):
                 if cur_node.name != self.start_node_name:
                     continue
 
+                # Disable inserting QDQ for DepthwiseConv2dNative since its poor perf.
+                if cur_node.op == "DepthwiseConv2dNative" and self.itex_mode:
+                    continue
+
                 if ((v in ("Conv2D", "DepthwiseConv2dNative")
                      and not self.enable_s8)
                 ) and not self._find_relu_node(cur_node):

--- a/test/itex/test_tensorflow_itex_basic.py
+++ b/test/itex/test_tensorflow_itex_basic.py
@@ -216,7 +216,7 @@ class TestItexEnabling(unittest.TestCase):
             for i in output_graph.graph_def.node:
                 if i.op == 'Reshape':
                     reshape_counter += 1
-            self.assertEqual(reshape_counter, 2)
+            self.assertEqual(reshape_counter, 0)
 
     @disable_random()
     @unittest.skipIf(version1_lt_version2(tf.version.VERSION, '2.8.0') or \


### PR DESCRIPTION
## Type of Change

bug fix 
API not changed

## Description

detail description 
JIRA ticket: ILITV-2496
DepthwiseConv2dNative onednn performance is not good. oneDNN graph team requested INC not to insert QDQ before DepthwiseConv2dNative .

## Expected Behavior & Potential Risk

DepthwiseConv2dNative will not be quantized in ITEX mode.

## How has this PR been tested?

UT, Pre-CI and OOB extension test.

## Dependency Change?

No.
