### PR TITLE
fix numpy version for old_api_example

### DIFF
--- a/examples/pytorch/image_recognition/3d-unet/quantization/ptq/eager/nnUnet/requirements.txt
+++ b/examples/pytorch/image_recognition/3d-unet/quantization/ptq/eager/nnUnet/requirements.txt
@@ -5,7 +5,7 @@ scikit-image>=0.14
 medpy
 scipy
 batchgenerators==0.21.0
-numpy
+numpy==1.23.5
 sklearn
 SimpleITK
 pandas

--- a/examples/pytorch/image_recognition/3d-unet/quantization/ptq/eager/nnUnet/requirements.txt
+++ b/examples/pytorch/image_recognition/3d-unet/quantization/ptq/eager/nnUnet/requirements.txt
@@ -5,7 +5,7 @@ scikit-image>=0.14
 medpy
 scipy
 batchgenerators==0.21.0
-numpy==1.23.5
+numpy<=1.23.5
 sklearn
 SimpleITK
 pandas

--- a/examples/pytorch/object_detection/maskrcnn/quantization/ptq/fx/requirements.txt
+++ b/examples/pytorch/object_detection/maskrcnn/quantization/ptq/fx/requirements.txt
@@ -3,3 +3,4 @@ yacs
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==1.8.0+cpu
 torchvision==0.9.0+cpu
+numpy==1.23.5

--- a/examples/pytorch/object_detection/maskrcnn/quantization/ptq/fx/requirements.txt
+++ b/examples/pytorch/object_detection/maskrcnn/quantization/ptq/fx/requirements.txt
@@ -3,4 +3,4 @@ yacs
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==1.8.0+cpu
 torchvision==0.9.0+cpu
-numpy==1.23.5
+numpy<=1.23.5


### PR DESCRIPTION
Signed-off-by: changwa1 <chang1.wang@intel.com>

## Type of Change

bug fix.

## Description
3dunet: https://jira.devtools.intel.com/browse/ILITV-2576
maskrcnn_fx: https://inteltf-jenk.sh.intel.com/job/intel-lpot-validation-top-release-v2.0/77/artifact/linux/pytorch/maskrcnn_fx/pytorch-maskrcnn_fx-linux-clx8280-tune.log


## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
