### PR TITLE
Add weight attribute to SQLinearWrapper class

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -1351,10 +1351,12 @@ class TemplateAdaptor(Adaptor):
             def __init__(self, module):
                 super().__init__()
                 self.add_module('sq_linear', module)
-                self.weight = self.sq_linear.weight
 
             def forward(self, X):
                 return self.sq_linear(X)
+            
+            def weight(self):
+                return self.sq_linear.weight
 
         from .torch_utils.smooth_quant import get_module, set_module
         if recover:
@@ -3042,6 +3044,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                     tmp_model = ipex.quantization.prepare(tmp_model, static_qconfig, \
                                             example_inputs=self.example_inputs, inplace=True)
                 if self.q_dataloader or self.example_inputs:
+                    #import pdb;pdb.set_trace();
+                    #self.q_func(tmp_model)
                     self._simple_inference(tmp_model, self.q_dataloader, iterations=1)
                 else:
                     try:
@@ -3049,6 +3053,7 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                     except Exception as e:
                         logger.error("Calibration with IPEX failed due to:{}".format(e))
                         assert False, "Please pass in example_inputs or calib_dataloader to bypass."
+
                 tmp_model.save_qconf_summary(qconf_summary=self.ipex_config_path)
             if isinstance(self.q_dataloader, BaseDataLoader):
                 self.q_dataloader.batch(batch_size)

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -1351,6 +1351,7 @@ class TemplateAdaptor(Adaptor):
             def __init__(self, module):
                 super().__init__()
                 self.add_module('sq_linear', module)
+                self.weight = self.sq_linear.weight
 
             def forward(self, X):
                 return self.sq_linear(X)

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -1355,6 +1355,7 @@ class TemplateAdaptor(Adaptor):
             def forward(self, X):
                 return self.sq_linear(X)
             
+            @property 
             def weight(self):
                 return self.sq_linear.weight
 
@@ -3044,8 +3045,6 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                     tmp_model = ipex.quantization.prepare(tmp_model, static_qconfig, \
                                             example_inputs=self.example_inputs, inplace=True)
                 if self.q_dataloader or self.example_inputs:
-                    #import pdb;pdb.set_trace();
-                    #self.q_func(tmp_model)
                     self._simple_inference(tmp_model, self.q_dataloader, iterations=1)
                 else:
                     try:

--- a/neural_compressor/adaptor/torch_utils/model_wrapper.py
+++ b/neural_compressor/adaptor/torch_utils/model_wrapper.py
@@ -68,7 +68,9 @@ class SQLinearWrapper(torch.nn.Module):
         self.scale, self.zero_point = self._calculate_qparams(input_scale, input_minmax, dtype)
         self.add_module('sq_linear', module)
         self.ipex = False  # a flag used for ipex inference
-        self.weight = self.sq_linear.weight
+
+    def weight(self):
+        return self.sq_linear.weight
 
     def forward(self, X):
         if self.ipex:

--- a/neural_compressor/adaptor/torch_utils/model_wrapper.py
+++ b/neural_compressor/adaptor/torch_utils/model_wrapper.py
@@ -68,6 +68,7 @@ class SQLinearWrapper(torch.nn.Module):
         self.scale, self.zero_point = self._calculate_qparams(input_scale, input_minmax, dtype)
         self.add_module('sq_linear', module)
         self.ipex = False  # a flag used for ipex inference
+        self.weight = self.sq_linear.weight
 
     def forward(self, X):
         if self.ipex:

--- a/neural_compressor/adaptor/torch_utils/model_wrapper.py
+++ b/neural_compressor/adaptor/torch_utils/model_wrapper.py
@@ -44,6 +44,10 @@ class QDQLinear(torch.nn.Module):
         self.add_module('dequant', nnq.DeQuantize())
         self.add_module('module', module)
         self.qdq_weight()
+     
+    @property
+    def weight(self):
+        return self.module.weight
 
     def forward(self, X):
         X = self.quant(X)
@@ -68,7 +72,8 @@ class SQLinearWrapper(torch.nn.Module):
         self.scale, self.zero_point = self._calculate_qparams(input_scale, input_minmax, dtype)
         self.add_module('sq_linear', module)
         self.ipex = False  # a flag used for ipex inference
-
+    
+    @property
     def weight(self):
         return self.sq_linear.weight
 

--- a/test/algorithm/test_smooth_quant.py
+++ b/test/algorithm/test_smooth_quant.py
@@ -609,6 +609,7 @@ class TestSqLinearOpFuse(unittest.TestCase):
         )
         from neural_compressor.adaptor.torch_utils.model_wrapper import SQLinearWrapper
         assert isinstance(q_model.model.fc1, SQLinearWrapper)
+        assert isinstance(fp32_model.fc1.weight, torch.Tensor)
         assert isinstance(fp32_model.fc1, SQLinearWrapper) # for smoothquant, inplace=True.
 
         q_model.save('saved_result')


### PR DESCRIPTION
## Type of Change

to enable t5 series smooth quant.

## Description
to avoid inference failed. https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py#L318
```
-> isinstance(self.wo.weight, torch.Tensor)
(Pdb) self.wo.weight
*** AttributeError: 'SQLinearWrapper' object has no attribute 'weight'
(Pdb) self.wo
SQLinearWrapper(
  (sq_linear): Linear(in_features=2816, out_features=1024, bias=False)
)
```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
