### PR TITLE
Clean incorrect usage of fit for Keras examples

### DIFF
--- a/examples/keras/image_recognition/inception_resnet_v2/quantization/ptq/main.py
+++ b/examples/keras/image_recognition/inception_resnet_v2/quantization/ptq/main.py
@@ -127,7 +127,6 @@ def main(_):
             model=FLAGS.input_model,
             conf=config,
             calib_dataloader=calib_dataloader,
-            eval_dataloader=eval_dataloader,
             eval_func=evaluate)
         q_model.save(FLAGS.output_model)
 

--- a/examples/keras/image_recognition/inception_v3/quantization/ptq/main.py
+++ b/examples/keras/image_recognition/inception_v3/quantization/ptq/main.py
@@ -127,7 +127,6 @@ def main(_):
             model=FLAGS.input_model,
             conf=config,
             calib_dataloader=calib_dataloader,
-            eval_dataloader=eval_dataloader,
             eval_func=evaluate)
         q_model.save(FLAGS.output_model)
 

--- a/examples/keras/image_recognition/mobilenet_v2/quantization/ptq/main.py
+++ b/examples/keras/image_recognition/mobilenet_v2/quantization/ptq/main.py
@@ -126,7 +126,6 @@ def main(_):
             model=FLAGS.input_model,
             conf=config,
             calib_dataloader=calib_dataloader,
-            eval_dataloader=eval_dataloader,
             eval_func=evaluate)
         q_model.save(FLAGS.output_model)
 

--- a/examples/keras/image_recognition/resnet101/quantization/ptq/main.py
+++ b/examples/keras/image_recognition/resnet101/quantization/ptq/main.py
@@ -133,7 +133,6 @@ def main(_):
             model=FLAGS.input_model,
             conf=config,
             calib_dataloader=calib_dataloader,
-            eval_dataloader=eval_dataloader,
             eval_func=evaluate)
         q_model.save(FLAGS.output_model)
 

--- a/examples/keras/image_recognition/resnetv2_101/quantization/ptq/main.py
+++ b/examples/keras/image_recognition/resnetv2_101/quantization/ptq/main.py
@@ -126,7 +126,6 @@ def main(_):
             model=FLAGS.input_model,
             conf=config,
             calib_dataloader=calib_dataloader,
-            eval_dataloader=eval_dataloader,
             eval_func=evaluate)
         q_model.save(FLAGS.output_model)
 

--- a/examples/keras/image_recognition/resnetv2_50/quantization/ptq/main.py
+++ b/examples/keras/image_recognition/resnetv2_50/quantization/ptq/main.py
@@ -126,7 +126,6 @@ def main(_):
             model=FLAGS.input_model,
             conf=config,
             calib_dataloader=calib_dataloader,
-            eval_dataloader=eval_dataloader,
             eval_func=evaluate)
         q_model.save(FLAGS.output_model)
 

--- a/examples/keras/image_recognition/xception/quantization/ptq/main.py
+++ b/examples/keras/image_recognition/xception/quantization/ptq/main.py
@@ -126,7 +126,6 @@ def main(_):
             model=FLAGS.input_model,
             conf=config,
             calib_dataloader=calib_dataloader,
-            eval_dataloader=eval_dataloader,
             eval_func=evaluate)
         q_model.save(FLAGS.output_model)
 

--- a/examples/tensorflow/semantic_image_segmentation/3dunet-mlperf/quantization/ptq/run_accuracy.py
+++ b/examples/tensorflow/semantic_image_segmentation/3dunet-mlperf/quantization/ptq/run_accuracy.py
@@ -214,7 +214,6 @@ if __name__ == "__main__":
             model=graph,
             conf=config,
             calib_dataloader=DataLoader(framework='tensorflow', dataset=CalibrationDL()),
-            eval_dataloader=DataLoader(framework='tensorflow', dataset=CalibrationDL()),
             eval_func=eval_func)
         try:
             q_model.save(args.output_model)


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Clean incorrect usage of fit for Keras examples

## Expected Behavior & Potential Risk

The quantization fit API usage is correct for Keras examples.

## How has this PR been tested?

Pre-CI and extension test.

## Dependency Change?

No.
