### PR TITLE
Add examples for mse_v2 tuning strategy

### DIFF
--- a/examples/.config/model_params_pytorch.json
+++ b/examples/.config/model_params_pytorch.json
@@ -9,24 +9,6 @@
       "batch_size": 100,
       "new_benchmark": false
     },
-      "efficientnet_b0_fx": {
-      "model_src_dir": "image_recognition/torchvision_models/quantization/ptq/cpu/fx/",
-      "dataset_location": "/tf_dataset/pytorch/ImageNet/raw",
-      "input_model": "",
-      "yaml": "conf.yaml",
-      "strategy": "hawq_v2",
-      "batch_size": 100,
-      "new_benchmark": false
-    },
-      "efficientnet_b3_fx": {
-      "model_src_dir": "image_recognition/torchvision_models/quantization/ptq/cpu/fx/",
-      "dataset_location": "/tf_dataset/pytorch/ImageNet/raw",
-      "input_model": "",
-      "yaml": "conf.yaml",
-      "strategy": "hawq_v2",
-      "batch_size": 100,
-      "new_benchmark": false
-      },
     "resnet18_fx": {
       "model_src_dir": "image_recognition/torchvision_models/quantization/ptq/cpu/fx/",
       "dataset_location": "/tf_dataset/pytorch/ImageNet/raw",

--- a/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
+++ b/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
@@ -61,6 +61,7 @@ python main.py -t -a mobilenet_v2 --pretrained /path/to/imagenet
 python main.py -t -a efficientnet_b0 --pretrained /path/to/imagenet
 ```
 > **Note**
+>
 > It is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
 > strategy for quantizing `efficientnet_b0` model to reduce tuning time 
 > and get the result faster.
@@ -71,6 +72,7 @@ python main.py -t -a efficientnet_b0 --pretrained /path/to/imagenet
 python main.py -t -a efficientnet_b3 --pretrained /path/to/imagenet
 ```
 > **Note**
+>
 > It is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
 > strategy for quantizing `efficientnet_b3` model to reduce tuning time 
 > and get the result faster.
@@ -81,6 +83,7 @@ python main.py -t -a efficientnet_b3 --pretrained /path/to/imagenet
 python main.py -t -a efficientnet_b7 --pretrained /path/to/imagenet
 ```
 > **Note**
+>
 > It is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
 > strategy for quantizing `efficientnet_b7` model to reduce tuning time 
 > and get the result faster.

--- a/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
+++ b/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
@@ -60,30 +60,30 @@ python main.py -t -a mobilenet_v2 --pretrained /path/to/imagenet
 ```shell
 python main.py -t -a efficientnet_b0 --pretrained /path/to/imagenet
 ```
-
-Note that it is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
-strategy for quantizing `efficientnet_b0` model to reduce tuning time 
-and get the result faster.
+> **Note**
+> It is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
+> strategy for quantizing `efficientnet_b0` model to reduce tuning time 
+> and get the result faster.
 
 ### 7. Efficientnet_b3
 
 ```shell
 python main.py -t -a efficientnet_b3 --pretrained /path/to/imagenet
 ```
-
-Note that it is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
-strategy for quantizing `efficientnet_b3` model to reduce tuning time 
-and get the result faster.
+> **Note**
+> It is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
+> strategy for quantizing `efficientnet_b3` model to reduce tuning time 
+> and get the result faster.
 
 ### 8. Efficientnet_b7
 
 ```shell
 python main.py -t -a efficientnet_b7 --pretrained /path/to/imagenet
 ```
-
-Note that it is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
-strategy for quantizing `efficientnet_b7` model to reduce tuning time 
-and get the result faster.
+> **Note**
+> It is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
+> strategy for quantizing `efficientnet_b7` model to reduce tuning time 
+> and get the result faster.
 
 # Saving and loading model:
 

--- a/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
+++ b/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
@@ -55,6 +55,36 @@ python main.py -t -a inception_v3 --pretrained /path/to/imagenet
 python main.py -t -a mobilenet_v2 --pretrained /path/to/imagenet
 ```
 
+### 6. Efficientnet_b0
+
+```shell
+python main.py -t -a efficientnet_b0 --pretrained /path/to/imagenet
+```
+
+Note that it is recommended to use `MSE_v2` strategy for quantizing
+`efficientnet_b0` model to reduce tuning time and get the result 
+faster.
+
+### 7. Efficientnet_b3
+
+```shell
+python main.py -t -a efficientnet_b3 --pretrained /path/to/imagenet
+```
+
+Note that it is recommended to use `MSE_v2` strategy for quantizing
+`efficientnet_b3` model to reduce tuning time and get the result 
+faster.
+
+### 8. Efficientnet_b7
+
+```shell
+python main.py -t -a efficientnet_b7 --pretrained /path/to/imagenet
+```
+
+Note that it is recommended to use `MSE_v2` strategy for quantizing
+`efficientnet_b7` model to reduce tuning time and get the result 
+faster.
+
 # Saving and loading model:
 
 * Saving model:

--- a/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
+++ b/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx/README.md
@@ -61,9 +61,9 @@ python main.py -t -a mobilenet_v2 --pretrained /path/to/imagenet
 python main.py -t -a efficientnet_b0 --pretrained /path/to/imagenet
 ```
 
-Note that it is recommended to use `MSE_v2` strategy for quantizing
-`efficientnet_b0` model to reduce tuning time and get the result 
-faster.
+Note that it is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
+strategy for quantizing `efficientnet_b0` model to reduce tuning time 
+and get the result faster.
 
 ### 7. Efficientnet_b3
 
@@ -71,9 +71,9 @@ faster.
 python main.py -t -a efficientnet_b3 --pretrained /path/to/imagenet
 ```
 
-Note that it is recommended to use `MSE_v2` strategy for quantizing
-`efficientnet_b3` model to reduce tuning time and get the result 
-faster.
+Note that it is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
+strategy for quantizing `efficientnet_b3` model to reduce tuning time 
+and get the result faster.
 
 ### 8. Efficientnet_b7
 
@@ -81,9 +81,9 @@ faster.
 python main.py -t -a efficientnet_b7 --pretrained /path/to/imagenet
 ```
 
-Note that it is recommended to use `MSE_v2` strategy for quantizing
-`efficientnet_b7` model to reduce tuning time and get the result 
-faster.
+Note that it is recommended to use [`MSE_v2`](/docs/source/tuning_strategies.md#MSE_v2)
+strategy for quantizing `efficientnet_b7` model to reduce tuning time 
+and get the result faster.
 
 # Saving and loading model:
 


### PR DESCRIPTION
## Type of Change

documentation and examples.

## Description

* [x] add examples of `efficientnet_b0`, `efficientnet_b3`, and `efficientnet_b7` to PyTorch examples,
      and recommendation for user to use `mse_v2` as tuning strategy for these models.
* [x] remove duplicate configs for `efficientnet_b0` and `efficientnet_b3` models,
      by keeping ones with `mse_v2` strategy, removing ones with `hawq_v2` strategy.

JIRA ticket: [ILITV-2519](https://jira.devtools.intel.com/browse/ILITV-2519)

## Expected Behavior & Potential Risk

New examples are included.

## How has this PR been tested?

By PreCI Test.

## Dependency Change?

no dependency changes.