### PR TITLE
Fix model type not recognized for saved model issue

### DIFF
--- a/neural_compressor/model/tensorflow_model.py
+++ b/neural_compressor/model/tensorflow_model.py
@@ -52,6 +52,9 @@ def get_model_type(model):
                             " lower not support intel ITEX.")
             try:
                 model = tf.keras.models.load_model(model)
+                if isinstance(model, tf.keras.Model) and hasattr(model, 'to_json'):
+                    return 'keras'
+                return 'saved_model'
             except:
                 pass
     if isinstance(model, tf.keras.Model) and hasattr(model, 'to_json'):


### PR DESCRIPTION
Signed-off-by: Lv, Liang1 <liang1.lv@intel.com>

## Type of Change

bug fix
API not changed

## Description

detail description 
JIRA ticket: ILITV-2531
[release1st][tf2.10.0] mobilenetv2_saved,mobilenetv1_saved failed with ValueError

## Expected Behavior & Potential Risk

The saved model can be tuned successfully.

## How has this PR been tested?

UT, Pre-CI test.

## Dependency Change?

No.
