### PR TITLE
add weight for fx_model and fix export bug

### DIFF
--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -241,6 +241,11 @@ def append_attr(fx_model, model, fx_white_list=[]):
                             r'_activation_post_process_']
     add_special_patterns = [r"_forward_hooks", r"_forward_pre_hooks", r"_backward_hooks"]
     attr_names = []
+    if hasattr(fx_model, 'module') and hasattr(fx_model.module, 'weight'):
+        if not isinstance(fx_model.module.weight, torch.Tensor):
+            fx_model.weight=fx_model.module.weight()
+        else:
+            fx_model.weight=fx_model.module.weight
     for i in org_attr:
         if type(model) in fx_white_list and type(model) != torch.nn.Sequential \
           and any([re.search(p, i) for p in add_special_patterns]):

--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -243,9 +243,9 @@ def append_attr(fx_model, model, fx_white_list=[]):
     attr_names = []
     if hasattr(fx_model, 'module') and hasattr(fx_model.module, 'weight'):
         if not isinstance(fx_model.module.weight, torch.Tensor):
-            fx_model.weight=fx_model.module.weight()
+            fx_model.weight = fx_model.module.weight()
         else:
-            fx_model.weight=fx_model.module.weight
+            fx_model.weight = fx_model.module.weight
     for i in org_attr:
         if type(model) in fx_white_list and type(model) != torch.nn.Sequential \
           and any([re.search(p, i) for p in add_special_patterns]):

--- a/neural_compressor/experimental/export/torch2onnx.py
+++ b/neural_compressor/experimental/export/torch2onnx.py
@@ -23,6 +23,7 @@ from collections import UserDict
 from neural_compressor.adaptor.torch_utils.util import input2tuple
 from neural_compressor.utils import logger
 from neural_compressor.utils.utility import LazyImport
+from neural_compressor.utils.pytorch import is_int8_model
 
 torch = LazyImport('torch')
 onnx = LazyImport('onnx')
@@ -681,6 +682,8 @@ def torch_to_fp32_onnx(
         do_constant_folding (bool, optional): do constant folding or not. Defaults to True.
         verbose (bool, optional): dump verbose or not. Defaults to True.
     """
+    assert is_int8_model(fp32_model) == False, "The fp32 model is replaced during quantization. " + \
+        "please customize a eval_func when quantizing, if not, such as `lambda x: 1`."
     if input_names is None and \
       (isinstance(example_inputs, dict) or isinstance(example_inputs, UserDict)):
         input_names = list(example_inputs.keys())

--- a/neural_compressor/experimental/export/torch2onnx.py
+++ b/neural_compressor/experimental/export/torch2onnx.py
@@ -23,7 +23,6 @@ from collections import UserDict
 from neural_compressor.adaptor.torch_utils.util import input2tuple
 from neural_compressor.utils import logger
 from neural_compressor.utils.utility import LazyImport
-from neural_compressor.utils.pytorch import is_int8_model
 
 torch = LazyImport('torch')
 onnx = LazyImport('onnx')
@@ -682,6 +681,7 @@ def torch_to_fp32_onnx(
         do_constant_folding (bool, optional): do constant folding or not. Defaults to True.
         verbose (bool, optional): dump verbose or not. Defaults to True.
     """
+    from neural_compressor.utils.pytorch import is_int8_model
     assert is_int8_model(fp32_model) == False, "The fp32 model is replaced during quantization. " + \
         "please customize a eval_func when quantizing, if not, such as `lambda x: 1`."
     if input_names is None and \

--- a/neural_compressor/experimental/export/torch2onnx.py
+++ b/neural_compressor/experimental/export/torch2onnx.py
@@ -688,6 +688,8 @@ def torch_to_fp32_onnx(
       (isinstance(example_inputs, dict) or isinstance(example_inputs, UserDict)):
         input_names = list(example_inputs.keys())
         example_inputs = list(example_inputs.values())
+    elif isinstance(example_inputs, dict) or isinstance(example_inputs, UserDict):
+        example_inputs = list(example_inputs.values())
     # match input_names with inspected input_order, especailly for bert in hugginface.
     if input_names and len(input_names) > 1:
         import inspect

--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -466,6 +466,8 @@ def fit(model,
         # Saved quantized model in ./saved folder
         q_model.save("./saved")
     """
+    if eval_func is None and eval_dataloader is None:
+        conf.performance_only = True
     quantizer = PostTrainingQuant(conf)
     quantizer.model = model
     if eval_func is not None:

--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -466,8 +466,6 @@ def fit(model,
         # Saved quantized model in ./saved folder
         q_model.save("./saved")
     """
-    if eval_func is None and eval_dataloader is None:
-        conf.performance_only = True
     quantizer = PostTrainingQuant(conf)
     quantizer.model = model
     if eval_func is not None:

--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -349,6 +349,7 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
     if checkpoint_dir is None and history_cfg is not None:
         _set_activation_scale_zeropoint(model, history_cfg)
     else:
-        model.load_state_dict(stat_dict)
+        # set strict=False to avoid loading linked tensors.
+        model.load_state_dict(stat_dict, strict=False)
     util.get_embedding_contiguous(model)
     return model

--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -43,10 +43,22 @@ def is_int8_model(model):
     Returns:
         result(bool): Return True if the input model is a int8 model.
     """
-    stat_dict = dict(model.state_dict())
-    for k, v in stat_dict.items():
-        if hasattr(v, 'dtype') and 'int8' in str(v.dtype):
+    def _is_int8_value(value):
+        """Check whether the input tensor is a int8 tensor."""
+        if hasattr(value, 'dtype') and 'int8' in str(value.dtype):
             return True
+        else:
+            return False
+
+    stat_dict = dict(model.state_dict())
+    for name, value in stat_dict.items():
+        if _is_int8_value(value):
+            return True
+        # value maybe a tuple, such as 'linear._packed_params._packed_params'
+        if isinstance(value, tuple):
+            for v in value:
+                if _is_int8_value(v):
+                    return True
     return False
 
 def _set_sub_module_scale_zeropoint(model, tune_cfg, prefix=''):

--- a/test/export/test_torch2onnx.py
+++ b/test/export/test_torch2onnx.py
@@ -293,7 +293,7 @@ class TestPytorch2ONNX(unittest.TestCase):
         inc_model = Model(model)
         fp32_onnx_config = Torch2ONNXConfig(
             dtype="fp32",
-            example_inputs=tuple(self.nlp_input.values()),
+            example_inputs=self.nlp_input,
             input_names=list(self.nlp_input.keys()),
             output_names=['labels'],
             dynamic_axes=dynamic_axes,


### PR DESCRIPTION
## Type of Change

redirect weight for fine-grained fx modules and fix export bug.

## Description

[AttributeError: 'GraphModule' object has no attribute 'weight' - flan-t5-small dynamic quantization](https://github.com/huggingface/optimum-intel/issues/212)
Fix export bug raised by [PR642](https://github.com/intel/neural-compressor/pull/642)
