### PR TITLE
Fix MobileNet-V3 bias convert to int32 OverflowError issue

### DIFF
--- a/neural_compressor/adaptor/tf_utils/transform_graph/rerange_quantized_concat.py
+++ b/neural_compressor/adaptor/tf_utils/transform_graph/rerange_quantized_concat.py
@@ -286,7 +286,7 @@ class RerangeQuantizedConcat(GraphTransformBase):
                     another_conv_node.input[offset_value + 1]]
                 min_input = min_freezed_output_node.attr['value'].tensor.float_val[0]
                 max_input = max_freezed_output_node.attr['value'].tensor.float_val[0]
-                # To avoid generate int32 bias exception for corner case
+                # To avoid generating int32 bias exception for corner case
                 if min_input == 0 and max_input == 0:
                     continue
 

--- a/neural_compressor/adaptor/tf_utils/transform_graph/rerange_quantized_concat.py
+++ b/neural_compressor/adaptor/tf_utils/transform_graph/rerange_quantized_concat.py
@@ -286,6 +286,9 @@ class RerangeQuantizedConcat(GraphTransformBase):
                     another_conv_node.input[offset_value + 1]]
                 min_input = min_freezed_output_node.attr['value'].tensor.float_val[0]
                 max_input = max_freezed_output_node.attr['value'].tensor.float_val[0]
+                # To avoid generate int32 bias exception for corner case
+                if min_input == 0 and max_input == 0:
+                    continue
 
                 bias_tensor = (tensor_util.MakeNdarray(bias_node.attr['value'].tensor))
 


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

ILITV-2735: Tensorflow-mobilenetv3, OverflowError: cannot convert float infinity to integer
When strategy trigger 5th time tuning for MobileNet-V3 for test purpose, the freezed min and max value are both 0 of one Conv2D. It caused the scales value become float infinity since the scales value is calculated from the freezed min and max value.

## Expected Behavior & Potential Risk

The MobileNet-V3 tuning will not crash.

## How has this PR been tested?

Pre-CI and extension test.

## Dependency Change?

No.
