### PR TITLE
Fix inception_v3 tuning issue on SPR with ITF2.11.0

### DIFF
--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/main.py
@@ -111,7 +111,9 @@ class eval_classifier_optimized_graph:
                 'filter': None
             }
             eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
-            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100])
+            op_name_dict = {'v0/cg/conv0/conv2d/Conv2D': {
+               'activation':  {'dtype': ['fp32']}}}
+            conf = PostTrainingQuantConfig(calibration_sampling_size=[50, 100], op_name_dict=op_name_dict)
             q_model = quantization.fit(args.input_graph, conf=conf, calib_dataloader=calib_dataloader,
                         eval_dataloader=eval_dataloader)
             q_model.save(args.output_graph)


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

ILITV-2799: [3rd release test][spr][ITF2.11.0] inception_v3 failed in tune3.

## Expected Behavior & Potential Risk

inception_v3 tuning issue can be fixed on SPR. 

## How has this PR been tested?

Pre-CI and model test on CLX and SPR.

## Dependency Change?

No.
