### PR TITLE
enable smoothquant with calibration func

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -1266,7 +1266,7 @@ class TemplateAdaptor(Adaptor):
                     "IPEX version >= 2.1 is required for SmoothQuant folding=False, reset folding=True.")
 
         if not hasattr(self, 'sq') or force_re_smooth:
-            self.sq = TorchSmoothQuant(model._model, dataloader=dataloader)
+            self.sq = TorchSmoothQuant(model._model, dataloader=dataloader, q_func=self.q_func)
         kwargs = {}  ##different backends may have different default values
         if op_types != None:
             kwargs["op_types"] = op_types

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -175,7 +175,7 @@ class TorchSmoothQuant:
     to recover the weights if needed
     """
 
-    def __init__(self, model, dataloader, traced_model=None):
+    def __init__(self, model, dataloader, q_func=None, traced_model=None):
         """
         :param model: Torch model :param dataloader: Calibration dataloader :param traced_model: A specific model
         shares the same architecture as the model and could be traced by torch.jit. If not supplied, we use model
@@ -188,6 +188,7 @@ class TorchSmoothQuant:
         self.device = device
         self.dtype = dtype
         self.dataloader = dataloader
+        self.q_func = q_func
         self.input_values = {}
         self.output_values = {}
         self.input_maxes = {}
@@ -324,7 +325,11 @@ class TorchSmoothQuant:
         :param calib_iter: Sample size for calibration
         :return:
         """
-        model_forward(self.model, self.dataloader, calib_iter, self.device)
+        if self.q_func:
+            self.q_func(self.model)
+        else:
+            assert self.dataloader, "Please set dataloader for calibration."
+            model_forward(self.model, self.dataloader, calib_iter, self.device)
         ##stack
         for key in self.input_maxes.keys():
             max_val = self.input_maxes[key]

--- a/neural_compressor/algorithm/algorithm.py
+++ b/neural_compressor/algorithm/algorithm.py
@@ -117,7 +117,6 @@ class AlgorithmScheduler(object):
         if len(self._exec_algorithms.get(location, [])) == 0:
             return self._q_model
         assert self._origin_model, 'set origin model for algorithm'
-        assert self._dataloader, 'set dataloader for algorithm'
         assert self._adaptor, 'set adaptor for algorithm'
         assert self._calib_iter, 'set calibration iteration for algorithm'
         for algo in self._exec_algorithms.get(location, []):

--- a/test/algorithm/test_smooth_quant.py
+++ b/test/algorithm/test_smooth_quant.py
@@ -599,7 +599,7 @@ class TestSqLinearOpFuse(unittest.TestCase):
                 yield input_ids
         def calib_func(model):
             for i in range(10):
-                model(ipnut_ids)
+                model(input_ids)
 
         q_model = quantization.fit(
             fp32_model,
@@ -634,15 +634,16 @@ class TestSqLinearOpFuse(unittest.TestCase):
         # with calib_func
         conf = PostTrainingQuantConfig(
                         recipes={"smooth_quant": True,
-                                "smooth_quant_args": {'alpha': 'auto', 'folding':False}}
+                                "smooth_quant_args": {'alpha': 'auto', 'folding': False}}
                         )
+        fp32_model = Model()
         q_model = quantization.fit(
                         fp32_model,
                         conf,
                         calib_func=calib_func,
                         eval_func=lambda x: 0.1,
                         )
-        self.assertTrue(float(q_model.model.fc1.bias()[0]) != origin_bias)
+        self.assertTrue(isinstance(q_model.model.fc1, SQLinearWrapper))
 
     @unittest.skipIf(not TEST_IPEX, "Please install Intel extension for Pytorch")
     def test_sq_quant_ipex(self):


### PR DESCRIPTION
## Type of Change

support smoothquant only with calibration func, w/o calibration_dataloader.

## Description
usage:
```
      conf = PostTrainingQuantConfig(
                        recipes={"smooth_quant": True,
                                "smooth_quant_args": {'alpha': 'auto', 'folding': False}}
                        )
        fp32_model = Model()
        q_model = quantization.fit(
                        fp32_model,
                        conf,
                        calib_func=calib_func,
                        )

```
## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
