### PR TITLE
Rename `optimization_level` to `quant_level`

### DIFF
--- a/neural_compressor/conf/config.py
+++ b/neural_compressor/conf/config.py
@@ -806,7 +806,7 @@ schema = Schema({
                                                       'pre_post_process_quantization': True},
                                       'model_wise': {'weight': {'bit': [7.0]},
                                                      'activation': {}},
-                                      'optimization_level': 1,
+                                      'quant_level': 1,
                                       }): {
         Optional('approach', default='post_training_static_quant'): And(
             str,
@@ -900,10 +900,10 @@ schema = Schema({
         Optional('op_wise', default=None): {
             str: ops_schema
         },
-        Optional('optimization_level', default=1): And(int, lambda level: level in [0, 1]),
+        Optional('quant_level', default=1): And(int, lambda level: level in [0, 1]),
     },
     Optional('use_bf16', default=True): bool,
-    Optional('optimization_level', default=1): And(int, lambda level: level in [0, 1]),
+    Optional('quant_level', default=1): And(int, lambda level: level in [0, 1]),
     Optional('graph_optimization'): graph_optimization_schema,
     Optional('mixed_precision'): mixed_precision_schema,
 
@@ -1178,7 +1178,7 @@ quantization_default_schema = Schema({
                                                      'activation': {}},
                                     }): dict,
     Optional('use_bf16', default=False): bool,
-    Optional('optimization_level', default=1): int,
+    Optional('quant_level', default=1): int,
     Optional('tuning', default={
         'strategy': {'name': 'basic'},
         'accuracy_criterion': {'relative': 0.01, 'higher_is_better': True},
@@ -1415,7 +1415,7 @@ class Conf(object):
                 'tuning.exit_policy.max_trials': pythonic_config.quantization.max_trials,
                 'tuning.exit_policy.performance_only': pythonic_config.quantization.performance_only,
                 'use_bf16': pythonic_config.quantization.use_bf16,
-                'quantization.optimization_level': pythonic_config.quantization.optimization_level,
+                'quantization.quant_level': pythonic_config.quantization.quant_level,
                 'reduce_range': pythonic_config.quantization.reduce_range
             })
             if pythonic_config.quantization.strategy_kwargs:

--- a/neural_compressor/conf/pythonic_config.py
+++ b/neural_compressor/conf/pythonic_config.py
@@ -41,7 +41,7 @@ class QuantizationConfig(_BaseQuantizationConfig):
                  performance_only=False,
                  reduce_range=None,
                  use_bf16=True,
-                 optimization_level=1,
+                 quant_level=1,
                  accuracy_criterion=accuracy_criterion):
         excluded_precisions = ["bf16"] if not use_bf16 else []
         super().__init__(
@@ -61,7 +61,7 @@ class QuantizationConfig(_BaseQuantizationConfig):
             reduce_range=reduce_range,
             excluded_precisions=excluded_precisions,
             accuracy_criterion=accuracy_criterion,
-            optimization_level=optimization_level
+            quant_level=quant_level
         )
         self._approach = approach
 

--- a/neural_compressor/config.py
+++ b/neural_compressor/config.py
@@ -317,7 +317,7 @@ class _BaseQuantizationConfig:
                  performance_only=False,
                  reduce_range=None,
                  excluded_precisions=[],
-                 optimization_level=1,
+                 quant_level=1,
                  accuracy_criterion=accuracy_criterion):
         self.inputs = inputs
         self.outputs = outputs
@@ -337,7 +337,7 @@ class _BaseQuantizationConfig:
         self.use_bf16 = "bf16" not in self.excluded_precisions
         self.accuracy_criterion = accuracy_criterion
         self.calibration_sampling_size = calibration_sampling_size
-        self.optimization_level = optimization_level
+        self.quant_level = quant_level
 
     @property
     def accuracy_criterion(self):
@@ -359,12 +359,12 @@ class _BaseQuantizationConfig:
             self._use_bf16 = "bf16" not in excluded_precisions
 
     @property
-    def optimization_level(self):
-        return self._optimization_level
+    def quant_level(self):
+        return self._quant_level
 
-    @optimization_level.setter
-    def optimization_level(self, optimization_level):
-        self._optimization_level = optimization_level
+    @quant_level.setter
+    def quant_level(self, quant_level):
+        self._quant_level = quant_level
 
     @property
     def reduce_range(self):
@@ -591,7 +591,7 @@ class PostTrainingQuantConfig(_BaseQuantizationConfig):
                  op_name_list=None,
                  reduce_range=None,
                  excluded_precisions=[],
-                 optimization_level=1,
+                 quant_level=1,
                  tuning_criterion=tuning_criterion,
                  accuracy_criterion=accuracy_criterion,
     ):
@@ -611,7 +611,7 @@ class PostTrainingQuantConfig(_BaseQuantizationConfig):
                          max_trials=tuning_criterion.max_trials,
                          reduce_range=reduce_range,
                          excluded_precisions=excluded_precisions,
-                         optimization_level=optimization_level,
+                         quant_level=quant_level,
                          accuracy_criterion=accuracy_criterion)
         self.approach = approach
 
@@ -644,7 +644,7 @@ class QuantizationAwareTrainingConfig(_BaseQuantizationConfig):
                  op_name_list=None,
                  reduce_range=None,
                  excluded_precisions=[],
-                 optimization_level=1):
+                 quant_level=1):
         super().__init__(inputs=inputs,
                          outputs=outputs,
                          device=device,
@@ -653,7 +653,7 @@ class QuantizationAwareTrainingConfig(_BaseQuantizationConfig):
                          op_name_list=op_name_list,
                          reduce_range=reduce_range,
                          excluded_precisions=excluded_precisions,
-                         optimization_level=optimization_level)
+                         quant_level=quant_level)
         self._approach = 'quant_aware_training'
 
     @property

--- a/neural_compressor/experimental/quantization.py
+++ b/neural_compressor/experimental/quantization.py
@@ -135,7 +135,7 @@ class Quantization(Component):
         self._create_eval_dataloader(cfg)
         self._create_calib_dataloader(cfg)
         strategy = cfg.tuning.strategy.name.lower()
-        if cfg.quantization.optimization_level == 0:
+        if cfg.quantization.quant_level == 0:
             strategy = "conservative"
             logger.info(f"On the premise that the accuracy meets the conditions, improve the performance.")
         assert strategy in STRATEGIES, "Tuning strategy {} is NOT supported".format(strategy)

--- a/test/strategy/test_mse_v2_2.x.py
+++ b/test/strategy/test_mse_v2_2.x.py
@@ -69,7 +69,7 @@ class Test_MSEV2Strategy(unittest.TestCase):
         
         conf = PostTrainingQuantConfig(
             approach="static",
-            optimization_level=1,
+            quant_level=1,
             tuning_criterion=TuningCriterion(strategy="mse_v2"))
         
         q_model = fit(
@@ -96,7 +96,7 @@ class Test_MSEV2Strategy(unittest.TestCase):
         
         conf = PostTrainingQuantConfig(
             approach="static",
-            optimization_level=1,
+            quant_level=1,
             tuning_criterion=TuningCriterion(
                 strategy="mse_v2",
                 strategy_kwargs={
@@ -126,7 +126,7 @@ class Test_MSEV2Strategy(unittest.TestCase):
         
         conf = PostTrainingQuantConfig(
             approach="static",
-            optimization_level=1,
+            quant_level=1,
             tuning_criterion=TuningCriterion(strategy="mse_v2"))
         
         q_model = fit(

--- a/test/strategy/test_optimization_level_2.x.py
+++ b/test/strategy/test_optimization_level_2.x.py
@@ -72,8 +72,8 @@ class TestOptimizationLevel(unittest.TestCase):
         dataloader = DATALOADERS["tensorflow"](dataset)
 
         # tuning and accuracy criterion
-        optimization_level = 0
-        conf = PostTrainingQuantConfig(optimization_level=0)
+        quant_level = 0
+        conf = PostTrainingQuantConfig(quant_level=0)
 
         # fit
         q_model = fit(model=self.constant_graph,
@@ -135,8 +135,8 @@ class TestOptimizationLevel(unittest.TestCase):
         dataloader = DATALOADERS["pytorch"](dataset)
 
         # tuning and accuracy criterion
-        optimization_level = 0
-        conf = PostTrainingQuantConfig(optimization_level=optimization_level)
+        quant_level = 0
+        conf = PostTrainingQuantConfig(quant_level=quant_level)
 
         # fit
         q_model = fit(model=resnet18,


### PR DESCRIPTION
Signed-off-by: intel-zhangyi <yi5.zhang@intel.com>

## Type of Change

Refactor.

## Description

Refactor the new API. Remame `optimization_level` to `quant_level`;

## Expected Behavior & Potential Risk

The field `optimization_level` is replaced by `quant_level` in all configs.

## How has this PR been tested?

By PreCI tests.

## Dependency Change?

No.