### PR TITLE
fix error of building doc and user guide link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ q_model = fit(
     <tr>
       <td colspan="4" align="center"><a href="./docs/source/design.md#architecture">Architecture</a></td>
       <td colspan="3" align="center"><a href="./docs/source/design.md#workflow">Workflow</a></td>
-      <td colspan="1" align="center"><a href="https://intel.github.io/neural-compressor/latest/docs/source/api-doc/apis.html">APIs</a></td>
+      <td colspan="1" align="center"><a href="api-doc/apis.html">APIs</a></td>
       <td colspan="1" align="center"><a href="./docs/source/bench.md">GUI</a></td>
     </tr>
     <tr>
-      <td colspan="2" align="center"><a href="./examples#notebook-examples">Notebook</a></td>
-      <td colspan="1" align="center"><a href="./examples">Examples</a></td>
+      <td colspan="2" align="center"><a href="examples/README.md#notebook-examples">Notebook</a></td>
+      <td colspan="1" align="center"><a href="examples/README.md">Examples</a></td>
       <td colspan="1" align="center"><a href="./docs/source/validated_model_list.md">Results</a></td>
       <td colspan="5" align="center"><a href="https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-ai-linux/top.html">Intel oneAPI AI Analytics Toolkit</a></td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ q_model = fit(
     <tr>
       <td colspan="4" align="center"><a href="./docs/source/design.md#architecture">Architecture</a></td>
       <td colspan="3" align="center"><a href="./docs/source/design.md#workflow">Workflow</a></td>
-      <td colspan="1" align="center"><a href="api-doc/apis.html">APIs</a></td>
+      <td colspan="1" align="center"><a href="https://intel.github.io/neural-compressor/latest/docs/source/api-doc/apis.html">APIs</a></td>
       <td colspan="1" align="center"><a href="./docs/source/bench.md">GUI</a></td>
     </tr>
     <tr>

--- a/docs/build_docs/build.sh
+++ b/docs/build_docs/build.sh
@@ -89,6 +89,7 @@ sed -i 's/.\/docs\/source\/_static/./g' ./source/docs/source/Welcome.md ./source
 sed -i 's/.md/.html/g; s/.\/docs\/source\//.\//g' ./source/docs/source/Welcome.md ./source/docs/source/user_guide.md
 sed -i 's/\/examples\/README.html/https:\/\/github.com\/intel\/neural-compressor\/blob\/master\/examples\/README.md/g' ./source/docs/source/user_guide.md
 sed -i 's/href=\"\/neural_coder/href=\".\/neural_coder/g' ./source/docs/source/user_guide.md
+sed -i 's/https\:\/\/intel.github.io\/neural-compressor\/lates.\/api-doc\/apis.html/https\:\/\/intel.github.io\/neural-compressor\/latest\/docs\/source\/api-doc\/apis.html/g' ./source/docs/source/Welcome.md ./source/docs/source/user_guide.md
 
 sed -i 's/examples\/README.html/https:\/\/github.com\/intel\/neural-compressor\/blob\/master\/examples\/README.md/g' ./source/docs/source/Welcome.md
 

--- a/docs/build_docs/build.sh
+++ b/docs/build_docs/build.sh
@@ -88,6 +88,8 @@ cp -f "../SECURITY.md" "./source/docs/source/SECURITY.md"
 sed -i 's/.\/docs\/source\/_static/./g' ./source/docs/source/Welcome.md ./source/docs/source/user_guide.md
 sed -i 's/.md/.html/g; s/.\/docs\/source\//.\//g' ./source/docs/source/Welcome.md ./source/docs/source/user_guide.md
 sed -i 's/\/examples\/README.html/https:\/\/github.com\/intel\/neural-compressor\/blob\/master\/examples\/README.md/g' ./source/docs/source/user_guide.md
+sed -i 's/href=\"\/neural_coder/href=\".\/neural_coder/g' ./source/docs/source/user_guide.md
+
 sed -i 's/examples\/README.html/https:\/\/github.com\/intel\/neural-compressor\/blob\/master\/examples\/README.md/g' ./source/docs/source/Welcome.md
 
 sed -i 's/\"\/neural_coder\/extensions\/screenshots\/extmanager.png/\".\/neural_coder\/extensions\/screenshots\/extmanager.png/g' ./source/docs/source/get_started.md

--- a/docs/source/api-doc/adaptor/torch_utils.rst
+++ b/docs/source/api-doc/adaptor/torch_utils.rst
@@ -8,6 +8,5 @@ The torch utils API information is available:
 
    torch_utils/bf16_convert.rst
    torch_utils/hawq_metric.rst
-   torch_utils/onnx.rst
    torch_utils/symbolic_trace.rst
    torch_utils/util.rst

--- a/docs/source/api-doc/adaptor/torch_utils/onnx.rst
+++ b/docs/source/api-doc/adaptor/torch_utils/onnx.rst
@@ -1,6 +1,0 @@
-Onnx
-==============
-
-.. autoapisummary::
-
-   neural_compressor.adaptor.torch_utils.onnx

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -18,15 +18,15 @@ Intel® Neural Compressor aims to provide popular model compression techniques s
   </thead>
   <tbody>
     <tr>
-      <td colspan="4" align="center"><a href="/docs/source/design.md#architecture">Architecture</a></td>
-      <td colspan="3" align="center"><a href="/docs/source/design.md#workflow">Workflow</a></td>
-      <td colspan="1" align="center"><a href="https://intel.github.io/neural-compressor/latest/docs/source/api-doc/apis.html">APIs</a></td>
-      <td colspan="1" align="center"><a href="/docs/source/bench.md">GUI</a></td>
+      <td colspan="4" align="center"><a href="design.md#architecture">Architecture</a></td>
+      <td colspan="3" align="center"><a href="design.md#workflow">Workflow</a></td>
+      <td colspan="1" align="center"><a href="api-doc/apis.html">APIs</a></td>
+      <td colspan="1" align="center"><a href="bench.md">GUI</a></td>
     </tr>
     <tr>
-      <td colspan="2" align="center"><a href="/examples#notebook-examples">Notebook</a></td>
-      <td colspan="1" align="center"><a href="/examples">Examples</a></td>
-      <td colspan="1" align="center"><a href="/docs/source/validated_model_list.md">Results</a></td>
+      <td colspan="2" align="center"><a href="/examples/README.md#notebook-examples">Notebook</a></td>
+      <td colspan="1" align="center"><a href="/examples/README.md">Examples</a></td>
+      <td colspan="1" align="center"><a href="validated_model_list.md">Results</a></td>
       <td colspan="5" align="center"><a href="https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-ai-linux/top.html">Intel oneAPI AI Analytics Toolkit</a></td>
     </tr>
   </tbody>
@@ -37,16 +37,16 @@ Intel® Neural Compressor aims to provide popular model compression techniques s
   </thead>
   <tbody>
     <tr>
-        <td colspan="2" align="center"><a href="/docs/source/quantization.md">Quantization</a></td>
-        <td colspan="3" align="center"><a href="/docs/source/mixed_precision.md">Advanced Mixed Precision</a></td>
-        <td colspan="2" align="center"><a href="/docs/source/pruning.md">Pruning (Sparsity)</a></td> 
-        <td colspan="2" align="center"><a href="/docs/source/distillation.md">Distillation</a></td>
+        <td colspan="2" align="center"><a href="quantization.md">Quantization</a></td>
+        <td colspan="3" align="center"><a href="mixed_precision.md">Advanced Mixed Precision</a></td>
+        <td colspan="2" align="center"><a href="pruning.md">Pruning (Sparsity)</a></td>
+        <td colspan="2" align="center"><a href="distillation.md">Distillation</a></td>
     </tr>
     <tr>
-        <td colspan="2" align="center"><a href="/docs/source/orchestration.md">Orchestration</a></td>        
-        <td colspan="2" align="center"><a href="/docs/source/benchmark.md">Benchmarking</a></td>
-        <td colspan="3" align="center"><a href="/docs/source/distributed.md">Distributed Compression</a></td>
-        <td colspan="3" align="center"><a href="/docs/source/export.md">Model Export</a></td>
+        <td colspan="2" align="center"><a href="orchestration.md">Orchestration</a></td>
+        <td colspan="2" align="center"><a href="benchmark.md">Benchmarking</a></td>
+        <td colspan="3" align="center"><a href="distributed.md">Distributed Compression</a></td>
+        <td colspan="3" align="center"><a href="export.md">Model Export</a></td>
     </tr>
   </tbody>
   <thead>
@@ -56,7 +56,7 @@ Intel® Neural Compressor aims to provide popular model compression techniques s
   </thead>
   <tbody>
     <tr>
-        <td colspan="9" align="center"><a href="/docs/source/migration.md">Code Migration from Intel® Neural Compressor 1.X to Intel® Neural Compressor 2.X</a></td>
+        <td colspan="9" align="center"><a href="migration.md">Code Migration from Intel® Neural Compressor 1.X to Intel® Neural Compressor 2.X</a></td>
     </tr>    
   </tbody>
   <thead>
@@ -66,10 +66,10 @@ Intel® Neural Compressor aims to provide popular model compression techniques s
   </thead>
   <tbody>
     <tr>
-        <td colspan="1" align="center"><a href="/neural_coder/docs/PythonLauncher.md">Launcher</a></td>
-        <td colspan="2" align="center"><a href="/neural_coder/extensions/neural_compressor_ext_lab/README.md">JupyterLab Extension</a></td>
-        <td colspan="3" align="center"><a href="/neural_coder/extensions/neural_compressor_ext_vscode/README.md">Visual Studio Code Extension</a></td>
-        <td colspan="3" align="center"><a href="/neural_coder/docs/SupportMatrix.md">Supported Matrix</a></td>
+        <td colspan="1" align="center"><a href="neural_coder/docs/PythonLauncher.md">Launcher</a></td>
+        <td colspan="2" align="center"><a href="neural_coder/extensions/neural_compressor_ext_lab/README.md">JupyterLab Extension</a></td>
+        <td colspan="3" align="center"><a href="neural_coder/extensions/neural_compressor_ext_vscode/README.md">Visual Studio Code Extension</a></td>
+        <td colspan="3" align="center"><a href="neural_coder/docs/SupportMatrix.md">Supported Matrix</a></td>
     </tr>    
   </tbody>
   <thead>
@@ -79,13 +79,13 @@ Intel® Neural Compressor aims to provide popular model compression techniques s
   </thead>
   <tbody>
       <tr>
-          <td colspan="3" align="center"><a href="/docs/source/adaptor.md">Adaptor</a></td>
-          <td colspan="3" align="center"><a href="/docs/source/tuning_strategies.md">Strategy</a></td>
-          <td colspan="3" align="center"><a href="/docs/source/distillation_quantization.md">Distillation for Quantization</a></td>
+          <td colspan="3" align="center"><a href="adaptor.md">Adaptor</a></td>
+          <td colspan="3" align="center"><a href="tuning_strategies.md">Strategy</a></td>
+          <td colspan="3" align="center"><a href="distillation_quantization.md">Distillation for Quantization</a></td>
       </tr>
       <tr>
-        <td colspan="3" align="center"><a href="/docs/source/metric.md">Metric</a></td>        
-        <td colspan="3" align="center"><a href="/docs/source/objective.md">Objective</a></td>
+        <td colspan="3" align="center"><a href="metric.md">Metric</a></td>
+        <td colspan="3" align="center"><a href="objective.md">Objective</a></td>
         <td colspan="3" align="center">SmoothQuant (Coming Soon)</td>
       </tr>
   </tbody>

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -20,7 +20,7 @@ Intel® Neural Compressor aims to provide popular model compression techniques s
     <tr>
       <td colspan="4" align="center"><a href="design.md#architecture">Architecture</a></td>
       <td colspan="3" align="center"><a href="design.md#workflow">Workflow</a></td>
-      <td colspan="1" align="center"><a href="api-doc/apis.html">APIs</a></td>
+      <td colspan="1" align="center"><a href="https://intel.github.io/neural-compressor/latest/docs/source/api-doc/apis.html">APIs</a></td>
       <td colspan="1" align="center"><a href="bench.md">GUI</a></td>
     </tr>
     <tr>

--- a/docs/source/user_guide.md
+++ b/docs/source/user_guide.md
@@ -66,10 +66,10 @@ Intel® Neural Compressor aims to provide popular model compression techniques s
   </thead>
   <tbody>
     <tr>
-        <td colspan="1" align="center"><a href="neural_coder/docs/PythonLauncher.md">Launcher</a></td>
-        <td colspan="2" align="center"><a href="neural_coder/extensions/neural_compressor_ext_lab/README.md">JupyterLab Extension</a></td>
-        <td colspan="3" align="center"><a href="neural_coder/extensions/neural_compressor_ext_vscode/README.md">Visual Studio Code Extension</a></td>
-        <td colspan="3" align="center"><a href="neural_coder/docs/SupportMatrix.md">Supported Matrix</a></td>
+        <td colspan="1" align="center"><a href="/neural_coder/docs/PythonLauncher.md">Launcher</a></td>
+        <td colspan="2" align="center"><a href="/neural_coder/extensions/neural_compressor_ext_lab/README.md">JupyterLab Extension</a></td>
+        <td colspan="3" align="center"><a href="/neural_coder/extensions/neural_compressor_ext_vscode/README.md">Visual Studio Code Extension</a></td>
+        <td colspan="3" align="center"><a href="/neural_coder/docs/SupportMatrix.md">Supported Matrix</a></td>
     </tr>    
   </tbody>
   <thead>


### PR DESCRIPTION
## Type of Change

documentation

## Description

Fix the error to break online doc building:
  remove neural_compressor.adaptor.torch_utils.onnx.py, but no remove it in rst file.
  It break the online doc building.

Fix the link issue in user guide and welcome page in online document

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
