### PR TITLE
mark 1.x API examples with flag

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 Examples
 ==========
 Intel® Neural Compressor validated examples with multiple compression techniques, including quantization, pruning, knowledge distillation and orchestration. Part of the validated cases can be found in the example tables, and the release data is available [here](../docs/source/validated_model_list.md).
+> Note: New API migration work in progress, the example marked with `*` means it still using old API.
 
 ## Helloworld Examples
 
@@ -14,11 +15,11 @@ Intel® Neural Compressor validated examples with multiple compression technique
 
 ## Notebook Examples
 
-* [BERT Mini SST2 performance boost with INC](/examples/notebook/bert_mini_distillation): train a BERT-Mini model on SST-2 dataset through distillation, and leverage quantization to accelerate the inference while maintaining the accuracy using Intel® Neural Compressor.
+* *[BERT Mini SST2 performance boost with INC](/examples/notebook/bert_mini_distillation): train a BERT-Mini model on SST-2 dataset through distillation, and leverage quantization to accelerate the inference while maintaining the accuracy using Intel® Neural Compressor.
 * [Performance of FP32 Vs. INT8 ResNet50 Model](/examples/notebook/perf_fp32_int8_tf): compare existed FP32 & INT8 ResNet50 model directly.
-* [Intel® Neural Compressor Sample for PyTorch*](/examples/notebook/pytorch/alexnet_fashion_mnist): an End-To-End pipeline to build up a CNN model by PyTorch to recognize fashion image and speed up AI model by Intel® Neural Compressor.
-* [Intel® Neural Compressor Sample for TensorFlow*](/examples/notebook/tensorflow/alexnet_mnist): an End-To-End pipeline to build up a CNN model by TensorFlow to recognize handwriting number and speed up AI model by Intel® Neural Compressor.
-* [Accelerate VGG19 Inference on Intel® Gen4 Xeon® Sapphire Rapids](/examples/notebook/tensorflow/vgg19_ibean): an End-To-End pipeline to train VGG19 model by transfer learning based on pre-trained model from [TensorFlow Hub](https://tfhub.dev); quantize it by Intel® Neural Compressor on Intel® Gen4 Xeon® Sapphire Rapids.
+* *[Intel® Neural Compressor Sample for PyTorch*](/examples/notebook/pytorch/alexnet_fashion_mnist): an End-To-End pipeline to build up a CNN model by PyTorch to recognize fashion image and speed up AI model by Intel® Neural Compressor.
+* *[Intel® Neural Compressor Sample for TensorFlow*](/examples/notebook/tensorflow/alexnet_mnist): an End-To-End pipeline to build up a CNN model by TensorFlow to recognize handwriting number and speed up AI model by Intel® Neural Compressor.
+* *[Accelerate VGG19 Inference on Intel® Gen4 Xeon® Sapphire Rapids](/examples/notebook/tensorflow/vgg19_ibean): an End-To-End pipeline to train VGG19 model by transfer learning based on pre-trained model from [TensorFlow Hub](https://tfhub.dev); quantize it by Intel® Neural Compressor on Intel® Gen4 Xeon® Sapphire Rapids.
 
 # TensorFlow Examples
 ## Quantization
@@ -33,175 +34,175 @@ Intel® Neural Compressor validated examples with multiple compression technique
 </thead>
 <tbody>
   <tr>
-    <td>ResNet50 V1.0</td>
+    <td>*ResNet50 V1.0</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>ResNet50 V1.5</td>
+    <td>*ResNet50 V1.5</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>ResNet101</td>
+    <td>*ResNet101</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>MobileNet V1</td>
+    <td>*MobileNet V1</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>MobileNet V2</td>
+    <td>*MobileNet V2</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a> / <a href="./tensorflow/image_recognition/keras_models/mobilenet_v2/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>MobileNet V3</td>
+    <td>*MobileNet V3</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>Inception V1</td>
+    <td>*Inception V1</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>Inception V2</td>
+    <td>*Inception V2</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>Inception V3</td>
+    <td>*Inception V3</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>Inception V4</td>
+    <td>*Inception V4</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>Inception ResNet V2</td>
+    <td>*Inception ResNet V2</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>VGG16</td>
+    <td>*VGG16</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/vgg16/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>VGG19</td>
+    <td>*VGG19</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/vgg19/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>ResNet V2 50</td>
+    <td>*ResNet V2 50</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a> / <a href="./tensorflow/image_recognition/keras_models/resnetv2_50/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>ResNet V2 101</td>
+    <td>*ResNet V2 101</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a> / <a href="./tensorflow/image_recognition/keras_models/resnetv2_101/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>ResNet V2 152</td>
+    <td>*ResNet V2 152</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>DenseNet121</td>
+    <td>*DenseNet121</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>DenseNet161</td>
+    <td>*DenseNet161</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>DenseNet169</td>
+    <td>*DenseNet169</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>EfficientNet B0</td>
+    <td>*EfficientNet B0</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/tensorflow_models/quantization/ptq">ckpt</a></td>
   </tr>
   <tr>
-    <td>MNIST </td>
+    <td>*MNIST </td>
     <td>Image Recognition</td>
     <td>Quantization-Aware Training</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/mnist/quantization/qat">keras</a></td>
   </tr>
   <tr>
-    <td>ResNet50</td>
+    <td>*ResNet50</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/resnet50/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>ResNet50 Fashion</td>
+    <td>*ResNet50 Fashion</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/resnet50_fashion/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>ResNet101</td>
+    <td>*ResNet101</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/resnet101/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>Inception V3</td>
+    <td>*Inception V3</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/inception_v3/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>Inception Resnet V2</td>
+    <td>*Inception Resnet V2</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/inception_resnet_v2/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>Xception</td>
+    <td>*Xception</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/keras_models/xception/quantization/ptq">keras</a></td>
   </tr>
   <tr>
-    <td>ResNet V2</td>
+    <td>*ResNet V2</td>
     <td>Image Recognition</td>
     <td>Quantization-Aware Training</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/resnet_v2/quantization/qat">keras</a> </td>
   </tr>
   <tr>
-    <td>EfficientNet V2 B0</td>
+    <td>*EfficientNet V2 B0</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/SavedModel/quantization/ptq">SavedModel</a></td>
@@ -213,13 +214,13 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./tensorflow/nlp/bert_base_mrpc/quantization/ptq">ckpt</a></td>
   </tr>
   <tr>
-    <td>BERT large SQuAD (Model Zoo)</td>
+    <td>*BERT large SQuAD (Model Zoo)</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/nlp/bert_large_squad_model_zoo/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>BERT large SQuAD</td>
+    <td>*BERT large SQuAD</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/nlp/bert_large_squad/quantization/ptq">pb</a></td>
@@ -243,49 +244,49 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./tensorflow/nlp/transformer_lt_mlperf/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>SSD ResNet50 V1</td>
+    <td>*SSD ResNet50 V1</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">pb</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">ckpt</a></td>
   </tr>
   <tr>
-    <td>SSD MobileNet V1</td>
+    <td>*SSD MobileNet V1</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">pb</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">ckpt</a></td>
   </tr>
   <tr>
-    <td>Faster R-CNN Inception ResNet V2</td>
+    <td>*Faster R-CNN Inception ResNet V2</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">pb</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">SavedModel</a></td>
   </tr>
   <tr>
-    <td>Faster R-CNN ResNet101</td>
+    <td>*Faster R-CNN ResNet101</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">pb</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">SavedModel</a></td>
   </tr>
   <tr>
-    <td>Faster R-CNN ResNet50</td>
+    <td>*Faster R-CNN ResNet50</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>Mask R-CNN Inception V2</td>
+    <td>*Mask R-CNN Inception V2</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">pb</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">ckpt</a></td>
   </tr>
   <tr>
-    <td>SSD ResNet34</td>
+    <td>*SSD ResNet34</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/tensorflow_models/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>YOLOv3</td>
+    <td>*YOLOv3</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/object_detection/yolo_v3/quantization/ptq">pb</a></td>
@@ -297,7 +298,7 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./tensorflow/recommendation/wide_deep_large_ds/quantization/ptq">pb</a></td>
   </tr>
   <tr>
-    <td>Arbitrary Style Transfer</td>
+    <td>*Arbitrary Style Transfer</td>
     <td>Style Transfer</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/style_transfer/arbitrary_style_transfer/quantization/ptq">ckpt</a></td>
@@ -318,21 +319,21 @@ Intel® Neural Compressor validated examples with multiple compression technique
 </thead>
 <tbody>
   <tr>
-    <td>Inception V3</td>
+    <td>*Inception V3</td>
     <td>Image Recognition</td>
     <td>Unstructured</td>
     <td>Magnitude</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/inception_v3/pruning/magnitude">pb</a></td>
   </tr>
   <tr>
-    <td>ResNet V2</td>
+    <td>*ResNet V2</td>
     <td>Image Recognition</td>
     <td>Unstructured</td>
     <td>Magnitude</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/tensorflow/image_recognition/resnet_v2/pruning/magnitude">pb</a></td>
   </tr>
   <tr>
-    <td>ViT</td>
+    <td>*ViT</td>
     <td>Image Recognition</td>
     <td>Unstructured</td>
     <td>Magnitude</td>
@@ -354,7 +355,7 @@ Intel® Neural Compressor validated examples with multiple compression technique
 </thead>
 <tbody>
   <tr>
-    <td>MobileNet</td>
+    <td>*MobileNet</td>
     <td>DenseNet201</td>
     <td>Image Recognition</td>
     <td>Knowledge Distillation</td>
@@ -376,25 +377,25 @@ Intel® Neural Compressor validated examples with multiple compression technique
 </thead>
 <tbody>
   <tr>
-    <td>ResNet18</td>
+    <td>*ResNet18</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/eager">eager</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx">fx</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex">ipex</a></td>
   </tr>
   <tr>
-    <td>ResNet18</td>
+    <td>*ResNet18</td>
     <td>Image Recognition</td>
     <td>Quantization-Aware Training</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/qat/eager">eager</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/qat/fx">fx</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/qat/eager/distributed">distributed</a></td>
   </tr>
   <tr>
-    <td>ResNet50</td>
+    <td>*ResNet50</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/eager">eager</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx">fx</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex">ipex</a></td>
   </tr>
   <tr>
-    <td>ResNet50</td>
+    <td>*ResNet50</td>
     <td>Image Recognition</td>
     <td>Quantization-Aware Training</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/qat/eager">eager</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/qat/fx">fx</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/qat/eager/distributed">distributed</a></td>
@@ -406,43 +407,43 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/ipex">ipex</a></td>
   </tr>
   <tr>
-    <td>ResNeXt101_32x8d</td>
+    <td>*ResNeXt101_32x8d</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/eager">eager</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx">fx</a></td>
   </tr>
   <tr>
-    <td>Se_ResNeXt50_32x4d</td>
+    <td>*Se_ResNeXt50_32x4d</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/se_resnext/quantization/ptq/eager">eager</a></td>
   </tr>
   <tr>
-    <td>Inception V3</td>
+    <td>*Inception V3</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/eager">eager</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx">fx</a></td>
   </tr>
   <tr>
-    <td>MobileNet V2</td>
+    <td>*MobileNet V2</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/eager">eager</a> / <a href="./pytorch/image_recognition/torchvision_models/quantization/ptq/cpu/fx">fx</a></td>
   </tr>
   <tr>
-    <td>PeleeNet</td>
+    <td>*PeleeNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/peleenet/quantization/ptq/eager">eager</a></td>
   </tr>
   <tr>
-    <td>ResNeSt50</td>
+    <td>*ResNeSt50</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/resnest/quantization/ptq/eager">eager</a></td>
   </tr>
   <tr>
-    <td>3D-UNet</td>
+    <td>*3D-UNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/image_recognition/3d-unet/quantization/ptq/eager">eager</a></td>
@@ -454,43 +455,43 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./pytorch/object_detection/ssd_resnet34/quantization/ptq/fx">fx</a> / <a href="./pytorch/object_detection/ssd_resnet34/quantization/ptq/ipex">ipex</a></td>
   </tr>
   <tr>
-    <td>Mask R-CNN</td>
+    <td>*Mask R-CNN</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/object_detection/maskrcnn/quantization/ptq/fx">fx</a></td>
   </tr>
   <tr>
-    <td>YOLOv3</td>
+    <td>*YOLOv3</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/object_detection/yolo_v3/quantization/ptq/eager">eager</a></td>
   </tr>
   <tr>
-    <td>DLRM</td>
+    <td>*DLRM</td>
     <td>Recommendation</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/recommendation/dlrm/quantization/ptq/eager">eager</a> / <a href="./pytorch/recommendation/dlrm/quantization/ptq/ipex">ipex</a> / <a href="./pytorch/recommendation/dlrm/quantization/ptq/fx">fx</a></td>
   </tr>
   <tr>
-    <td>RNN-T</td>
+    <td>*RNN-T</td>
     <td>Speech Recognition</td>
     <td>Post-Training Dynamic Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/speech_recognition/rnnt/quantization/ptq_dynamic/eager">eager</a> </td>
   </tr>
   <tr>
-    <td>Wav2Vec2</td>
+    <td>*Wav2Vec2</td>
     <td>Speech Recognition</td>
     <td>Post-Training Dynamic</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/speech_recognition/torchaudio_models/quantization/ptq_dynamic/eager">eager</a> </td>
   </tr>
   <tr>
-    <td>HuBERT</td>
+    <td>*HuBERT</td>
     <td>Speech Recognition</td>
     <td>Post-Training Dynamic /Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/speech_recognition/torchaudio_models/quantization/ptq_dynamic/eager">eager</a> / <a href="./pytorch/speech_recognition/torchaudio_models/quantization/ptq_static/fx">fx</a></td>
   </tr>
   <tr>
-    <td>BlendCNN</td>
+    <td>*BlendCNN</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/nlp/blendcnn/quantization/ptq/eager">eager</a></td>
@@ -508,19 +509,19 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex">ipex</a></td>
   </tr>
   <tr>
-    <td>t5-small</td>
+    <td>*t5-small</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Dynamic Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/nlp/huggingface_models/translation/quantization/ptq_dynamic/eager">eager</a></td>
   </tr>
   <tr>
-    <td>Helsinki-NLP/opus-mt-en-ro</td>
+    <td>*Helsinki-NLP/opus-mt-en-ro</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Dynamic Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/nlp/huggingface_models/translation/quantization/ptq_dynamic/eager">eager</a></td>
   </tr>
   <tr>
-    <td>lvwerra/pegasus-samsum</td>
+    <td>*lvwerra/pegasus-samsum</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Dynamic Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/nlp/huggingface_models/summarization/quantization/ptq_dynamic/eager">eager</a></td>
@@ -630,7 +631,7 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./pytorch/image_recognition/torchvision_models/pruning/magnitude/eager">eager</a></td>
   </tr>
   <tr>
-    <td>BERT large</td>
+    <td>*BERT large</td>
     <td>Natural Language Processing</td>
     <td>Structured (2x1)</td>
     <td>Group Lasso</td>
@@ -638,28 +639,28 @@ Intel® Neural Compressor validated examples with multiple compression technique
   </tr>
 
   <tr>
-    <td>Intel/bert-base-uncased-sparse-70-unstructured</td>
+    <td>*Intel/bert-base-uncased-sparse-70-unstructured</td>
     <td>Natural Language Processing (question-answering)</td>
     <td>Unstructured</td>
     <td>Prune once for all</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/nlp/huggingface_models/question-answering/pruning/legacy/pattern_lock/eager">eager</a></td>
   </tr>
   <tr>
-    <td>bert-base-uncased</td>
+    <td>*bert-base-uncased</td>
     <td>Natural Language Processing</td>
     <td>Structured (Filter/Channel-wise)</td>
     <td>Gradient Sensitivity</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/nlp/huggingface_models/text-classification/pruning/legacy/gradient_sensitivity/eager">eager</a></td>
   </tr>
   <tr>
-    <td>DistilBERT</td>
+    <td>*DistilBERT</td>
     <td>Natural Language Processing</td>
     <td>Unstructured</td>
     <td>Magnitude</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/pytorch/nlp/huggingface_models/text-classification/pruning/legacy/magnitude/eager">eager</a></td>
   </tr>
   <tr>
-    <td>Intel/bert-base-uncased-sparse-70-unstructured</td>
+    <td>*Intel/bert-base-uncased-sparse-70-unstructured</td>
     <td>Natural Language Processing (text-classification)</td>
     <td>Unstructured</td>
     <td>Prune once for all</td>
@@ -818,55 +819,55 @@ Intel® Neural Compressor validated examples with multiple compression technique
 </thead>
 <tbody>
   <tr>
-    <td>ResNet50 V1.5</td>
+    <td>*ResNet50 V1.5</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/resnet50/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/resnet50/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>ResNet50 V1.5 MLPerf</td>
+    <td>*ResNet50 V1.5 MLPerf</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/resnet50/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/resnet50/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>VGG16</td>
+    <td>*VGG16</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/vgg16/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/vgg16/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>MobileNet V2</td>
+    <td>*MobileNet V2</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/mobilenet_v2/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/mobilenet_v2/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>MobileNet V3 MLPerf</td>
+    <td>*MobileNet V3 MLPerf</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/mobilenet_v3/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/mobilenet_v3/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>AlexNet</td>
+    <td>*AlexNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/alexnet/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/alexnet/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>CaffeNet</td>
+    <td>*CaffeNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/caffenet/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/caffenet/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>DenseNet</td>
+    <td>*DenseNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/densenet/quantization/ptq">qlinearops</a></td>
   </tr>
   <tr>
-    <td>EfficientNet</td>
+    <td>*EfficientNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/efficientnet/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/efficientnet/quantization/ptq">qdq</a></td>
@@ -878,37 +879,37 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./onnxrt/image_recognition/onnx_model_zoo/fcn/quantization/ptq">qlinearops</a> / <a href="./onnxrt/image_recognition/onnx_model_zoo/fcn/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>GoogleNet</td>
+    <td>*GoogleNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/googlenet/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/googlenet/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>Inception V1</td>
+    <td>*Inception V1</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/inception/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/inception/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>MNIST</td>
+    <td>*MNIST</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/mnist/quantization/ptq">qlinearops</a></td>
   </tr>
   <tr>
-    <td>MobileNet V2 (ONNX Model Zoo)</td>
+    <td>*MobileNet V2 (ONNX Model Zoo)</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/mobilenet/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/mobilenet/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>ResNet50 V1.5 (ONNX Model Zoo)</td>
+    <td>*ResNet50 V1.5 (ONNX Model Zoo)</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/resnet50/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/resnet50/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>ShuffleNet V2</td>
+    <td>*ShuffleNet V2</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/shufflenet/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/shufflenet/quantization/ptq">qdq</a></td>
@@ -920,13 +921,13 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./onnxrt/image_recognition/onnx_model_zoo/squeezenet/quantization/ptq">qlinearops</a> / <a href="./onnxrt/image_recognition/onnx_model_zoo/squeezenet/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>VGG16 (ONNX Model Zoo)</td>
+    <td>*VGG16 (ONNX Model Zoo)</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/vgg16/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/vgg16/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>ZFNet</td>
+    <td>*ZFNet</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/zfnet/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/image_recognition/onnx_model_zoo/zfnet/quantization/ptq">qdq</a></td>
@@ -938,31 +939,31 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./onnxrt/body_analysis/onnx_model_zoo/arcface/quantization/ptq">qlinearops</a></td>
   </tr>
   <tr>
-    <td>BERT base MRPC</td>
+    <td>*BERT base MRPC</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/bert/quantization/ptq">integerops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/bert/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>BERT base MRPC</td>
+    <td>*BERT base MRPC</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Dynamic Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/bert/quantization/ptq">integerops</a></td>
   </tr>
   <tr>
-    <td>DistilBERT base MRPC</td>
+    <td>*DistilBERT base MRPC</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Dynamic / Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/distilbert/quantization/ptq">integerops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/distilbert/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>Mobile bert MRPC</td>
+    <td>*Mobile bert MRPC</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Dynamic / Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/mobilebert/quantization/ptq">integerops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/mobilebert/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>Roberta base MRPC</td>
+    <td>*Roberta base MRPC</td>
     <td>Natural Language Processing</td>
     <td>Post-Training Dynamic / Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/roberta/quantization/ptq">integerops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/nlp/roberta/quantization/ptq">qdq</a></td>
@@ -1052,19 +1053,19 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./onnxrt/nlp/huggingface_model/question_answering/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>SSD MobileNet V1</td>
+    <td>*SSD MobileNet V1</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/ssd_mobilenet_v1/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/ssd_mobilenet_v1/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>SSD MobileNet V2</td>
+    <td>*SSD MobileNet V2</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/ssd_mobilenet_v2/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/ssd_mobilenet_v2/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>SSD MobileNet V1 (ONNX Model Zoo)</td>
+    <td>*SSD MobileNet V1 (ONNX Model Zoo)</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/ssd_mobilenet_v1/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/ssd_mobilenet_v1/quantization/ptq">qdq</a></td>
@@ -1076,37 +1077,37 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./onnxrt/object_detection/onnx_model_zoo/DUC/quantization/ptq">qlinearops</a></td>
   </tr>
   <tr>
-    <td>Faster R-CNN</td>
+    <td>*Faster R-CNN</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/faster_rcnn/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/faster_rcnn/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>Mask R-CNN</td>
+    <td>*Mask R-CNN</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/mask_rcnn/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/mask_rcnn/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>SSD</td>
+    <td>*SSD</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/ssd/quantization/ptq">qlinearops</a> / <a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/ssd/quantization/ptq">qdq</a></td>
   </tr>
   <tr>
-    <td>Tiny YOLOv3</td>
+    <td>*Tiny YOLOv3</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/tiny_yolov3/quantization/ptq">qlinearops</a></td>
   </tr>
   <tr>
-    <td>YOLOv3</td>
+    <td>*YOLOv3</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/yolov3/quantization/ptq">qlinearops</a></td>
   </tr>
   <tr>
-    <td>YOLOv4</td>
+    <td>*YOLOv4</td>
     <td>Object Detection</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="https://github.com/intel/neural-compressor/tree/old_api_examples/examples/onnxrt/object_detection/onnx_model_zoo/yolov4/quantization/ptq">qlinearops</a></td>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 Examples
 ==========
 Intel® Neural Compressor validated examples with multiple compression techniques, including quantization, pruning, knowledge distillation and orchestration. Part of the validated cases can be found in the example tables, and the release data is available [here](../docs/source/validated_model_list.md).
-> Note: New API migration work in progress, the example marked with `*` means it still using old API.
+> Note: 2.0 API migration work in progress, the example marked with `*` means it still using 1.x API.
 
 ## Helloworld Examples
 


### PR DESCRIPTION
Signed-off-by: chensuyue <suyue.chen@intel.com>

## Type of Change

documentation 

## Description

Mark 1.x API examples with flag to help user quickly find 2.0 API examples, the flag will be removed after API migrate is done. 