### PR TITLE
Fix OOB DynamicMemory model quantize issue

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_util.py
+++ b/neural_compressor/adaptor/tf_utils/graph_util.py
@@ -962,6 +962,10 @@ class GraphRewriterHelper():
                 iterations += 1
 
         step = int(len(valid_data) / iterations)
+        if step % 2 == 1:
+            step -= 1
+            iterations = int(len(valid_data) / step) + int(len(valid_data) % step > 0)
+
         final_res = []
 
         for i in range(iterations):


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

ILITV-2850: [regression][ITF2.11.0]TF OOB DynamicMemory quantize failed

gen_valid_sampling_log has an issue of calculate final result, the step size is 9. It must be even for min and max.

## Expected Behavior & Potential Risk

The OOB DynamicMemory model can be quantized successfully.

## How has this PR been tested?

Pre-CI and OOB extension test.

## Dependency Change?

No.
