### PR TITLE
Fix bert_large_squad/bert_base_mrpc quantize fail issue

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/pre_optimize.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/pre_optimize.py
@@ -235,7 +235,6 @@ class PreOptimization():
         if self.new_api or itex_mode:
             self._tmp_graph_def = DilatedContraction(
                 self._tmp_graph_def).do_transformation()
-        self._tmp_graph_def.library.CopyFrom(self.model.graph_def.library)
 
         # node device info will be removed by GrapplerOptimizer, insert it again.
         if version1_lt_version2(tf.version.VERSION, '2.0.0'): # pragma: no cover
@@ -265,6 +264,8 @@ class PreOptimization():
             node = graph_info[node_name].node
             node.device = node_device
         self._tmp_graph_def = cur_graph.dump_graph()
+
+        self._tmp_graph_def.library.CopyFrom(self.model.graph_def.library)
 
         for function_def in self.model.graph_def.library.function:
             if function_def.signature.name == 'swish_f32':


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

ILITV-2890: [regression]TF bert_large_squad/bert_base_mrpc quantize failed

It's caused by PR #802.

## Expected Behavior & Potential Risk

The bert_large_squad/bert_base_mrpc quantize fail issue can be fixed.

## How has this PR been tested?

Model test and pre-CI test.

## Dependency Change?

No.
