### PR TITLE
Fixed case error for without tuning

### DIFF
--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -470,9 +470,6 @@ def fit(model,
         # Saved quantized model in ./saved folder
         q_model.save("./saved")
     """
-    assert all((eval_dataloader is not None, eval_metric is not None)) or \
-        all((eval_dataloader is None, eval_metric is None)), \
-        "Please set eval_metric also if you set eval_dataloader!"
     quantizer = PostTrainingQuant(conf)
     quantizer.model = model
     if eval_func is not None:

--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -95,7 +95,7 @@ class PostTrainingQuant:
                 logger.warning(f"MSE_v2 does not support {cfg.model.framework} now, use basic instead.")
                 logger.warning("Only tensorflow, pytorch_fx is supported by MSE_v2 currently.")
         assert strategy in STRATEGIES, "Tuning strategy {} is NOT supported".format(strategy)
-        
+
         logger.info(f"Start {strategy} tuning.")
         _resume = None
         # check if interrupted tuning procedure exists. if yes, it will resume the
@@ -107,6 +107,10 @@ class PostTrainingQuant:
                 "The specified resume file {} doesn't exist!".format(self.resume_file)
             with open(self.resume_file, 'rb') as f:
                 _resume = pickle.load(f).__dict__
+
+        if self._eval_func is None and self.self._eval_dataloader is None:
+            self.conf.usr_cfg.tuning.exit_policy.performance_only = True
+            logger.info("Quantize model without tuning!")
 
         self.strategy = STRATEGIES[strategy](
             self._model,
@@ -466,6 +470,9 @@ def fit(model,
         # Saved quantized model in ./saved folder
         q_model.save("./saved")
     """
+    assert all((eval_dataloader is not None, eval_metric is not None)) or \
+        all((eval_dataloader is None, eval_metric is None)), \
+        "Please set eval_metric also if you set eval_dataloader!"
     quantizer = PostTrainingQuant(conf)
     quantizer.model = model
     if eval_func is not None:

--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -108,7 +108,7 @@ class PostTrainingQuant:
             with open(self.resume_file, 'rb') as f:
                 _resume = pickle.load(f).__dict__
 
-        if self._eval_func is None and self.self._eval_dataloader is None:
+        if self._eval_func is None and self._eval_dataloader is None:
             self.conf.usr_cfg.tuning.exit_policy.performance_only = True
             logger.info("Quantize model without tuning!")
 


### PR DESCRIPTION
## Type of Change

Fixed case error for without tuning
No API changed

## Description

In 2.x API, if user didn't set eval_func, eval_dataloader and eval_metric, then neural compressor should not to tune with accuracy. 

## Expected Behavior & Potential Risk

Quantized model without tuning if user doesn't set eval_func, eval_dataloader and eval_metric. 

## How has this PR been tested?

Local tested
