### PR TITLE
Support KerasModel just on Keras backend

### DIFF
--- a/neural_compressor/mix_precision.py
+++ b/neural_compressor/mix_precision.py
@@ -222,11 +222,7 @@ class _MixedPrecision:
         if not isinstance(user_model, BaseModel):
             logger.warning("Force convert framework model to neural_compressor model.")
             if "tensorflow" in cfg.model.framework or cfg.model.framework == "keras":
-                if get_model_type(user_model) == 'keras':
-                    self._model = Model(user_model, backend=cfg.model.framework,
-                                        device=cfg.device, modelType="saved_model")
-                else:
-                    self._model = Model(user_model, backend=cfg.model.framework, device=cfg.device)
+                self._model = Model(user_model, backend=cfg.model.framework, device=cfg.device)
             else:
                 self._model = Model(user_model, backend=cfg.model.framework)
         else:

--- a/neural_compressor/model/model.py
+++ b/neural_compressor/model/model.py
@@ -172,7 +172,7 @@ class Model(object):
         elif backend == "ipex":
             backend = "pytorch_ipex"
 
-        if 'tensorflow' in backend:
+        if 'tensorflow' in backend or backend == 'keras':
             if kwargs.get("approach", None) == "quant_aware_training":
                 return TensorflowQATModel(root, **kwargs)
 
@@ -180,7 +180,7 @@ class Model(object):
                 model_type = kwargs['modelType']
             else:
                 model_type = get_model_type(root)
-            if model_type == 'keras':
+            if backend == 'keras' and model_type == 'keras':
                 return MODELS['keras'](root, **kwargs)
             model = MODELS['tensorflow'](model_type, root, **kwargs)
         else:


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

ILITV-2398: During studying this issue, I found current design would convert SavedModel to KerasModel on Tensorflow backend, it will cause the quantization fail. We should support KerasModel just on Keras backend.

## Expected Behavior & Potential Risk

TFHub saved model can be quantized successfully on stock tensorflow.

## How has this PR been tested?

Pre-CI and TFHub saved model test.

## Dependency Change?

None.
