### PR TITLE
Add log for bfloat16 data type for PyTorch framework

### DIFF
--- a/neural_compressor/adaptor/torch_utils/bf16_convert.py
+++ b/neural_compressor/adaptor/torch_utils/bf16_convert.py
@@ -17,6 +17,7 @@
 """Bf16 Convert for Torch Utils."""
 import torch
 import torch.nn as nn
+from ...utils import logger
 from torch.fx import symbolic_trace
 
 class BF16ModuleWrapper(nn.Module):
@@ -47,6 +48,8 @@ def Convert(model, tune_cfg):
         bf16_ops_list = tune_cfg['bf16_ops_list']
         fx_sub_module_list = tune_cfg['fx_sub_module_list'] \
                              if 'fx_sub_module_list' in tune_cfg.keys() else []
+        if len(bf16_ops_list) > 0:
+            logger.info("Convert operators to bfloat16")
         mixed_precision_model = _bf16_wrapper_model(model, bf16_ops_list)
         if fx_sub_module_list is not None and len(fx_sub_module_list) > 0:
             mixed_precision_model = bf16_symbolic_trace(mixed_precision_model, fx_sub_module_list)

--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -371,10 +371,7 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
 
     bf16_ops_list = tune_cfg['bf16_ops_list'] if 'bf16_ops_list' in tune_cfg.keys() else []
     if len(bf16_ops_list) > 0 and (version >= Version("1.11.0-rc1")):
-        from .utility import CpuInfo
         from ..adaptor.torch_utils.bf16_convert import Convert
-        if os.getenv('FORCE_BF16') != '1':
-            assert CpuInfo().bf16, "Please run the model in the machine in which supports the bfloat16 data type!"
         model = Convert(model, tune_cfg)
     assert is_int8_model(model), "Int8 model is not loaded."
     if checkpoint_dir is None and history_cfg is not None:

--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -371,7 +371,10 @@ def load(checkpoint_dir=None, model=None, history_cfg=None, **kwargs):
 
     bf16_ops_list = tune_cfg['bf16_ops_list'] if 'bf16_ops_list' in tune_cfg.keys() else []
     if len(bf16_ops_list) > 0 and (version >= Version("1.11.0-rc1")):
+        from .utility import CpuInfo
         from ..adaptor.torch_utils.bf16_convert import Convert
+        if os.getenv('FORCE_BF16') != '1':
+            assert CpuInfo().bf16, "Please run the model in the machine in which supports the bfloat16 data type!"
         model = Convert(model, tune_cfg)
     assert is_int8_model(model), "Int8 model is not loaded."
     if checkpoint_dir is None and history_cfg is not None:


### PR DESCRIPTION
## Type of Change

Add log for bfloat16 for the PyTorch framework  
No API changed

## Description

Add log for bfloat16 for PyTorch framework 

## Expected Behavior & Potential Risk

It will print the bf16 log when HW supports bfloat16.

## How has this PR been tested?

Local tested
