### PR TITLE
Update TensorFlow version to resolve CVEs

### DIFF
--- a/examples/helloworld/tf_example1/requirements.txt
+++ b/examples/helloworld/tf_example1/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/helloworld/tf_example2/requirements.txt
+++ b/examples/helloworld/tf_example2/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/helloworld/tf_example3/requirements.txt
+++ b/examples/helloworld/tf_example3/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/helloworld/tf_example4/requirements.txt
+++ b/examples/helloworld/tf_example4/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/helloworld/tf_example5/requirements.txt
+++ b/examples/helloworld/tf_example5/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/helloworld/tf_example6/requirements.txt
+++ b/examples/helloworld/tf_example6/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/helloworld/tf_example7/requirements.txt
+++ b/examples/helloworld/tf_example7/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/helloworld/tf_example7/test.py
+++ b/examples/helloworld/tf_example7/test.py
@@ -4,6 +4,7 @@ from neural_compressor.data import DataLoader
 from neural_compressor.data import Datasets
 from neural_compressor.quantization import fit
 
+
 def main():
 
     # Built-in dummy dataset
@@ -20,6 +21,7 @@ def main():
                   calib_dataloader=dataloader,
                   eval_dataloader=dataloader,
                   eval_metric=top1)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/keras/image_recognition/inception_resnet_v2/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/inception_resnet_v2/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/inception_v3/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/inception_v3/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/mobilenet_v2/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/mobilenet_v2/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/resnet101/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/resnet101/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/resnet50/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/resnet50/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/resnet50_fashion/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/resnet50_fashion/quantization/ptq/requirements.txt
@@ -1,3 +1,3 @@
 tqdm
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/resnetv2_101/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/resnetv2_101/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/resnetv2_50/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/resnetv2_50/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/vgg16/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/vgg16/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/vgg19/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/vgg19/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/keras/image_recognition/xception/quantization/ptq/requirements.txt
+++ b/examples/keras/image_recognition/xception/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow <= 2.11.0
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/bert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/bert/quantization/ptq_static/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/distilbert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/distilbert/quantization/ptq_dynamic/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/distilbert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/distilbert/quantization/ptq_static/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_dynamic/requirements.txt
@@ -1,4 +1,5 @@
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/requirements.txt
@@ -1,4 +1,5 @@
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/requirements.txt
@@ -2,6 +2,7 @@ onnx
 onnxruntime
 onnxruntime-extensions; python_version < '3.10'
 transformers
+accelerate
 tensorboard
 numpy==1.23.5
 datasets >= 1.8.0

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/requirements.txt
@@ -2,6 +2,7 @@ onnx
 onnxruntime
 onnxruntime-extensions; python_version < '3.10'
 transformers
+accelerate
 tensorboard
 numpy==1.23.5
 datasets >= 1.8.0

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/quantization/ptq_dynamic/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 onnxruntime-extensions; python_version < '3.10'

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/quantization/ptq_static/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 onnxruntime-extensions; python_version < '3.10'

--- a/examples/onnxrt/nlp/mobilebert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/mobilebert/quantization/ptq_dynamic/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/onnxrt/nlp/onnx_model_zoo/bert-squad/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/bert-squad/quantization/ptq_dynamic/requirements.txt
@@ -1,6 +1,6 @@
 onnx
 onnxruntime
-intel-tensorflow==2.10.0
+intel-tensorflow==2.12.0
 torch
 onnxruntime-extensions; python_version < '3.10'
 pillow>=8.1.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_dynamic/requirements.txt
@@ -1,6 +1,6 @@
 onnx
 onnxruntime
-intel-tensorflow==2.10.0
+intel-tensorflow==2.12.0
 tf2onnx
 torch
 onnxruntime-extensions; python_version < '3.10'

--- a/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_static/requirements.txt
@@ -1,6 +1,6 @@
 onnx
 onnxruntime
-intel-tensorflow==2.10.0
+intel-tensorflow==2.12.0
 tf2onnx
 torch
 onnxruntime-extensions; python_version < '3.10'

--- a/examples/onnxrt/nlp/roberta/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/roberta/quantization/ptq_dynamic/requirements.txt
@@ -1,5 +1,6 @@
 torch
 transformers
+accelerate
 onnx
 onnxruntime
 coloredlogs

--- a/examples/pytorch/nlp/huggingface_models/text-classification/quantization/ptq_dynamic/fx/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/text-classification/quantization/ptq_dynamic/fx/requirements.txt
@@ -5,4 +5,5 @@ scipy
 scikit-learn
 Keras-Preprocessing
 transformers>=4.16.0
+accelerate
 torch>=1.9.0

--- a/examples/pytorch/nlp/huggingface_models/text-classification/quantization/ptq_static/fx/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/text-classification/quantization/ptq_static/fx/requirements.txt
@@ -7,4 +7,5 @@ Keras-Preprocessing
 onnx
 onnxruntime
 transformers>=4.16.0
+accelerate
 torch>=1.9.0

--- a/examples/pytorch/nlp/huggingface_models/text-classification/quantization/qat/fx/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/text-classification/quantization/qat/fx/requirements.txt
@@ -1,5 +1,6 @@
 neural-compressor
 transformers>=4.16.0
+accelerate
 datasets>=1.18.0
 sentencepiece!=0.1.92
 protobuf<=3.20.3

--- a/examples/pytorch/object_detection/yolo_v3/quantization/ptq_static/fx/requirements.txt
+++ b/examples/pytorch/object_detection/yolo_v3/quantization/ptq_static/fx/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 matplotlib
-tensorflow
+tensorflow>=2.11.1
 tensorboard
 terminaltables
 pillow>=8.2.0

--- a/examples/pytorch/object_detection/yolo_v5/pruning/eager/requirements.txt
+++ b/examples/pytorch/object_detection/yolo_v5/pruning/eager/requirements.txt
@@ -30,7 +30,7 @@ seaborn>=0.11.0
 # nvidia-pyindex  # TensorRT export
 # nvidia-tensorrt  # TensorRT export
 # scikit-learn<=1.1.2  # CoreML quantization
-# tensorflow>=2.4.1  # TF exports (-cpu, -aarch64, -macos)
+# tensorflow>=2.11.1  # TF exports (-cpu, -aarch64, -macos)
 # tensorflowjs>=3.9.0  # TF.js export
 # openvino-dev  # OpenVINO export
 

--- a/examples/tensorflow/image_recognition/resnet_v2/quantization/qat/requirements.txt
+++ b/examples/tensorflow/image_recognition/resnet_v2/quantization/qat/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet121/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet121/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet161/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet161/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet169/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet169/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/efficientnet-b0/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/efficientnet-b0/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_resnet_v2/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_resnet_v2/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v1/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v1/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v2/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v2/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v4/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v4/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v1/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v1/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/export/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]
 tf2onnx
 onnx

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v3/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v3/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet101/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet101/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]
 tf2onnx
 onnx

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]
 tf2onnx
 onnx

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_101/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_101/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_152/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_152/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_50/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_50/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]
 tf2onnx
 onnx

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg16/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg16/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg19/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg19/quantization/ptq/requirements.txt
@@ -1,2 +1,2 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 neural-compressor

--- a/examples/tensorflow/nlp/bert_large_squad_model_zoo/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/nlp/bert_large_squad_model_zoo/quantization/ptq/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/tensorflow/nlp/distilbert_base/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/nlp/distilbert_base/quantization/ptq/requirements.txt
@@ -4,3 +4,4 @@ scipy>=1.9.3
 sklearn==0.0
 tokenizers==0.13.1
 transformers==4.23.1
+intel-tensorflow>=2.12.0

--- a/examples/tensorflow/nlp/transformer_lt_mlperf/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/nlp/transformer_lt_mlperf/quantization/ptq/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/export/requirements.txt
+++ b/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/export/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]
 tf2onnx
 onnx

--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/export/requirements.txt
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/export/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow>=2.11.1
 intel-extension-for-tensorflow[cpu]
 tf2onnx
 onnx

--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet34/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet34/quantization/ptq/requirements.txt
@@ -1,1 +1,1 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0

--- a/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/requirements.txt
+++ b/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/requirements.txt
@@ -1,4 +1,4 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 Cython
 contextlib2
 pillow>=8.2.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-intel-tensorflow
+intel-tensorflow>=2.12.0
 onnx
 onnxruntime
 --find-links https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
## Type of Change

Others

## Description

1. Add deps accelerate to adopt transformers==4.29.0 
2. Fix TensorFlow CVE by update version larger than 2.11.1. 

## Expected Behavior & Potential Risk

CI pass

## How has this PR been tested?

CI

## Dependency Change?

No
