### PR TITLE
Neural Coder use INC API by default instead of Optimum

### DIFF
--- a/neural_coder/backends/pytorch_inc_dynamic_quant.yaml
+++ b/neural_coder/backends/pytorch_inc_dynamic_quant.yaml
@@ -17,30 +17,29 @@ transformation:
     - insert_below_model_definition_line
   content:
     - |-
-      [+] if "GraphModule" not in str(type(MODEL_NAME)):
-      [+]     def eval_func(model):
-      [+]         EVAL_FUNC_LINES
-      [+]     try:
-      [+]         torch.backends.quantized.engine = 'onednn'
-      [+]     except:
-      [+]         from torch.backends.quantized import engine; engine = 'onednn'
-      [+]     from neural_compressor.conf.config import QuantConf
-      [+]     from neural_compressor.experimental import Quantization, common
-      [+]     quant_config = QuantConf()
-      [+]     quant_config.usr_cfg.quantization.approach = "post_training_dynamic_quant"
-      [+]     quant_config.usr_cfg.model.framework = "pytorch"
-      [+]     quantizer = Quantization(quant_config)
-      [+]     quantizer.model = common.Model(MODEL_NAME)
-      [+]     quantizer.eval_func = eval_func
-      [+]     MODEL_NAME = quantizer()
-      [+]     MODEL_NAME = MODEL_NAME.model
-      [+]     MODEL_NAME.eval()
-      [+]     try:
-      [+]         with torch.no_grad():
-      [+]             MODEL_NAME = torch.jit.script(MODEL_NAME)
-      [+]         MODEL_NAME = torch.jit.freeze(MODEL_NAME)
-      [+]     except:
-      [+]         pass
+      [+] def eval_func(model):
+      [+]     EVAL_FUNC_LINES
+      [+] try:
+      [+]     torch.backends.quantized.engine = 'onednn'
+      [+] except:
+      [+]     from torch.backends.quantized import engine; engine = 'onednn'
+      [+] from neural_compressor.conf.config import QuantConf
+      [+] from neural_compressor.experimental import Quantization, common
+      [+] quant_config = QuantConf()
+      [+] quant_config.usr_cfg.quantization.approach = "post_training_dynamic_quant"
+      [+] quant_config.usr_cfg.model.framework = "pytorch"
+      [+] quantizer = Quantization(quant_config)
+      [+] quantizer.model = common.Model(MODEL_NAME)
+      [+] quantizer.eval_func = eval_func
+      [+] MODEL_NAME = quantizer()
+      [+] MODEL_NAME = MODEL_NAME.model
+      [+] MODEL_NAME.eval()
+      [+] try:
+      [+]     with torch.no_grad():
+      [+]         MODEL_NAME = torch.jit.script(MODEL_NAME)
+      [+]     MODEL_NAME = torch.jit.freeze(MODEL_NAME)
+      [+] except:
+      [+]     pass
   order:
     - below:
       above:

--- a/neural_coder/backends/pytorch_inc_dynamic_quant_fp8.yaml
+++ b/neural_coder/backends/pytorch_inc_dynamic_quant_fp8.yaml
@@ -17,32 +17,31 @@ transformation:
     - ["insert_below_dataloader_definition_line", "insert_below_model_definition_line"]
   content:
     - |-
-      [+] if "GraphModule" not in str(type(MODEL_NAME)):
-      [+]     def eval_func(model):
-      [+]         EVAL_FUNC_LINES
-      [+]     try:
-      [+]         torch.backends.quantized.engine = 'onednn'
-      [+]     except:
-      [+]         from torch.backends.quantized import engine; engine = 'onednn'
-      [+]     from neural_compressor.conf.config import QuantConf
-      [+]     from neural_compressor.experimental import Quantization, common
-      [+]     quant_config = QuantConf()
-      [+]     quant_config.usr_cfg.quantization.approach = "post_training_dynamic_quant"
-      [+]     quant_config.usr_cfg.model.framework = "pytorch"
-      [+]     quant_config.usr_cfg.quantization.precision = FP8_DATA_FORMAT
-      [+]     quantizer = Quantization(quant_config)
-      [+]     quantizer.model = common.Model(MODEL_NAME)
-      [+]     quantizer.calib_dataloader = DATALOADER_NAME
-      [+]     quantizer.eval_func = eval_func
-      [+]     MODEL_NAME = quantizer()
-      [+]     MODEL_NAME = MODEL_NAME.model
-      [+]     MODEL_NAME.eval()
-      [+]     try:
-      [+]         with torch.no_grad():
-      [+]             MODEL_NAME = torch.jit.script(MODEL_NAME)
-      [+]         MODEL_NAME = torch.jit.freeze(MODEL_NAME)
-      [+]     except:
-      [+]         pass
+      [+] def eval_func(model):
+      [+]     EVAL_FUNC_LINES
+      [+] try:
+      [+]     torch.backends.quantized.engine = 'onednn'
+      [+] except:
+      [+]     from torch.backends.quantized import engine; engine = 'onednn'
+      [+] from neural_compressor.conf.config import QuantConf
+      [+] from neural_compressor.experimental import Quantization, common
+      [+] quant_config = QuantConf()
+      [+] quant_config.usr_cfg.quantization.approach = "post_training_dynamic_quant"
+      [+] quant_config.usr_cfg.model.framework = "pytorch"
+      [+] quant_config.usr_cfg.quantization.precision = FP8_DATA_FORMAT
+      [+] quantizer = Quantization(quant_config)
+      [+] quantizer.model = common.Model(MODEL_NAME)
+      [+] quantizer.calib_dataloader = DATALOADER_NAME
+      [+] quantizer.eval_func = eval_func
+      [+] MODEL_NAME = quantizer()
+      [+] MODEL_NAME = MODEL_NAME.model
+      [+] MODEL_NAME.eval()
+      [+] try:
+      [+]     with torch.no_grad():
+      [+]         MODEL_NAME = torch.jit.script(MODEL_NAME)
+      [+]     MODEL_NAME = torch.jit.freeze(MODEL_NAME)
+      [+] except:
+      [+]     pass
   order:
     - below:
       above:

--- a/neural_coder/backends/pytorch_inc_huggingface_optimum_dynamic.yaml
+++ b/neural_coder/backends/pytorch_inc_huggingface_optimum_dynamic.yaml
@@ -17,16 +17,15 @@ transformation:
     - ["insert_below_dataloader_definition_line", "insert_below_model_definition_line"]
   content:
     - |-
-      [+] if "GraphModule" not in str(type(MODEL_NAME)):
-      [+]     def eval_func(model):
-      [+]         EVAL_FUNC_LINES
-      [+]     from neural_compressor.config import PostTrainingQuantConfig
-      [+]     from optimum.intel.neural_compressor import INCQuantizer
-      [+]     quantization_config = PostTrainingQuantConfig(approach="dynamic")
-      [+]     quantizer = INCQuantizer.from_pretrained(MODEL_NAME)
-      [+]     quantizer.quantize(quantization_config=quantization_config, save_directory="quantized_model", save_onnx_model=False)
-      [+]     MODEL_NAME = quantizer._quantized_model
-      [+]     MODEL_NAME.eval()
+      [+] def eval_func(model):
+      [+]     EVAL_FUNC_LINES
+      [+] from neural_compressor.config import PostTrainingQuantConfig
+      [+] from optimum.intel.neural_compressor import INCQuantizer
+      [+] quantization_config = PostTrainingQuantConfig(approach="dynamic")
+      [+] quantizer = INCQuantizer.from_pretrained(MODEL_NAME)
+      [+] quantizer.quantize(quantization_config=quantization_config, save_directory="quantized_model", save_onnx_model=False)
+      [+] MODEL_NAME = quantizer._quantized_model
+      [+] MODEL_NAME.eval()
   order:
     - below:
       above:

--- a/neural_coder/backends/pytorch_inc_huggingface_optimum_static.yaml
+++ b/neural_coder/backends/pytorch_inc_huggingface_optimum_static.yaml
@@ -17,16 +17,15 @@ transformation:
     - ["insert_below_dataloader_definition_line", "insert_below_model_definition_line"]
   content:
     - |-
-      [+] if "GraphModule" not in str(type(MODEL_NAME)):
-      [+]     def eval_func(model):
-      [+]         EVAL_FUNC_LINES
-      [+]     from neural_compressor.config import PostTrainingQuantConfig
-      [+]     from optimum.intel.neural_compressor import INCQuantizer
-      [+]     quantization_config = PostTrainingQuantConfig(approach="static")
-      [+]     quantizer = INCQuantizer.from_pretrained(MODEL_NAME)
-      [+]     quantizer.quantize(quantization_config=quantization_config, calibration_dataset=eval_dataset, save_directory="quantized_model", save_onnx_model=False)
-      [+]     MODEL_NAME = quantizer._quantized_model
-      [+]     MODEL_NAME.eval()
+      [+] def eval_func(model):
+      [+]     EVAL_FUNC_LINES
+      [+] from neural_compressor.config import PostTrainingQuantConfig
+      [+] from optimum.intel.neural_compressor import INCQuantizer
+      [+] quantization_config = PostTrainingQuantConfig(approach="static")
+      [+] quantizer = INCQuantizer.from_pretrained(MODEL_NAME)
+      [+] quantizer.quantize(quantization_config=quantization_config, calibration_dataset=eval_dataset, save_directory="quantized_model", save_onnx_model=False)
+      [+] MODEL_NAME = quantizer._quantized_model
+      [+] MODEL_NAME.eval()
   order:
     - below:
       above:

--- a/neural_coder/backends/pytorch_inc_static_quant_fx.yaml
+++ b/neural_coder/backends/pytorch_inc_static_quant_fx.yaml
@@ -17,30 +17,29 @@ transformation:
     - ["insert_below_dataloader_definition_line", "insert_below_model_definition_line"]
   content:
     - |-
-      [+] if "GraphModule" not in str(type(MODEL_NAME)):
-      [+]     def eval_func(model):
-      [+]         EVAL_FUNC_LINES
-      [+]     try:
-      [+]         torch.backends.quantized.engine = 'onednn'
-      [+]     except:
-      [+]         from torch.backends.quantized import engine; engine = 'onednn'
-      [+]     from neural_compressor.conf.config import QuantConf
-      [+]     from neural_compressor.experimental import Quantization, common
-      [+]     quant_config = QuantConf()
-      [+]     quant_config.usr_cfg.model.framework = "pytorch_fx"
-      [+]     quantizer = Quantization(quant_config)
-      [+]     quantizer.model = common.Model(MODEL_NAME)
-      [+]     quantizer.calib_dataloader = DATALOADER_NAME
-      [+]     quantizer.eval_func = eval_func
-      [+]     MODEL_NAME = quantizer()
-      [+]     MODEL_NAME = MODEL_NAME.model
-      [+]     MODEL_NAME.eval()
-      [+]     try:
-      [+]         with torch.no_grad():
-      [+]             MODEL_NAME = torch.jit.script(MODEL_NAME)
-      [+]         MODEL_NAME = torch.jit.freeze(MODEL_NAME)
-      [+]     except:
-      [+]         pass
+      [+] def eval_func(model):
+      [+]     EVAL_FUNC_LINES
+      [+] try:
+      [+]     torch.backends.quantized.engine = 'onednn'
+      [+] except:
+      [+]     from torch.backends.quantized import engine; engine = 'onednn'
+      [+] from neural_compressor.conf.config import QuantConf
+      [+] from neural_compressor.experimental import Quantization, common
+      [+] quant_config = QuantConf()
+      [+] quant_config.usr_cfg.model.framework = "pytorch_fx"
+      [+] quantizer = Quantization(quant_config)
+      [+] quantizer.model = common.Model(MODEL_NAME)
+      [+] quantizer.calib_dataloader = DATALOADER_NAME
+      [+] quantizer.eval_func = eval_func
+      [+] MODEL_NAME = quantizer()
+      [+] MODEL_NAME = MODEL_NAME.model
+      [+] MODEL_NAME.eval()
+      [+] try:
+      [+]     with torch.no_grad():
+      [+]         MODEL_NAME = torch.jit.script(MODEL_NAME)
+      [+]     MODEL_NAME = torch.jit.freeze(MODEL_NAME)
+      [+] except:
+      [+]     pass
       
   order:
     - below:

--- a/neural_coder/backends/pytorch_inc_static_quant_fx_fp8.yaml
+++ b/neural_coder/backends/pytorch_inc_static_quant_fx_fp8.yaml
@@ -17,31 +17,30 @@ transformation:
     - ["insert_below_dataloader_definition_line", "insert_below_model_definition_line"]
   content:
     - |-
-      [+] if "GraphModule" not in str(type(MODEL_NAME)):
-      [+]     def eval_func(model):
-      [+]         EVAL_FUNC_LINES
-      [+]     try:
-      [+]         torch.backends.quantized.engine = 'onednn'
-      [+]     except:
-      [+]         from torch.backends.quantized import engine; engine = 'onednn'
-      [+]     from neural_compressor.conf.config import QuantConf
-      [+]     from neural_compressor.experimental import Quantization, common
-      [+]     quant_config = QuantConf()
-      [+]     quant_config.usr_cfg.model.framework = "pytorch_fx"
-      [+]     quant_config.usr_cfg.quantization.precision = FP8_DATA_FORMAT
-      [+]     quantizer = Quantization(quant_config)
-      [+]     quantizer.model = common.Model(MODEL_NAME)
-      [+]     quantizer.calib_dataloader = DATALOADER_NAME
-      [+]     quantizer.eval_func = eval_func
-      [+]     MODEL_NAME = quantizer()
-      [+]     MODEL_NAME = MODEL_NAME.model
-      [+]     MODEL_NAME.eval()
-      [+]     try:
-      [+]         with torch.no_grad():
-      [+]             MODEL_NAME = torch.jit.script(MODEL_NAME)
-      [+]         MODEL_NAME = torch.jit.freeze(MODEL_NAME)
-      [+]     except:
-      [+]         pass
+      [+] def eval_func(model):
+      [+]     EVAL_FUNC_LINES
+      [+] try:
+      [+]     torch.backends.quantized.engine = 'onednn'
+      [+] except:
+      [+]     from torch.backends.quantized import engine; engine = 'onednn'
+      [+] from neural_compressor.conf.config import QuantConf
+      [+] from neural_compressor.experimental import Quantization, common
+      [+] quant_config = QuantConf()
+      [+] quant_config.usr_cfg.model.framework = "pytorch_fx"
+      [+] quant_config.usr_cfg.quantization.precision = FP8_DATA_FORMAT
+      [+] quantizer = Quantization(quant_config)
+      [+] quantizer.model = common.Model(MODEL_NAME)
+      [+] quantizer.calib_dataloader = DATALOADER_NAME
+      [+] quantizer.eval_func = eval_func
+      [+] MODEL_NAME = quantizer()
+      [+] MODEL_NAME = MODEL_NAME.model
+      [+] MODEL_NAME.eval()
+      [+] try:
+      [+]     with torch.no_grad():
+      [+]         MODEL_NAME = torch.jit.script(MODEL_NAME)
+      [+]     MODEL_NAME = torch.jit.freeze(MODEL_NAME)
+      [+] except:
+      [+]     pass
       
   order:
     - below:

--- a/neural_coder/backends/pytorch_inc_static_quant_ipex.yaml
+++ b/neural_coder/backends/pytorch_inc_static_quant_ipex.yaml
@@ -17,19 +17,18 @@ transformation:
     - ["insert_below_dataloader_definition_line", "insert_below_model_definition_line"]
   content:
     - |-
-      [+] if "GraphModule" not in str(type(MODEL_NAME)):
-      [+]     from neural_compressor.conf.config import QuantConf
-      [+]     from neural_compressor.experimental import Quantization, common
-      [+]     from neural_compressor import options
-      [+]     options.pytorch.quantization.use_bf16 = False
-      [+]     quant_config = QuantConf()
-      [+]     quant_config.usr_cfg.model.framework = "pytorch_ipex"
-      [+]     quantizer = Quantization(quant_config)
-      [+]     quantizer.model = common.Model(MODEL_NAME)
-      [+]     quantizer.calib_dataloader = DATALOADER_NAME
-      [+]     MODEL_NAME = quantizer()
-      [+]     MODEL_NAME = MODEL_NAME.model
-      [+]     MODEL_NAME.eval()
+      [+] from neural_compressor.conf.config import QuantConf
+      [+] from neural_compressor.experimental import Quantization, common
+      [+] from neural_compressor import options
+      [+] options.pytorch.quantization.use_bf16 = False
+      [+] quant_config = QuantConf()
+      [+] quant_config.usr_cfg.model.framework = "pytorch_ipex"
+      [+] quantizer = Quantization(quant_config)
+      [+] quantizer.model = common.Model(MODEL_NAME)
+      [+] quantizer.calib_dataloader = DATALOADER_NAME
+      [+] MODEL_NAME = quantizer()
+      [+] MODEL_NAME = MODEL_NAME.model
+      [+] MODEL_NAME.eval()
   order:
     - below:
       above:

--- a/neural_coder/coders/autoinc/eval_func.py
+++ b/neural_coder/coders/autoinc/eval_func.py
@@ -50,7 +50,7 @@ class Eval_Func(object):
                 ]
             for index, line in enumerate(lines):
                 if index != 0:
-                    lines[index] = '[+] ' + ' ' * 8 + line
+                    lines[index] = '[+] ' + ' ' * 4 + line
             lines = '\n'.join(lines)
             globals.list_eval_func_lines.append(lines)
         elif globals.code_domain == 'transformers_no_trainer':

--- a/neural_coder/docs/PythonLauncher.md
+++ b/neural_coder/docs/PythonLauncher.md
@@ -5,7 +5,14 @@ Neural Coder can be used as a Python **Launcher**. Users can run the Python mode
 
 ## Quick-Start
 
-Example: Let's say you are running an NLP model using ```run_glue.py``` from HuggingFace transformers [examples](https://github.com/huggingface/transformers/blob/v4.21-release/examples/pytorch/text-classification/run_glue.py), you generally run with a Python command line like this:
+Example: Let's say you are running an NLP model using ```run_glue.py``` from HuggingFace transformers [examples](https://github.com/huggingface/transformers/blob/v4.21-release/examples/pytorch/text-classification/run_glue.py).
+
+Pre-requisites:
+```bash
+pip install transformers==4.21.0 torch datasets 
+```
+
+Generally we run this code with a Python command line like this:
 ```bash
 python run_glue.py --model_name_or_path bert-base-cased --task_name mrpc --do_eval --output_dir result
 ```

--- a/neural_coder/interface.py
+++ b/neural_coder/interface.py
@@ -66,7 +66,7 @@ def enable(
     test_code_line=False, # print code line info for debug use
     cache_load_transformers=True,
     optimum_quant_config="", # only for HF optimum optimizations, yaml or hub path
-    use_inc=False,
+    use_inc=True,
     use_modular=False,
     modular_item="",
 ):
@@ -752,7 +752,7 @@ def superbench(
     ncore_per_instance=-1,  # only for "self_defined" mode
     ninstances=-1,  # only for "self_defined" mode
     bench_batch_size=-1,  # only for "self_defined" mode
-    use_inc=False,
+    use_inc=True,
     auto_quant=False,
 ):
 
@@ -1281,7 +1281,7 @@ def auto_quant(
     ncore_per_instance=-1,  # only for "self_defined" mode
     ninstances=-1,  # only for "self_defined" mode
     bench_batch_size=-1,  # only for "self_defined" mode
-    use_inc=False,
+    use_inc=True,
 ):
     return superbench(
         code,

--- a/neural_coder/launcher.py
+++ b/neural_coder/launcher.py
@@ -42,6 +42,7 @@ class Launcher():
         args,
         use_modular=False,
         modular_pattern={},
+        use_inc=True,
     ):
         # copy user entry script (main.py -> main_optimized.py)
         script_copied = args.script[:-3] + "_optimized.py"
@@ -75,6 +76,7 @@ class Launcher():
                 overwrite=True,
                 use_modular=use_modular,
                 modular_item=modular_item,
+                use_inc=use_inc,
             )
 
             if not args.enable: # enable and run
@@ -95,4 +97,5 @@ class Launcher():
             auto_quant(
                 code=script_copied,
                 args=' '.join(args.script_args), # convert list of strings to a single string
+                use_inc=use_inc,
             )


### PR DESCRIPTION
## Type of Change

change logic of which default API design to be enabled

## Description

1. a change of default adopted optimization API's logic:
 
- Old logic:
-- Default all use Optimum API for launchers, no matter INC launcher or Optimum launcher
- New logic:
-- If user use INC launcher, then default API is INC API. 
-- If user use Optimum launcher, then default API is Optimum API.

Optimum side's modification is in this [PR](https://github.com/huggingface/optimum-intel/pull/183)

2. also refined some backend yamls

3. also added pre-requisite in Python Launcher example

## How has this PR been tested?

locally

## Dependency Change?

no