### PR TITLE
Revision for PyTorch Lightning

### DIFF
--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -237,7 +237,10 @@ def append_attr(fx_model, model):
           not any([re.search(p, i) for p in ignore_search_patterns]) :
             attr_names.append(i)
     for name in attr_names:
-        attr = getattr(model, name)
+        try:
+            attr = getattr(model, name)
+        except:
+            attr = None
         if isinstance(attr, torch.nn.Module) or \
           isinstance(attr, torch.quantization.qconfig.QConfig):
             continue

--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -237,10 +237,8 @@ def append_attr(fx_model, model):
           not any([re.search(p, i) for p in ignore_search_patterns]) :
             attr_names.append(i)
     for name in attr_names:
-        try:
-            attr = getattr(model, name)
-        except:
-            attr = None
+        attr = getattr(model, name, None)
+
         if isinstance(attr, torch.nn.Module) or \
           isinstance(attr, torch.quantization.qconfig.QConfig):
             continue


### PR DESCRIPTION
Signed-off-by: XuhuiRen <xuhui.ren@intel.com>

## Type of Change

Fix a error that "getattr()" cannot recognize the attribute name during tuning

## Description

[GitHub issue #422](https://github.com/intel/neural-compressor/issues/422)

## Expected Behavior & Potential Risk

The customer of PyTorch Lightning could quantize the model with INC

## How has this PR been tested?

Reported by the lightning user

## Dependency Change?

No
