### PR TITLE
Enable ResNet50 pruning example's device setting arguments

### DIFF
--- a/examples/pytorch/image_recognition/ResNet50/pruning/eager/README.md
+++ b/examples/pytorch/image_recognition/ResNet50/pruning/eager/README.md
@@ -28,21 +28,44 @@ python ./train.py \
     --pretrained \
     --batch-size 128 \
     --lr 0.175 \
-    --epochs 60 \
+    --epochs 180 \
     --warmup-epochs 0 \
-    --cooldown-epochs 10 \
+    --cooldown-epochs 20 \
     --do-prune \
     --do-distillation \
     --target-sparsity 0.75 \
     --pruning-pattern "2x1" \
     --update-frequency-on-step 2000 \
     --distillation-loss-weight "1.0" \
-    --output ./outputs/ \
-
+    --output ./path/save/your/models/ \
 ```
 After configs are settled, just run:
 ```bash
 sh run_resnet50_prune.sh
+```
+
+If you do not have a GPU, our code will automatically deploy pruning process on your CPU. If you do have GPUs and CUDA but you still want to execute the pruning on CPU, use an extra argument of "--no-cuda" in your script.
+```bash
+#!/bin/bash
+DATA="/path/to/your/dataset/"
+python ./train.py \
+    ${DATA} \
+    --model "resnet50" \
+    --num-classes 1000 \
+    --pretrained \
+    --batch-size 128 \
+    --lr 0.175 \
+    --epochs 180 \
+    --warmup-epochs 0 \
+    --cooldown-epochs 20 \
+    --do-prune \
+    --do-distillation \
+    --target-sparsity 0.75 \
+    --pruning-pattern "2x1" \
+    --update-frequency-on-step 2000 \
+    --distillation-loss-weight "1.0" \
+    --output ./path/save/your/models/ \
+    --no-cuda
 ```
 
 # Results

--- a/examples/pytorch/image_recognition/ResNet50/pruning/eager/run_resnet50_prune.sh
+++ b/examples/pytorch/image_recognition/ResNet50/pruning/eager/run_resnet50_prune.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 DATA="/path/to/your/dataset/"
 python ./train.py \
     ${DATA} \
@@ -7,13 +6,13 @@ python ./train.py \
     --pretrained \
     --batch-size 128 \
     --lr 0.175 \
-    --epochs 60 \
+    --epochs 180 \
     --warmup-epochs 0 \
-    --cooldown-epochs 10 \
+    --cooldown-epochs 20 \
     --do-prune \
     --do-distillation \
     --target-sparsity 0.75 \
     --pruning-pattern "2x1" \
     --update-frequency-on-step 2000 \
     --distillation-loss-weight "1.0" \
-    --output ./outputs/ \
+    --output ./path/save/your/models/ \

--- a/examples/pytorch/image_recognition/ResNet50/pruning/eager/train.py
+++ b/examples/pytorch/image_recognition/ResNet50/pruning/eager/train.py
@@ -396,7 +396,6 @@ def main():
         torch.backends.cudnn.benchmark = True
 
     args.prefetcher = not args.no_prefetcher
-    # import pdb;pdb.set_trace()
     device = utils.init_distributed_device(args)
     
     # user define args.no_cuda, even if the machine have GPU, user can still choose CPU to train.

--- a/examples/pytorch/image_recognition/ResNet50/pruning/eager/train.py
+++ b/examples/pytorch/image_recognition/ResNet50/pruning/eager/train.py
@@ -367,6 +367,8 @@ group.add_argument('--target-sparsity', type=float, default=0.9,
                     help='the coefficient of teacher-student distillation loss')
 group.add_argument('--pruning-pattern', type=str, default="1x1",
                     help='the coefficient of teacher-student distillation loss')
+group.add_argument('--no-cuda', action='store_true', default=False,
+                    help='user defined device setter.')
 
 def _parse_args():
     # Do we have a config file to parse?
@@ -394,7 +396,15 @@ def main():
         torch.backends.cudnn.benchmark = True
 
     args.prefetcher = not args.no_prefetcher
+    # import pdb;pdb.set_trace()
     device = utils.init_distributed_device(args)
+    
+    # user define args.no_cuda, even if the machine have GPU, user can still choose CPU to train.
+    if args.no_cuda:
+        device = torch.device("cpu")
+    if torch.cuda.is_available() and device.type == "cpu":
+        _logger.warning(f"Your device has cuda enabled, but your model will be pruned on cpu.")
+
     if args.distributed:
         _logger.info(
             'Training in distributed mode with multiple processes, 1 device per process.'
@@ -828,10 +838,12 @@ def main():
         loader_eval,
         validate_loss_fn,
         args,
+        device=device,
         amp_autocast=amp_autocast,
     )
     _logger.info(f"Model accuracy before pruning is {eval_metrics}")
 
+    
     try:
         for epoch in range(start_epoch, num_epochs):
             if hasattr(dataset_train, 'set_epoch'):
@@ -847,6 +859,7 @@ def main():
                 optimizer,
                 train_loss_fn,
                 args,
+                device=device,
                 lr_scheduler=lr_scheduler,
                 saver=saver,
                 output_dir=output_dir,
@@ -867,6 +880,7 @@ def main():
                 loader_eval,
                 validate_loss_fn,
                 args,
+                device=device,
                 amp_autocast=amp_autocast,
             )
 
@@ -879,6 +893,7 @@ def main():
                     loader_eval,
                     validate_loss_fn,
                     args,
+                    device=device,
                     amp_autocast=amp_autocast,
                     log_suffix=' (EMA)',
                 )
@@ -920,7 +935,7 @@ def train_one_epoch(
         optimizer,
         loss_fn,
         args,
-        device=torch.device('cuda'),
+        device=None,
         lr_scheduler=None,
         saver=None,
         output_dir=None,
@@ -995,8 +1010,9 @@ def train_one_epoch(
 
         if model_ema is not None:
             model_ema.update(model)
-
-        torch.cuda.synchronize()
+        
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
 
         num_updates += 1
         batch_time_m.update(time.time() - end)
@@ -1056,7 +1072,7 @@ def validate(
         loader,
         loss_fn,
         args,
-        device=torch.device('cuda'),
+        device=None,
         amp_autocast=suppress,
         log_suffix=''
 ):


### PR DESCRIPTION
## Type of Change

bugfix.

## Description

Add an extra arguments for user to define the device where want to run pruning.
Several situations: only CPU, with GPU but want to run on CPU.

## Expected Behavior & Potential Risk

Users can define their target device to run pruning.

## How has this PR been tested?

CI and example tests.

## Dependency Change?

None
