### PR TITLE
Fix ITEX resnetv2_50 tuning accuracy issue

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -434,8 +434,8 @@ class GraphConverter:
         g = GraphAnalyzer()
         g.graph = self._fp32_model.graph_def
         g.parse_graph()
-        y_pattern = [['Conv2D', 'MatMul'], ['BiasAdd'], ['Add', 'AddV2'], ('Relu',)]
-        y_pattern_variant = [['MaxPool', 'AvgPool'], ['Add', 'AddV2'], ('Relu',)]
+        y_pattern = [['Conv2D', 'MatMul'], ['BiasAdd'], ['Add', 'AddV2', 'AddN'], ('Relu',)]
+        y_pattern_variant = [['MaxPool', 'AvgPool'], ['Add', 'AddV2', 'AddN'], ('Relu',)]
         target_nodes = g.query_fusion_pattern_nodes(y_pattern)
         target_nodes_variant = g.query_fusion_pattern_nodes(y_pattern_variant)
 


### PR DESCRIPTION
Signed-off-by: Lv, Liang1 <liang1.lv@intel.com>

## Type of Change

bug fix
API not changed

## Description

detail description 
JIRA ticket: ILITV-2525
[TF][ITEX]resnetv2_50 failed in tuing with result 0.001
In this pb file, the Add op use 'AddN'. This caused the y-pattern can't match.

## Expected Behavior & Potential Risk

ITEX resnetv2_50 tuning accuracy issue can be fixed.

## How has this PR been tested?

UT, Pre-CI test.

## Dependency Change?

No.
