### PR TITLE
Fix TF2ONNX ssd_mobilenet_v1 failed to export int8 issue

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/onnx/onnx_graph.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/onnx/onnx_graph.py
@@ -20,6 +20,7 @@
 import collections
 import logging
 import six
+import re
 import numpy as np
 
 from onnx import helper, numpy_helper, AttributeProto, TensorProto
@@ -1252,6 +1253,10 @@ class OnnxGraph:
 
         input_dequantize_node = self.get_node_by_output(conv_node.input[0])
         weight_dequantize_node = self.get_node_by_output(conv_node.input[1])
+        if re.search(r"\w+:\d+", input_dequantize_node.input[1]):
+            input_dequantize_node.input[1] = input_dequantize_node.input[1].rsplit(':', 1)[0]
+        if re.search(r"\w+:\d+", weight_dequantize_node.input[1]):
+            weight_dequantize_node.input[1] = weight_dequantize_node.input[1].rsplit(':', 1)[0]
         input_scale = self.get_node_by_name(
             input_dequantize_node.input[1]).get_tensor_value(as_list=False)
         weight_scale = self.get_node_by_name(


### PR DESCRIPTION
## Type of Change

bug fix 
API not changed

## Description

ILITV-2909: TF2ONNX ssd_mobilenet_v1 failed due to 'NoneType' object has no attribute 'get_tensor_value'

## Expected Behavior & Potential Risk

Tensorflow ssd_mobilenet_v1 int8 model can be exported to onnx int8 model.

## How has this PR been tested?

Pre-CI and ssd_mobilenet_v1 model export test.

## Dependency Change?

None.
