### PR TITLE
support config list which length is 1 and add “model.backend" for pruning and distillation config

### DIFF
--- a/neural_compressor/conf/config.py
+++ b/neural_compressor/conf/config.py
@@ -1476,6 +1476,11 @@ class Conf(object):
                     pythonic_config.benchmark.intra_num_of_threads,
             })
 
+        if "model.backend" not in mapping:
+            mapping.update({
+                'model.backend': "default",
+            })
+
         for k, v in mapping.items():
             if k in ['tuning.accuracy_criterion.relative', 'tuning.accuracy_criterion.absolute']:
                 target_key = str(pythonic_config.quantization.accuracy_criterion)

--- a/neural_compressor/experimental/distillation.py
+++ b/neural_compressor/experimental/distillation.py
@@ -217,6 +217,7 @@ class Distillation(Component):
     def prepare(self):
         """Prepare hooks."""
         self.generate_hooks()
+        self.create_criterion()
 
     def pre_process(self):
         """Preprocessing before the disillation pipeline.
@@ -256,7 +257,8 @@ class Distillation(Component):
             self._eval_dataloader = create_dataloader(self.framework, eval_dataloader_cfg)
 
         if self._train_func is None:
-            self.create_criterion()
+            if self.criterion is None:
+                self.create_criterion()
             self.create_optimizer()
             if self._train_dataloader is not None:
                 self._train_func = create_train_func(self.framework, \

--- a/neural_compressor/training.py
+++ b/neural_compressor/training.py
@@ -163,7 +163,7 @@ def prepare_compression(model: Callable, confs: Union[Callable, List], **kwargs)
             compression_manager.on_train_end()
     """
 
-    if isinstance(confs, List):
+    if isinstance(confs, List) and len(confs) > 1:
         from .experimental.scheduler import Scheduler
         comps = []
         for conf in confs:
@@ -204,6 +204,8 @@ def prepare_compression(model: Callable, confs: Union[Callable, List], **kwargs)
         scheduler.append(comp)
         component = scheduler
     else:
+        if isinstance(confs, List):
+            confs = confs[0]
         if isinstance(confs, QuantizationAwareTrainingConfig):
             conf = Config(quantization=confs,
                           benchmark=None,


### PR DESCRIPTION
Signed-off-by: Cheng, Penghui <penghui.cheng@intel.com>

## Type of Change

Enhancement API 
No API changed

## Description

support config list which length is 1
set model.backend for "default" in new API
fixed distillation criterion is none issue for oneshot optimization.

## Expected Behavior & Potential Risk

we can pass a list with one config to prepare_compression

## How has this PR been tested?

local tested
