### PR TITLE
Fix pytorch windows benchmark issue

### DIFF
--- a/neural_compressor/benchmark.py
+++ b/neural_compressor/benchmark.py
@@ -221,6 +221,19 @@ class Benchmark(object):
             # (TODO) should add summary after win32 benchmark has log
             pass
 
+    def call_one(self, cmd, log_file):
+        """Execute one command for one instance in one thread and dump the log (for Windows)."""
+        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                shell=True) # nosec
+        with open(log_file, "w", 1, encoding="utf-8") as log_file:
+            log_file.write(f"[ COMMAND ] {cmd} \n")
+            for line in proc.stdout:
+                decoded_line = line.decode("utf-8", errors="ignore").strip()
+                logger.info(decoded_line)   # redirect to terminal
+                log_file.write(decoded_line + "\n")
+
     def config_instance(self, raw_cmd):
         """Configure the multi-instance commands and trigger benchmark with sub process.
 


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Pytorch model runs benchmark on Windows reported no 'call_one' interface.

## Expected Behavior & Potential Risk
Pytorch and Tensorflow benchmark can run successfully on Windows.

## How has this PR been tested?

Pre-CI and Pytorch, TF model benchmark test on Windows.

## Dependency Change?

No.
