### PR TITLE
Turn off BF16 conversion for some models whose accuracy can't reach the goal

### DIFF
--- a/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/inception_v3.yaml
+++ b/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq/inception_v3.yaml
@@ -19,6 +19,8 @@ model:                                               # mandatory. used to specif
 
 device: cpu                                          # optional. default value is cpu, other value is gpu.
 
+use_bf16: false                                      # optional. turn off bf16 conversion
+
 quantization:                                        # optional. tuning constraints on model-wise for advance user to reduce tuning space.
   calibration:
     sampling_size: 50, 100                           # optional. default value is 100. used to set how many samples should be used in calibration.

--- a/examples/tensorflow/nlp/bert_large_squad_model_zoo/quantization/ptq/bert.yaml
+++ b/examples/tensorflow/nlp/bert_large_squad_model_zoo/quantization/ptq/bert.yaml
@@ -23,6 +23,8 @@ model:
 
 device: cpu                                          # optional. default value is cpu, other value is gpu.
 
+use_bf16: false                                      # optional. turn off bf16 conversion
+
 evaluation:
   accuracy:
     metric:

--- a/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq/faster_rcnn_inception_resnet_v2.yaml
+++ b/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq/faster_rcnn_inception_resnet_v2.yaml
@@ -21,6 +21,8 @@ model:                                               # mandatory. used to specif
 
 device: cpu                                          # optional. default value is cpu, other value is gpu.
 
+use_bf16: false                                      # optional. turn off bf16 conversion
+
 quantization:                                        # optional. tuning constraints on model-wise for advance user to reduce tuning space.
   calibration:
     sampling_size: 10, 50, 100, 200                  # optional. default value is 100. used to set how many samples should be used in calibration.

--- a/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq/faster_rcnn_resnet101.yaml
+++ b/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq/faster_rcnn_resnet101.yaml
@@ -21,6 +21,8 @@ model:                                               # mandatory. used to specif
 
 device: cpu                                          # optional. default value is cpu, other value is gpu.
 
+use_bf16: false                                      # optional. turn off bf16 conversion
+
 quantization:                                        # optional. tuning constraints on model-wise for advance user to reduce tuning space.
   calibration:
     sampling_size: 10, 50, 100, 200                  # optional. default value is 100. used to set how many samples should be used in calibration.


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

detail description 
JIRA ticket: ILITV-2566

## Expected Behavior & Potential Risk

inception_v3,bert_large_squad_model_zoo,faster_rcnn_inception_resnet_v2,faster_rcnn_inception_resnet_v2_saved,faster_rcnn_resnet101,faster_rcnn_resnet101_saved can't reach the accuracy goal on SPR with spr-base.
Fix this issue by turning off BF16 conversion.

## How has this PR been tested?

UT, Pre-CI and model test.

## Dependency Change?

No.
