### PR TITLE
Fix failed `test_run_sigopt_one_trial_new_api`

### DIFF
--- a/test/strategy/test_sigopt.py
+++ b/test/strategy/test_sigopt.py
@@ -156,7 +156,7 @@ class TestSigoptTuningStrategy(unittest.TestCase):
                            'sigopt_project_id': 'sigopt_project_id_test',
                            'sigopt_experiment_name': 'nc-tune'}
         tuning_criterion = TuningCriterion(strategy='sigopt', strategy_kwargs=strategy_kwargs, max_trials=3)
-        conf = PostTrainingQuantConfig(approach="static", backend="default", 
+        conf = PostTrainingQuantConfig(approach="static", 
                                        tuning_criterion=tuning_criterion,
                                        accuracy_criterion=accuracy_criterion)
         self.assertEqual(conf.strategy_kwargs, strategy_kwargs)

--- a/test/strategy/test_sigopt.py
+++ b/test/strategy/test_sigopt.py
@@ -156,7 +156,7 @@ class TestSigoptTuningStrategy(unittest.TestCase):
                            'sigopt_project_id': 'sigopt_project_id_test',
                            'sigopt_experiment_name': 'nc-tune'}
         tuning_criterion = TuningCriterion(strategy='sigopt', strategy_kwargs=strategy_kwargs, max_trials=3)
-        conf = PostTrainingQuantConfig(approach="static", backend="tensorflow", 
+        conf = PostTrainingQuantConfig(approach="static", backend="default", 
                                        tuning_criterion=tuning_criterion,
                                        accuracy_criterion=accuracy_criterion)
         self.assertEqual(conf.strategy_kwargs, strategy_kwargs)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Fix the failed unit-test `test_run_sigopt_one_trial_new_api` by updating the backend field from framework name to `'default'`;

JIRA ticket: [ILITV-2544](https://jira.devtools.intel.com/browse/ILITV-2544)

## Expected Behavior & Potential Risk

UT `test_run_sigopt_one_trial_new_api` pass.

## How has this PR been tested?

By Pre-CI.

## Dependency Change?

No.