### PR TITLE
op wise setting remove

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -208,7 +208,7 @@ Intel® Neural Compressor validated examples with multiple compression technique
     <td><a href="./tensorflow/image_recognition/keras_models/resnet50/quantization/qat">keras</a> </td>
   </tr>
   <tr>
-    <td>*EfficientNet V2 B0</td>
+    <td>EfficientNet V2 B0</td>
     <td>Image Recognition</td>
     <td>Post-Training Static Quantization</td>
     <td><a href="./tensorflow/image_recognition/SavedModel/efficientnet_v2_b0/quantization/ptq">SavedModel</a></td>

--- a/examples/onnxrt/nlp/onnx_model_zoo/bert-squad/quantization/ptq/main.py
+++ b/examples/onnxrt/nlp/onnx_model_zoo/bert-squad/quantization/ptq/main.py
@@ -120,17 +120,8 @@ def main():
 
     if args.tune:
         from neural_compressor import quantization, PostTrainingQuantConfig
-        op_name_list={'bert/encoder/layer_2/output/dense/MatMul': {
-                        'activation':  {'dtype': ['fp32']},
-                        'weight': {'dtype': ['fp32']}
-                     },
-                      'bert/encoder/layer_10/output/dense/MatMul': {
-                        'activation':  {'dtype': ['fp32']},
-                        'weight': {'dtype': ['fp32']}
-                     }}
 
-        config = PostTrainingQuantConfig(approach='dynamic',
-                                         op_name_list=op_name_list)
+        config = PostTrainingQuantConfig(approach='dynamic')
         q_model = quantization.fit(model, 
                                    config,
                                    eval_func=eval_func)

--- a/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq/gpt2.py
+++ b/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq/gpt2.py
@@ -263,11 +263,7 @@ def main():
         accuracy_criterion = AccuracyCriterion()
         accuracy_criterion.higher_is_better = False
         accuracy_criterion.relative = 0.11
-        config = PostTrainingQuantConfig(approach='dynamic', 
-                                         op_name_list={'MatMul_2924': {
-                                                            'activation':  {'dtype': ['fp32']},
-                                                            'weight': {'dtype': ['fp32']}
-                                                        }},
+        config = PostTrainingQuantConfig(approach='dynamic',
                                          accuracy_criterion=accuracy_criterion)
         q_model = quantization.fit(model, 
                                    config,

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/smooth_quant/eval_lambada.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/smooth_quant/eval_lambada.py
@@ -140,13 +140,9 @@ if args.int8:
     from neural_compressor import quantization
 
     conf = PostTrainingQuantConfig(backend='ipex', excluded_precisions=["bf16"],
-                                 recipes={"smooth_quant": True},
-                                   )
-    ##conf.performance_only = True
+                                   recipes={"smooth_quant": True})
+
     if args.sq:
-        # from neural_compressor.adaptor.torch_utils.smooth_quant import TorchSmoothQuant
-        # sq = TorchSmoothQuant(model, calib_dataloader)
-        # model = sq.transform(alpha=args.alpha)
         q_model = quantization.fit(model,
                                    conf,
                                    calib_dataloader=calib_dataloader,

--- a/examples/tensorflow/image_recognition/SavedModel/mobilenet_v2/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/SavedModel/mobilenet_v2/quantization/ptq/main.py
@@ -106,17 +106,7 @@ class eval_object_detection_optimized_graph(object):
                 'filter': None
             }
             calib_dataloader = create_dataloader('tensorflow', calib_dataloader_args)
-            op_name_list={
-                'MobilenetV2/expanded_conv/depthwise/depthwise':
-                            {
-                            'activation':  {'dtype': ['fp32']}
-                            },
-                'MobilenetV2/Conv_1/Conv2D':
-                            {
-                            'activation':  {'dtype': ['fp32']}
-                            }
-                        }
-            conf = PostTrainingQuantConfig(calibration_sampling_size=[20, 50], op_name_list=op_name_list)
+            conf = PostTrainingQuantConfig(calibration_sampling_size=[20, 50])
             q_model = quantization.fit(model=args.input_graph, conf=conf,
                                        calib_dataloader=calib_dataloader, eval_func=evaluate)
             q_model.save(args.output_graph)

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet121/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet121/quantization/ptq/main.py
@@ -116,16 +116,7 @@ class eval_classifier_optimized_graph:
                 'filter': None
             }
             eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-            op_name_list = {
-                        'densenet121/MaxPool2D/MaxPool': {
-                          'activation':  {'dtype': ['fp32']}
-                        },
-                        'densenet121/transition_block[1-3]/AvgPool2D/AvgPool': {
-                          'activation':  {'dtype': ['fp32']},
-                        }
-                    }
-            conf = PostTrainingQuantConfig(calibration_sampling_size=[5, 10, 50, 100],
-                                           op_name_list=op_name_list)
+            conf = PostTrainingQuantConfig(calibration_sampling_size=[5, 10, 50, 100])
             from neural_compressor.metric import TensorflowTopK
             top1 = TensorflowTopK(k=1)
             from neural_compressor.data import LabelShift

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet161/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet161/quantization/ptq/main.py
@@ -116,16 +116,7 @@ class eval_classifier_optimized_graph:
                 'filter': None
             }
             eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-            op_name_list = {
-                        'densenet121/MaxPool2D/MaxPool': {
-                          'activation':  {'dtype': ['fp32']}
-                        },
-                        'densenet121/transition_block[1-3]/AvgPool2D/AvgPool': {
-                          'activation':  {'dtype': ['fp32']},
-                        }
-                    }
-            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100],
-                                           op_name_list=op_name_list)
+            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100])
             from neural_compressor.metric import TensorflowTopK
             top1 = TensorflowTopK(k=1)
             from neural_compressor.data import LabelShift

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet169/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet169/quantization/ptq/main.py
@@ -116,16 +116,7 @@ class eval_classifier_optimized_graph:
                 'filter': None
             }
             eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-            op_name_list = {
-                        'densenet121/MaxPool2D/MaxPool': {
-                          'activation':  {'dtype': ['fp32']}
-                        },
-                        'densenet121/transition_block[1-3]/AvgPool2D/AvgPool': {
-                          'activation':  {'dtype': ['fp32']},
-                        }
-                    }
-            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100],
-                                           op_name_list=op_name_list)
+            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100])
             from neural_compressor.metric import TensorflowTopK
             top1 = TensorflowTopK(k=1)
             from neural_compressor.data import LabelShift

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/main.py
@@ -111,13 +111,7 @@ class eval_classifier_optimized_graph:
                 'filter': None
             }
             eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-            op_name_list = {
-                      'v0/cg/conv0/conv2d/Conv2D': {
-                        'activation':  {'dtype': ['fp32']},
-                      }
-                    }
-            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100],
-                                           op_name_list=op_name_list)
+            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100])
             q_model = quantization.fit(args.input_graph, conf=conf, calib_dataloader=calib_dataloader,
                         eval_dataloader=eval_dataloader)
             q_model.save(args.output_graph)

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/main.py
@@ -104,16 +104,8 @@ class eval_classifier_optimized_graph:
                     'filter': None
                 }
                 eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-                op_name_list = {
-                    'resnet_model/dense/MatMul':
-                                {
-                                'activation':  {'dtype': ['fp32']},
-                                'weight': {'dtype': ['fp32']},
-                                }
-                            }
                 conf = PostTrainingQuantConfig(backend='itex', calibration_sampling_size=[50, 100],
-                                            outputs=['softmax_tensor'],
-                                            op_name_list=op_name_list)
+                                            outputs=['softmax_tensor'])
                 from neural_compressor.metric import TensorflowTopK
                 top1 = TensorflowTopK(k=1)
                 q_model = quantization.fit(self.args.input_graph, conf=conf, calib_dataloader=calib_dataloader,

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/main.py
@@ -113,16 +113,8 @@ class eval_classifier_optimized_graph:
                     'filter': None
                 }
                 eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-                op_name_list = {
-                    'resnet_model/dense/MatMul':
-                                {
-                                'activation':  {'dtype': ['fp32']},
-                                'weight': {'dtype': ['fp32']},
-                                }
-                            }
                 conf = PostTrainingQuantConfig(backend='itex', calibration_sampling_size=[50, 100],
-                                            outputs=['softmax_tensor'],
-                                            op_name_list=op_name_list)
+                                            outputs=['softmax_tensor'])
                 from neural_compressor.metric import TensorflowTopK
                 top1 = TensorflowTopK(k=1)
                 q_model = quantization.fit(self.args.input_graph, conf=conf, calib_dataloader=calib_dataloader,

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/main.py
@@ -136,16 +136,8 @@ class eval_classifier_optimized_graph:
                     'filter': None
                 }
                 eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-                op_name_list = {
-                    'resnet_model/dense/MatMul':
-                                {
-                                'activation':  {'dtype': ['fp32']},
-                                'weight': {'dtype': ['fp32']},
-                                }
-                            }
                 conf = PostTrainingQuantConfig(backend='itex', calibration_sampling_size=[50, 100],
-                                            outputs=['softmax_tensor'],
-                                            op_name_list=op_name_list)
+                                            outputs=['softmax_tensor'])
                 def eval(model):
                     return eval_func_tf(model, eval_dataloader, top1, postprocess)
                 q_model = quantization.fit(args.input_graph, conf=conf, calib_dataloader=calib_dataloader,

--- a/examples/tensorflow/object_detection/yolo_v3/quantization/ptq/infer_detections.py
+++ b/examples/tensorflow/object_detection/yolo_v3/quantization/ptq/infer_detections.py
@@ -160,16 +160,11 @@ def main(_):
     if FLAGS.tune:
         from neural_compressor import quantization
         from neural_compressor.config import PostTrainingQuantConfig
-        op_name_list={
-            'detector/yolo-v3/Conv_6/Conv2D': {'activation':  {'dtype': ['fp32']}},
-            'detector/yolo-v3/Conv_14/Conv2D': {'activation':  {'dtype': ['fp32']}},
-            'detector/yolo-v3/Conv_22/Conv2D': {'activation':  {'dtype': ['fp32']}}
-            }
+
         config = PostTrainingQuantConfig(
             inputs=["inputs"],
             outputs=["output_boxes"],
-            calibration_sampling_size=[2],
-            op_name_list=op_name_list)
+            calibration_sampling_size=[2])
         q_model = quantization.fit(model=FLAGS.input_graph, conf=config, 
                                     calib_dataloader=calib_dataloader, eval_func=evaluate)
         q_model.save(FLAGS.output_graph)

--- a/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/inference.py
+++ b/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/inference.py
@@ -190,12 +190,7 @@ class eval_classifier_optimized_graph:
         config = PostTrainingQuantConfig(
             inputs=["new_numeric_placeholder", "new_categorical_placeholder"],
             outputs=["import/head/predictions/probabilities"],
-            calibration_sampling_size=[2000],
-            op_name_list={
-                'import/dnn/hiddenlayer_0/MatMul': {
-                'activation':  {'dtype': ['uint8'], 'algorithm': ['minmax'], 'scheme':['asym']},
-                }
-            })
+            calibration_sampling_size=[2000])
 
         if self.args.calib_data:
             q_model = fit(


### PR DESCRIPTION
## Type of Change

others

## Description

Remove the unnecessary op wise setting(verified with both basic and new auto strategy), and tune with the new strategy. 
If it doesn't work on SPR machine, we will add back. 

## Expected Behavior & Potential Risk

Models may failed tuning on SPR machine. 

## How has this PR been tested?

CI

## Dependency Change?

No
