### PR TITLE
Fix bugs when automatically exclude classifier heads in pruning.

### DIFF
--- a/neural_compressor/compression/pruner/model_slim/pattern_analyzer.py
+++ b/neural_compressor/compression/pruner/model_slim/pattern_analyzer.py
@@ -676,15 +676,18 @@ class ClassifierHeadSearcher(object):
         super(ClassifierHeadSearcher, self).__init__()
         self.model = model
         self.pruning_ops = ["Linear", "Conv2d"]
+        self.excluded_ops = ["Dropout"] # to be extended
     
     def search(self, return_name=True):
-        # import pdb;pdb.set_trace()
         all_modules = []
         all_lc_modules = []
         for n, m in self.model.named_modules():
-            all_modules.append(n)
-            if type(m).__name__ in self.pruning_ops:
-                all_lc_modules.append(n)
+            if type(m).__name__ not in self.excluded_ops:
+                all_modules.append(n)
+                if type(m).__name__ in self.pruning_ops:
+                    all_lc_modules.append(n)
+            else:
+                continue
         # import pdb;pdb.set_trace()
         last_lc = all_lc_modules[-1]
         if last_lc == all_modules[-1]: return last_lc

--- a/neural_compressor/compression/pruner/model_slim/pattern_analyzer.py
+++ b/neural_compressor/compression/pruner/model_slim/pattern_analyzer.py
@@ -688,7 +688,6 @@ class ClassifierHeadSearcher(object):
                     all_lc_modules.append(n)
             else:
                 continue
-        # import pdb;pdb.set_trace()
         last_lc = all_lc_modules[-1]
         if last_lc == all_modules[-1]: return last_lc
         else: return None

--- a/test/pruning_2.x/test_auto_excluding_classifier.py
+++ b/test/pruning_2.x/test_auto_excluding_classifier.py
@@ -1,0 +1,63 @@
+import unittest
+
+import torch
+import torchvision
+import torch.nn as nn
+import sys
+sys.path.insert(0, './')
+from neural_compressor.data import Datasets
+from neural_compressor.data.dataloaders.pytorch_dataloader import PyTorchDataLoader
+from transformers import (
+    AutoConfig,
+    AutoModelForSequenceClassification,
+    AutoTokenizer
+)
+
+class NaiveMLP(nn.Module):
+    def __init__(self, hidden_size=16):
+        super(NaiveMLP, self).__init__()
+        self.linear1 = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.ac1 = nn.ReLU()
+        self.linear2 = nn.Linear(hidden_size, hidden_size, bias=True)
+        self.ac2 = nn.ReLU()
+        self.linear3 = nn.Linear(hidden_size, 2, bias=True)
+        
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.ac1(x)
+        x = self.linear2(x)
+        x = self.ac2(x)
+        x = self.linear3(x)
+        return x
+
+class TestPruning(unittest.TestCase):
+    
+    def test_pruning_basic(self):
+        # import pdb;pdb.set_trace()
+        hidden_size = 32
+        model = NaiveMLP(hidden_size)
+        # import classifier searching functions
+        # A naive MLP model
+        from neural_compressor.compression.pruner.model_slim.pattern_analyzer import ClassifierHeadSearcher
+        searcher = ClassifierHeadSearcher(model)
+        layer = searcher.search(return_name=True)
+        assert layer == "linear3"
+        del model
+
+        # A Transformer model
+        model_name_or_path = "textattack/distilbert-base-uncased-MRPC"
+        task_name = "mrpc"
+        num_labels = 2
+        config = AutoConfig.from_pretrained(model_name_or_path, num_labels=num_labels, finetuning_task=task_name)
+        tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        model = AutoModelForSequenceClassification.from_pretrained(
+            model_name_or_path,
+            from_tf=bool(".ckpt" in model_name_or_path),
+            config=config,
+        )
+        searcher = ClassifierHeadSearcher(model)
+        layer = searcher.search(return_name=True)
+        assert layer == "classifier"
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Type of Change

Bugfix.

## Description
Please refer to [this ticket](https://jira.devtools.intel.com/browse/ILITV-2888)
Fix a bug for excluding classifier head (does not have gradient) during pruning. 

## Expected Behavior & Potential Risk

Examples run without classifier pruning bugs

## How has this PR been tested?

PreCI

## Dependency Change?

None
