### PR TITLE
Fix mobilenetv2 accuracy issue with spr-base

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
@@ -182,7 +182,7 @@ class GenerateGraphWithQDQPattern(GraphRewriterBase):
                    "MaxPool", "MaxPool3D", "FusedBatchNormV3", "Requantize", "RequantizePerChannel", "AvgPool", "Pad",
                    "CropAndResize", "Dequantize", "Mean", "MatMul", "BatchMatMul", "BatchMatMulV2",
                    "FakeQuantWithMinMaxVars", "_MklFusedInstanceNorm",
-                   "Conv2DBackpropInput", "Conv3DBackpropInputV2", "Sigmoid", "BiasAdd")
+                   "Conv2DBackpropInput", "Conv3DBackpropInputV2", "Sigmoid")
         return any([node_type.find(i) != -1 for i in op_list])
 
     def _find_relu_node(self, node):


### PR DESCRIPTION
Signed-off-by: Lv, Liang1 <liang1.lv@intel.com>

## Type of Change

bug fix
API not changed

## Description

detail description 
JIRA ticket: ILITV-2567, ILITV-2568
[release1st][tf2.11.0202250] mobilenetv2 got invalid int8 accuracy with TF spr-base
[release1st][tf2.11.0202250] ssd_resnet50_v1,ssd_resnet50_v1_ckpt can't reach accuracy with TF spr-base on both SPR and CLX

## Expected Behavior & Potential Risk

Fix mobilenetv2, ssd_resnet50_v1,ssd_resnet50_v1_ckpt accuracy issue with TF spr-base.

## How has this PR been tested?

UT, Pre-CI and OOB extension test.

## Dependency Change?

No.
