### PR TITLE
Adapt to PyTorch 2.0 version

### DIFF
--- a/neural_compressor/training.py
+++ b/neural_compressor/training.py
@@ -345,12 +345,12 @@ class CallBacks:
         self.callbacks_list = callbacks_list
 
     def on_train_begin(self, dataloader=None):
-        """Be called before the beginning of epochs."""
+        """Be called before the beginning of training."""
         for callbacks in self.callbacks_list:
             callbacks.on_train_begin(dataloader)
 
     def on_train_end(self):
-        """Be called after the end of epochs."""
+        """Be called after the end of training."""
         for callbacks in self.callbacks_list:
             callbacks.on_train_end()
         logger.info("Training finished!")

--- a/neural_compressor/training.py
+++ b/neural_compressor/training.py
@@ -353,6 +353,7 @@ class CallBacks:
         """Be called after the end of epochs."""
         for callbacks in self.callbacks_list:
             callbacks.on_train_end()
+        logger.info("Training finished!")
 
     def on_epoch_begin(self, epoch):
         """Be called on the beginning of epochs."""

--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -23,12 +23,12 @@ from ..adaptor.pytorch import PyTorch_FXAdaptor
 from ..adaptor.torch_utils import util
 from . import logger
 from packaging.version import Version
-from torch.quantization import add_observer_, convert
+from torch.quantization import convert
 import torch
 import torch.quantization as tq
 import yaml
 import os
-import copy
+
 
 yaml.SafeLoader.add_constructor('tag:yaml.org,2002:python/tuple',
                                  lambda loader, node: tuple(loader.construct_sequence(node)))
@@ -108,7 +108,7 @@ def _load_int8_orchestration(model, tune_cfg, stat_dict, example_inputs, **kwarg
         from torch.quantization.quantize_fx import prepare_qat_fx, convert_fx
         quantized_ops = {op[0]: q_cfgs for op in tune_cfg['quantizable_ops']}
         version = get_torch_version()
-        if version < Version("1.11.0-rc1"):
+        if version.release < Version("1.11.0").release:
             quantized_ops["default_qconfig"] = None
         else:
             from torch.ao.quantization import default_embedding_qat_qconfig
@@ -238,19 +238,19 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
             op_cfg['activation']['quant_mode'] = approach_quant_mode
 
     if tune_cfg['approach'] != "post_training_dynamic_quant":
-        if version < Version("1.7.0-rc1"):   # pragma: no cover
+        if version.release < Version("1.7.0").release:   # pragma: no cover
             q_mapping = tq.default_mappings.DEFAULT_MODULE_MAPPING
-        elif version < Version("1.8.0-rc1"):   # pragma: no cover
+        elif version.release < Version("1.8.0").release:   # pragma: no cover
             q_mapping = \
                 tq.quantization_mappings.get_static_quant_module_mappings()
         else:
             q_mapping = \
                 tq.quantization_mappings.get_default_static_quant_module_mappings()
     else:
-        if version < Version("1.7.0-rc1"):   # pragma: no cover
+        if version.release < Version("1.7.0").release:   # pragma: no cover
             q_mapping = \
                 tq.default_mappings.DEFAULT_DYNAMIC_MODULE_MAPPING
-        elif version < Version("1.8.0-rc1"):   # pragma: no cover
+        elif version.release < Version("1.8.0").release:   # pragma: no cover
             q_mapping = \
                 tq.quantization_mappings.get_dynamic_quant_module_mappings()
         else:
@@ -259,7 +259,7 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
 
     if tune_cfg['framework'] == "pytorch_fx":             # pragma: no cover
         # For torch.fx approach
-        assert version >= Version("1.8.0-rc1"), \
+        assert version.release >= Version("1.8.0").release, \
                       "Please use PyTroch 1.8 or higher version with pytorch_fx backend"
         from torch.quantization.quantize_fx import prepare_fx, convert_fx, prepare_qat_fx
         if kwargs is None:
@@ -275,7 +275,7 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
             tmp_model = model
             if tune_cfg['approach'] == "quant_aware_training":
                 model.train()
-                if version > Version("1.12.1"):  # pragma: no cover
+                if version.release > Version("1.12.1").release:  # pragma: no cover
                     # pylint: disable=E1123
                     model = prepare_qat_fx(model,
                                            fx_op_cfgs,
@@ -286,7 +286,7 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
                                            fx_op_cfgs,
                                            prepare_custom_config_dict=prepare_custom_config_dict)
             else:
-                if version > Version("1.12.1"):  # pragma: no cover
+                if version.release > Version("1.12.1").release:  # pragma: no cover
                     # pylint: disable=E1123
                     model = prepare_fx(model,
                                        fx_op_cfgs,
@@ -296,7 +296,7 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
                     model = prepare_fx(model,
                                        fx_op_cfgs,
                                        prepare_custom_config_dict=prepare_custom_config_dict)
-            if version > Version("1.12.1"):  # pragma: no cover
+            if version.release > Version("1.12.1").release:  # pragma: no cover
                 # pylint: disable=E1123
                 model = convert_fx(model,
                   convert_custom_config=convert_custom_config_dict)
@@ -335,6 +335,10 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
                         "passed correct configuration through `qconfig_dict` or "
                         "by assigning the `.qconfig` attribute directly on submodules")
         if tune_cfg['approach'] != "post_training_dynamic_quant":
+            if version.release < Version("2.0.0").release:
+                from torch.quantization.quantize import add_observer_
+            else:
+                from torch.quantization.quantize import _add_observer_ as add_observer_
             add_observer_(model)
         model = convert(model, mapping=q_mapping, inplace=True)
 

--- a/neural_compressor/utils/utility.py
+++ b/neural_compressor/utils/utility.py
@@ -80,7 +80,7 @@ class LazyImport(object):
 
     def __init__(self, module_name):
         """Init LazyImport object.
-        
+
         Args:
            module_name (string): The name of module imported later
         """

--- a/test/adaptor/pytorch_adaptor/test_adaptor_pytorch_1.x.py
+++ b/test/adaptor/pytorch_adaptor/test_adaptor_pytorch_1.x.py
@@ -796,7 +796,11 @@ class TestPytorchAdaptor(unittest.TestCase):
             model.model.dequant.qconfig = torch.quantization.default_qconfig
         nc_torch._fallback_quantizable_ops_recursively(
             model.model, '', fallback_ops, op_qcfgs={})
-        torch.quantization.add_observer_(model.model)
+        if PT_VERSION >= Version("2.0.0").release:
+            from torch.quantization.quantize import _add_observer_ as add_observer_
+        else:
+            from torch.quantization.quantize import add_observer_
+        add_observer_(model.model)
         model.model(x)
         torch.quantization.convert(model.model, self.adaptor.q_mapping, inplace=True)
         qy = model.model(x)

--- a/test/adaptor/pytorch_adaptor/test_adaptor_pytorch_2.x.py
+++ b/test/adaptor/pytorch_adaptor/test_adaptor_pytorch_2.x.py
@@ -5,10 +5,8 @@ import shutil
 import torch
 import torch.nn as nn
 import unittest
-import os
 from neural_compressor import PostTrainingQuantConfig, QuantizationAwareTrainingConfig, set_workspace
 from neural_compressor.data import Datasets, DATALOADERS, DataLoader
-from neural_compressor.experimental.data.datasets.dataset import Datasets
 from neural_compressor import quantization
 from neural_compressor.training import prepare_compression, fit
 from neural_compressor.utils.pytorch import load


### PR DESCRIPTION
## Type of Change

Adapt to PyTorch 2.0 version  
No API changed

## Description

Since PyTorch 2.0 changed some quantization API name, so we need to change code to adapt to it.
JIRA ticket: [#2762](https://jira.devtools.intel.com/browse/ILITV-2762)

## Expected Behavior & Potential Risk

quantization successful with PyTorch 2.0. 

## How has this PR been tested?

Local tested
