### PR TITLE
Fix IPEX config json changed according to tune_cfg

### DIFF
--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -336,6 +336,10 @@ def check_cfg_and_qconfig(tune_cfg, cfgs, op_infos_from_cfgs, output_tensor_ids_
                         ipex_op_cfg['input_tensor_infos'] = input_tensor_infos
                         activation_observer = generate_activation_observer(inc_scheme,
                                                                            inc_algorithm)
+                        if inc_scheme == 'sym':
+                            input_tensor_infos[index]['force_dtype'] = 'torch.qint8'
+                        if inc_scheme == 'asym':
+                            input_tensor_infos[index]['force_dtype'] = 'torch.quint8'
                         ipex_op_cfg['activation_observer'] = activation_observer
                     # int8 -> fp32
                     else:


### PR DESCRIPTION
## Type of Change

bug fix.
ipex only support asym + quint8 and sym + qint8 now.

## Description
the input force dtype and activation observer dtype is mismatched,
```
            "9": {
                "op_type": "<method 'add' of 'torch._C._TensorBase' objects>",
                "op_type_is_module": false,
                "fqn": "",
                "input_tensor_infos": [
                    {
                        "id": 8,
                        "orig_dtype": "torch.float32",
                        "inf_dtype": "torch.float32",    
                        "force_dtype": "torch.float32",
                        "scale": [
                            0.014584152959287167
                        ],
                        "zero_point": [
                            121
                        ]
                    },
                    {
                        "id": 9,
                        "orig_dtype": "torch.float32",
                        "inf_dtype": "torch.qint8",     # input force dtype is torch.qint8
                        "force_dtype": "torch.qint8",
                        "scale": [
                            0.037025969475507736
                        ],
                        "zero_point": [
                            161
                        ]
                    }
                ],
                "weight_tensor_infos": [],
                "output_tensor_infos": [
                    {
                        "id": 10,
                        "orig_dtype": "torch.float32",
                        "inf_dtype": "torch.float32",
                        "scale": [
                            0.04625902697443962
                        ],
                        "zero_point": [
                            0
                        ]
                    }
                ],
                "activation_observer": {
                    "name": "MinMaxObserver",
                    "dtype": "torch.quint8",    #activation observer is torch.quint8
                    "qscheme": "torch.per_tensor_affine",
                    "reduce_range": false,
                    "quant_min": 0,
                    "quant_max": 255
                },
                "weight_observer": {
                    "name": "PerChannelMinMaxObserver",
                    "ch_axis": 0,
                    "dtype": "torch.qint8",
                    "qscheme": "torch.per_channel_symmetric",
                    "reduce_range": false,
                    "quant_min": -128,
                    "quant_max": 127
                }
            },
```
## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
