### PR TITLE
fix UT overflow error

### DIFF
--- a/test/adaptor/pytorch_adaptor/test_adaptor_pytorch_1.x.py
+++ b/test/adaptor/pytorch_adaptor/test_adaptor_pytorch_1.x.py
@@ -327,8 +327,8 @@ class FP32Model(torch.nn.Module):
     def forward(self, x):
         times = x.size(1)
         if times == 1:
-            return x + x
-        return x
+            return torch.ones(x.shape)
+        return torch.ones(x.shape) + 1
 
 
 class DynamicModel(torch.nn.Module):


### PR DESCRIPTION
Signed-off-by: Xin He <xin3.he@intel.com>

## Type of Change

The input tensor of middle layer goes to 1E30 with random input, which will cause an overflow sometimes. (No idea why it overflows) 

Anyway, we can reset the input to 1 to avoid this error.

## Description

[ILITV-2558(https://jira.devtools.intel.com/browse/ILITV-2558)

## Expected Behavior & Potential Risk

UT pass
