### PR TITLE
Fix transformer_lt mlperf model two outputs issue

### DIFF
--- a/examples/tensorflow/nlp/transformer_lt_mlperf/quantization/ptq/run_inference.py
+++ b/examples/tensorflow/nlp/transformer_lt_mlperf/quantization/ptq/run_inference.py
@@ -314,8 +314,9 @@ def main(unused_args):
                                       batch_size = FLAGS.batch_size)
 
         conf = PostTrainingQuantConfig(inputs=['input_tokens'],
-                                        outputs=['model/Transformer/strided_slice_15'],
-                                        calibration_sampling_size=[500])
+                                        outputs=['model/Transformer/strided_slice_15', 'model/Transformer/strided_slice_16'],
+                                        calibration_sampling_size=[500]
+                                        )
         q_model = quantization.fit(graph, conf=conf, calib_dataloader=calib_dataloader,
                     eval_func=eval_func)
         try:


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

The transformer_lt mlperf fp32 model has two outputs, but the quantized int8 model only has one output.

## Expected Behavior & Potential Risk

The quantized int8 model has two outputs 'model/Transformer/strided_slice_15', 'model/Transformer/strided_slice_16'

## How has this PR been tested?

transformer_lt mlperf model test, pre-CI and extension test.

## Dependency Change?

No.
