### PR TITLE
Update email display to mailto links in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,5 +153,5 @@ q_model = fit(
 
 ## Research Collaborations
 
-Welcome to raise any interesting research ideas on model compression techniques and feel free to reach us (inc.maintainers@intel.com). Look forward to our collaborations on Intel Neural Compressor!
+Welcome to raise any interesting research ideas on model compression techniques and feel free to reach us ([inc.maintainers@intel.com](mailto:inc.maintainers@intel.com)). Look forward to our collaborations on Intel Neural Compressor!
 

--- a/docs/source/CODE_OF_CONDUCT.md
+++ b/docs/source/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project maintainers at inc.maintainers@intel.com. All
+reported by contacting the project maintainers at [inc.maintainers@intel.com](mailto:inc.maintainers@intel.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/docs/source/CONTRIBUTING.md
+++ b/docs/source/CONTRIBUTING.md
@@ -42,7 +42,7 @@ any library dependency introduced or removed
 ## Support
 
 Submit your questions, feature requests, and bug reports to the
-[GitHub issues](https://github.com/intel/neural-compressor/issues) page. You may also reach out to [Maintainers](inc.maintainers@intel.com).
+[GitHub issues](https://github.com/intel/neural-compressor/issues) page. You may also reach out to [Maintainers](mailto:inc.maintainers@intel.com).
 
 ## Contributor Covenant Code of Conduct
 

--- a/docs/source/releases_info.md
+++ b/docs/source/releases_info.md
@@ -11,7 +11,7 @@ View new feature information and release downloads for the latest and previous r
 
 > <https://github.com/intel/neural-compressor/releases>
 
-Contact inc.maintainers@intel.com if you need additional assistance.
+Contact [inc.maintainers@intel.com](mailto:inc.maintainers@intel.com) if you need additional assistance.
 
 ## Known Issues
 


### PR DESCRIPTION
## Type of Change

Documentation change

## Description

This pull request implements changes to the documentation by updating email references with `mailto` links. The specific modifications include: 
- Adding `mailto` link on the [release info page](https://intel.github.io/neural-compressor/latest/docs/source/releases_info.html). 
- Adding `mailto` link on the [welcoming page](https://intel.github.io/neural-compressor/latest/docs/source/Welcome.html#research-collaborations).
- Adding `mailto` link on the [Code of Conduct page](https://intel.github.io/neural-compressor/latest/docs/source/Welcome.html#research-collaborations). 
- Fixing a broken email link on the [Contribution page](https://intel.github.io/neural-compressor/latest/docs/source/CONTRIBUTING.html#support).

## Expected Behavior & Potential Risk

Links are pointing to emails.

## How has this PR been tested?

Checking the above links.

## Dependency Change?

Not relevant.
