### PR TITLE
Fix a broken link in pruning.md

### DIFF
--- a/docs/source/pruning.md
+++ b/docs/source/pruning.md
@@ -31,8 +31,8 @@ Neural network pruning (briefly known as pruning or sparsity) is one of the most
 
 Pruning patterns defines the rules of pruned weights' arrangements in space.
 
-<a target="_blank" href="./imgs/pruning/pruning_pattern.png">
-    <img src="imgs/pruning/pruning_patterns.png" width=600 height=150 alt="Sparsity Pattern">
+<a target="_blank" href="./imgs/pruning/pruning_patterns.jpg">
+    <img src="imgs/pruning/pruning_patterns.jpg" width=600 height=150 alt="Sparsity Pattern">
 </a>
 
 


### PR DESCRIPTION
Signed-off-by: spycsh <sihan.chen@intel.com>

## Type of Change

documentation

## Description

If you read https://github.com/intel/neural-compressor/blob/master/docs/source/pruning.md
there is a broken link

## Expected Behavior & Potential Risk

 fix that broken link

## How has this PR been tested?

None

## Dependency Change?

None