### PR TITLE
Fix ITEX Quantize/ Dequantize before BN u8 issue

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
@@ -216,13 +216,10 @@ class GenerateGraphWithQDQPattern(GraphRewriterBase):
                 input1_node = self.node_name_mapping[node.input[1].rsplit(':', 1)[0]].node
             else:
                 input1_node = self.node_name_mapping[node.input[1]].node
-            if input0_node.op in ("AvgPool", "MaxPool"):
-                return self._find_relu_node(input0_node)
-            if input1_node.op in ("AvgPool", "MaxPool"):
-                return self._find_relu_node(input1_node)
-            if input1_node.op in ('BiasAdd', 'Add', 'AddV2', 'AddN'):
+            if input0_node.op in ('BiasAdd', 'Add', 'AddV2', 'AddN') or \
+               input1_node.op in ('BiasAdd', 'Add', 'AddV2', 'AddN'):
                 return False
-            return self._find_relu_node(input1_node)
+            return self._find_relu_node(input0_node) and self._find_relu_node(input1_node)
         elif self._check_op_list(node.op) or (self.itex_mode and node.op in ('Add', 'AddV2')):
             if node.op == 'ConcatV2':
                 find_relu = False


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

[ILITV-2913](https://jira.devtools.intel.com/browse/ILITV-2913): [ITEX][INT8] Quantize/ Dequantize before BN should be s8, rather than u8

## Expected Behavior & Potential Risk

The Quantize/ Dequantize before BN change to s8.

## How has this PR been tested?

Local test icv-emotions-recognition-0002 model, pre-CI and OOB extension test.

## Dependency Change?

No.
