### PR TITLE
improve ipex example benchmark

### DIFF
--- a/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex/main.py
+++ b/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex/main.py
@@ -311,10 +311,16 @@ def main_worker(gpu, ngpus_per_node, args):
         model.eval()
         if args.int8:
             from neural_compressor.utils.pytorch import load
-            q_model = load(os.path.expanduser(args.tuned_checkpoint), model, dataloader=val_loader)
+            q_model = load(os.path.expanduser(args.tuned_checkpoint), model)
             model = q_model
         else:
-            model = model
+            from neural_compressor.adaptor.adaptor import get_example_inputs
+            example_inputs = get_example_inputs(model, val_loader)
+            model = ipex.optimize(model)
+            with torch.no_grad():
+                model = torch.jit.trace(model, example_inputs)
+                model = torch.jit.freeze(model)
+
         if args.performance:
             from neural_compressor.config import BenchmarkConfig
             from neural_compressor import benchmark

--- a/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex/main.py
+++ b/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex/main.py
@@ -24,7 +24,7 @@ import torchvision.models.quantization as quantize_models
 import torchvision.models as models
 from neural_compressor.adaptor.pytorch import get_torch_version
 from packaging.version import Version
-import intel_extension_for_pytorch
+import intel_extension_for_pytorch as ipex
 
 
 model_names = sorted(name for name in models.__dict__

--- a/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex/main.py
+++ b/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex/main.py
@@ -314,7 +314,7 @@ def main_worker(gpu, ngpus_per_node, args):
             q_model = load(os.path.expanduser(args.tuned_checkpoint), model)
             model = q_model
         else:
-            from neural_compressor.adaptor.adaptor import get_example_inputs
+            from neural_compressor.adaptor.pytorch import get_example_inputs
             example_inputs = get_example_inputs(model, val_loader)
             model = ipex.optimize(model)
             with torch.no_grad():

--- a/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
+++ b/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
@@ -652,7 +652,7 @@ def main():
         from neural_compressor.utils.pytorch import load
         model = load(training_args.output_dir, model)
     else:
-        from neural_compressor.adaptor.adaptor import get_example_inputs
+        from neural_compressor.adaptor.pytorch import get_example_inputs
         example_inputs = get_example_inputs(model, eval_dataloader)
         model = ipex.optimize(model)
         with torch.no_grad():

--- a/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
+++ b/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
@@ -647,24 +647,30 @@ def main():
         q_model.save(training_args.output_dir)
         return
 
+    model.eval()
+    if model_args.int8:
+        from neural_compressor.utils.pytorch import load
+        model = load(training_args.output_dir, model)
+    else:
+        from neural_compressor.adaptor.adaptor import get_example_inputs
+        example_inputs = get_example_inputs(model, eval_dataloader)
+        model = ipex.optimize(model)
+        with torch.no_grad():
+            model = torch.jit.trace(model, example_inputs, checkout_trace=False, strict=False)
+            model = torch.jit.freeze(model)
+
     if model_args.benchmark or model_args.accuracy_only:
-        ipex.nn.utils._model_convert.replace_dropout_with_identity(model)
-        model.eval()
-        if model_args.int8:
-            from neural_compressor.utils.pytorch import load
-            model = load(training_args.output_dir, model, dataloader=eval_dataloader)
-        if model_args.benchmark or model_args.accuracy_only:
-            if model_args.benchmark:
-                from neural_compressor.config import BenchmarkConfig
-                from neural_compressor import benchmark
-                b_conf = BenchmarkConfig(backend="ipex",
-                                         warmup=5,
-                                         iteration=model_args.iters,
-                                         cores_per_instance=4,
-                                         num_of_instance=1)
-                benchmark.fit(model, b_conf, b_dataloader=eval_dataloader)
-            else:
-                eval_func(model)
+        if model_args.benchmark:
+            from neural_compressor.config import BenchmarkConfig
+            from neural_compressor import benchmark
+            b_conf = BenchmarkConfig(backend="ipex",
+                                     warmup=5,
+                                     iteration=model_args.iters,
+                                     cores_per_instance=4,
+                                     num_of_instance=1)
+            benchmark.fit(model, b_conf, b_dataloader=eval_dataloader)
+        else:
+            eval_func(model)
 
 def _mp_fn(index):
     # For xla_spawn (TPUs)

--- a/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
+++ b/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
@@ -655,6 +655,7 @@ def main():
         from neural_compressor.adaptor.pytorch import get_example_inputs
         example_inputs = get_example_inputs(model, eval_dataloader)
         model = ipex.optimize(model)
+        import torch
         with torch.no_grad():
             model = torch.jit.trace(model, example_inputs, checkout_trace=False, strict=False)
             model = torch.jit.freeze(model)

--- a/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
+++ b/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
@@ -657,7 +657,7 @@ def main():
         model = ipex.optimize(model)
         import torch
         with torch.no_grad():
-            model = torch.jit.trace(model, example_inputs, checkout_trace=False, strict=False)
+            model = torch.jit.trace(model, example_inputs, strict=False)
             model = torch.jit.freeze(model)
 
     if model_args.benchmark or model_args.accuracy_only:

--- a/examples/pytorch/object_detection/ssd_resnet34/quantization/ptq/ipex/infer.py
+++ b/examples/pytorch/object_detection/ssd_resnet34/quantization/ptq/ipex/infer.py
@@ -649,7 +649,7 @@ def eval_ssd_r34_mlperf_coco(args):
             from neural_compressor.utils.pytorch import load
             ssd_r34 = load(args.tuned_checkpoint, ssd_r34)
         else:
-            from neural_compressor.adaptor.adaptor import get_example_inputs
+            from neural_compressor.adaptor.pytorch import get_example_inputs
             example_inputs = get_example_inputs(model, val_dataloader)
             model = ipex.optimize(model)
             with torch.no_grad():

--- a/examples/pytorch/object_detection/ssd_resnet34/quantization/ptq/ipex/infer.py
+++ b/examples/pytorch/object_detection/ssd_resnet34/quantization/ptq/ipex/infer.py
@@ -650,11 +650,11 @@ def eval_ssd_r34_mlperf_coco(args):
             ssd_r34 = load(args.tuned_checkpoint, ssd_r34)
         else:
             from neural_compressor.adaptor.pytorch import get_example_inputs
-            example_inputs = get_example_inputs(model, val_dataloader)
-            model = ipex.optimize(model)
+            example_inputs = get_example_inputs(ssd_r34, val_dataloader)
+            ssd_r34 = ipex.optimize(ssd_r34)
             with torch.no_grad():
-                model = torch.jit.trace(model, example_inputs)
-                model = torch.jit.freeze(model)
+                ssd_r34 = torch.jit.trace(ssd_r34, example_inputs)
+                ssd_r34 = torch.jit.freeze(ssd_r34)
         from neural_compressor.config import BenchmarkConfig
         from neural_compressor import benchmark
         b_conf = BenchmarkConfig(cores_per_instance=4, num_of_instance=1)

--- a/examples/pytorch/recommendation/dlrm/quantization/ptq/ipex/dlrm_s_pytorch.py
+++ b/examples/pytorch/recommendation/dlrm/quantization/ptq/ipex/dlrm_s_pytorch.py
@@ -864,15 +864,15 @@ def run():
         args.num_cpu_cores = b_conf.cores_per_instance
 
         def b_func(model):
-            return inference(
+            with torch.no_grad():
+                return inference(
                           args,
                           model,
                           best_acc_test,
                           best_auc_test,
                           test_ld
                         )
-        with torch.no_grad():
-            benchmark.fit(dlrm, b_conf, b_func=b_func)
+        benchmark.fit(dlrm, b_conf, b_func=b_func)
         exit(0)
 
     if args.accuracy_only:

--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -217,17 +217,6 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
     version = get_torch_version()
     # Get example inputs for ipex and torch>=1.13.
     example_inputs = None
-    if isinstance(stat_dict, torch.jit._script.RecursiveScriptModule) or \
-      (version.release >= Version("1.13.0").release and \
-      tune_cfg['approach'] != "post_training_dynamic_quant"):
-        if "example_inputs" in kwargs:
-            example_inputs = kwargs["example_inputs"]
-        elif "dataloader" in kwargs:
-            from ..adaptor.pytorch import get_example_inputs
-            example_inputs = get_example_inputs(model, kwargs["dataloader"])
-        else:
-            logger.warning("Please provide the example_inputs or a dataloader" +
-                            " to get example_inputs for quantized model.")
 
     if isinstance(stat_dict, torch.jit._script.RecursiveScriptModule):
         q_model = torch.jit.freeze(stat_dict.eval())


### PR DESCRIPTION
Signed-off-by: changwa1 <chang1.wang@intel.com>

## Type of Change

1. modify benchmark to compare ipex optimized torchscript mode int8 model v.s. ipex optimized torchscript mode fp32 model
2. remove invaild code about get example_input in int8 model load function

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
