### PR TITLE
improve logging of scale and zero_point during fx static quantization

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3320,6 +3320,8 @@ class PyTorch_FXAdaptor(TemplateAdaptor):
                     sub_name = prefix + '--' + node.target
                 else:
                     sub_name = node.target
+                if not hasattr(model, node.target):
+                    continue 
                 if 'scale' in node.target:
                     tune_cfg['get_attr'][sub_name] = float(getattr(model, node.target))
                 elif 'zero_point' in node.target:


### PR DESCRIPTION
Signed-off-by: Wang, Chang1 <chang1.wang@intel.com>

## Type of Change

bug fix

## Description
model : convnext
```
2023-01-10 12:55:34 [ERROR] Unexpected exception AttributeError("'GraphModule' object has no attribute 'features.1.0.layer_scale'") happened during tuning.
Traceback (most recent call last):
  File "/home/changwa1/neural-compressor/neural_compressor/experimental/quantization.py", line 177, in execute
    self.strategy.traverse()
  File "/home/changwa1/neural-compressor/neural_compressor/strategy/strategy.py", line 229, in traverse
    self.q_model = self.adaptor.quantize(
  File "/home/changwa1/neural-compressor/neural_compressor/utils/utility.py", line 293, in fi
    res = func(*args, **kwargs)
  File "/home/changwa1/neural-compressor/neural_compressor/adaptor/pytorch.py", line 2889, in quantize
    self._get_scale_zeropoint(q_model._model, q_model.q_config)
  File "/home/changwa1/neural-compressor/neural_compressor/adaptor/pytorch.py", line 3367, in _get_scale_zeropoint
    self._get_module_scale_zeropoint(model, tune_cfg)
  File "/home/changwa1/neural-compressor/neural_compressor/adaptor/pytorch.py", line 3325, in _get_module_scale_zeropoint
    sub_name = node.target
  File "/home/changwa1/miniconda3/envs/torch13/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1265, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'GraphModule' object has no attribute 'features.1.0.layer_scale'
```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
