### PR TITLE
Modify the Check on Length of Dataloader for TF Backend

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -180,7 +180,7 @@ class GraphConverter:
             sess.run(init_table_op)
 
         logger.info("Start sampling on calibration dataset.")
-        if len(self.data_loader) == 0:
+        if hasattr(self.data_loader, "__len__") and len(self.data_loader) == 0:
             feed_dict = {}
             _ = sess.run(output_tensor, feed_dict) if iter_op==[] \
                 else iterator_sess_run(sess, iter_op, \


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or validation or others  
API changed or not: No

## Description

detail description 
JIRA ticket: [ILITV-2759](https://jira.devtools.intel.com/browse/ILITV-2759)

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR : TF backend will not request a "__len__" method from dataloaders 

## How has this PR been tested?

how to reproduce the test (including hardware information): Preci

## Dependency Change?

any library dependency introduced or removed: No
