### PR TITLE
Change the Order of Two Pre-optimizer for TF Backend

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/pre_optimize.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/pre_optimize.py
@@ -216,16 +216,19 @@ class PreOptimization():
 
         self._tmp_graph_def = FetchWeightFromReshapeOptimizer(
             self._tmp_graph_def).do_transformation()
+
+        self._tmp_graph_def = MoveSqueezeAfterReluOptimizer(
+            self._tmp_graph_def).do_transformation()
+
         if not self.new_api and not itex_mode:
             #TODO we need to remove below optimizer once the TF enabled the single
             # matmul op quantization
             self._tmp_graph_def = InjectDummyBiasAddOptimizer(
                 self._tmp_graph_def, output_node_names).do_transformation()
+                
         self._tmp_graph_def = FuseBiasAddAndAddOptimizer(
             self._tmp_graph_def).do_transformation()
 
-        self._tmp_graph_def = MoveSqueezeAfterReluOptimizer(
-            self._tmp_graph_def).do_transformation()
 
         self._tmp_graph_def = ConvertNanToRandom(
             self._tmp_graph_def).do_transformation()


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Change the order of MoveSqueezeAfterReluOptimizer and InjectDummyBiasAddOptimizer so that the former one can be done firstly.
It will makes Conv2D + Squeeze + BiasAdd + Relu pattern be correctly fused.

## Expected Behavior & Potential Risk

Fix a fusion pattern on TF backend

## How has this PR been tested?

Preci

## Dependency Change?

No
