### PR TITLE
Update DyNAS-T to 1.2

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -16,6 +16,6 @@ tensorflow_model_optimization
 horovod
 tensorflow-addons
 onnxruntime-extensions; python_version < '3.10'
-dynast==1.2.0rc1
+dynast==1.2.0rc2
 intel-extension-for-pytorch
 tf2onnx

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -16,6 +16,6 @@ tensorflow_model_optimization
 horovod
 tensorflow-addons
 onnxruntime-extensions; python_version < '3.10'
-dynast==1.2.0rc2
+dynast==1.2.0
 intel-extension-for-pytorch
 tf2onnx

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -16,6 +16,6 @@ tensorflow_model_optimization
 horovod
 tensorflow-addons
 onnxruntime-extensions; python_version < '3.10'
-dynast==1.1.0
+dynast==1.2.0rc1
 intel-extension-for-pytorch
 tf2onnx


### PR DESCRIPTION
DyNAS-T 1.1 has OFA dependency that causes issues when used with Torch 2.0. DyNAS-T 1.2 replaces OFA dependency with a built-in OFA-related code that has a fix addressing this issue.

Signed-off-by: Maciej Szankin <maciej.szankin@intel.com>