### PR TITLE
Fix efficientnet_b0 tuning failed with Op type not registered swish_f32

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -362,7 +362,9 @@ class GraphConverter:
         if self.new_api:
             if self.performance_only:
                 model.graph_def = FuseConvRedundantDequantizeTransformer(model.graph_def).do_transformation()
-            model.graph_def = FuseMatMulRedundantDequantizeTransformer(model.graph_def).do_transformation()
+            post_optimize_graph_def = FuseMatMulRedundantDequantizeTransformer(model.graph_def).do_transformation()
+            post_optimize_graph_def.library.CopyFrom(self.model.graph_def.library)
+            model.graph_def = post_optimize_graph_def
         post_cse_graph_def = PostCseOptimizer(model.graph_def).do_transformation()
         post_hostconst_graph_def = PostHostConstConverter(post_cse_graph_def).do_transformation()
         post_hostconst_graph_def.library.CopyFrom(self.model.graph_def.library)


### PR DESCRIPTION
Signed-off-by: Lv, Liang1 <liang1.lv@intel.com>

## Type of Change

bug fix
API not changed

## Description

detail description 
JIRA ticket: ILITV-2580
[release2nd][tf2.11.0][spr-base]efficientnet_b0 failed with NotFoundError: Op type not registered 'swish_f32'

## Expected Behavior & Potential Risk

efficientnet_b0 tuning failed with NotFoundError: Op type not registered 'swish_f32' can be fixed.

## How has this PR been tested?

UT, Pre-CI and OOB extension test.

## Dependency Change?

No.
