### PR TITLE
Fix TF2ONNX vgg16 failed due to Metric change

### DIFF
--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/main.py
@@ -23,7 +23,6 @@ import tensorflow as tf
 import onnxruntime as ort
 from argparse import ArgumentParser
 from neural_compressor.data import LabelShift
-from neural_compressor import Metric
 from neural_compressor.utils.create_obj_from_config import create_dataloader
 
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
@@ -137,8 +136,9 @@ class eval_classifier_optimized_graph:
                 eval_dataloader = create_dataloader('tensorflow', eval_dataloader_args)
                 conf = PostTrainingQuantConfig(backend='itex', calibration_sampling_size=[50, 100],
                                             outputs=['softmax_tensor'])
-                from neural_compressor import Metric
-                top1 = Metric(name="topk", k=1)
+                from neural_compressor import METRICS
+                metrics = METRICS('tensorflow')
+                top1 = metrics['topk']()
                 def eval(model):
                     return eval_func_tf(model, eval_dataloader, top1, postprocess)
                 q_model = quantization.fit(args.input_graph, conf=conf, calib_dataloader=calib_dataloader,


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

ILITV-2908: TF2ONNX vgg16 failed due to 'Metric' object has no attribute 'update'
This issue is caused by Metric change, needs to adapt it.

## Expected Behavior & Potential Risk

TF2ONNX vgg16 can be done successfully.

## How has this PR been tested?

Pre-CI and TF2ONNX example test.

## Dependency Change?

No.
