### PR TITLE
Support dictionary inputs for IPEX quantization

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -138,11 +138,15 @@ def get_example_inputs(model, dataloader):
             output = pytorch_forward_wrapper(model,
                                              input)
             if isinstance(input, (dict, UserDict)): # pragma: no cover
-                assert version.release >= Version("2.0.1").release, \
-                "INC support IPEX version >= 1.12.0"
+                assert version.release <= Version("1.12.0").release, \
+                "INC support dictionary inputs for IPEX version >= 1.12.0"
                 if "label" in input.keys():
                     input.pop("label")
-                return dict(input)
+                if version.release <= Version("2.0.1").release:
+                    return tuple(input.values())
+                else:
+                    return dict(input)
+
             if isinstance(input, (list, tuple)):
                 return tuple(input)
             if isinstance(input, torch.Tensor):
@@ -152,12 +156,15 @@ def get_example_inputs(model, dataloader):
         for idx, input in enumerate(dataloader):
             output = pytorch_forward_wrapper(model,
                                      input)
-            if isinstance(input, dict) or isinstance(input, UserDict): # pragma: no cover
+            if isinstance(input, (dict, UserDict)): # pragma: no cover
                 assert version.release >= Version("1.12.0").release, \
                 "INC support IPEX version >= 1.12.0"
                 if "label" in input.keys():
                     input.pop("label")
-                return dict(input)
+                if version.release <= Version("2.0.1").release:
+                    return tuple(input.values())
+                else:
+                    return dict(input)
             if isinstance(input, list) or isinstance(input, tuple):
                 return tuple(input)
             if isinstance(input, torch.Tensor):

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -138,8 +138,8 @@ def get_example_inputs(model, dataloader):
             output = pytorch_forward_wrapper(model,
                                              input)
             if isinstance(input, (dict, UserDict)): # pragma: no cover
-                assert version.release <= Version("1.12.0").release, \
-                "INC support dictionary inputs for IPEX version >= 1.12.0"
+                assert version.release >= Version("1.12.0").release, \
+                "INC support IPEX version >= 1.12.0"
                 if "label" in input.keys():
                     input.pop("label")
                 if version.release <= Version("2.0.1").release:

--- a/test/ipex/test_adaptor_ipex.py
+++ b/test/ipex/test_adaptor_ipex.py
@@ -273,7 +273,7 @@ class TestPytorchIPEX_1_12_Adaptor(unittest.TestCase):
             calib_dataloader=calib_dataloader,
         )
 
-    @unittest.skipIf(IPEX_VERSION.release <= Version("2.0.100").release,
+    @unittest.skipIf(IPEX_VERSION.release < Version("2.1.0").release,
                  "Please use Intel extension for Pytorch version higher or equal to 2.1.0")
     def test_dict_inputs_for_model(self):
         model = AutoModelForSequenceClassification.from_pretrained(
@@ -291,6 +291,30 @@ class TestPytorchIPEX_1_12_Adaptor(unittest.TestCase):
             calib_dataloader=dummy_dataloader,
         )
         q_model.save('./saved')
+
+    @unittest.skipIf(IPEX_VERSION.release < Version("2.1.0").release,
+                 "Please use Intel extension for Pytorch version higher or equal to 2.1.0")
+    def test_dict_inputs_for_model(self):
+        model = AutoModelForSequenceClassification.from_pretrained(
+            MODEL_NAME
+        )
+        example_inputs = DummyDataloader()[0]
+        from neural_compressor import PostTrainingQuantConfig, quantization
+
+        def calib_func(p_model):
+            p_model(**example_inputs)
+
+        conf = PostTrainingQuantConfig(
+            backend="ipex",
+            example_inputs=example_inputs
+        )
+        q_model = quantization.fit(
+            model,
+            conf,
+            calib_func=calib_func,
+        )
+        q_model.save('./saved')
+    
 
 
 if __name__ == "__main__":

--- a/test/ipex/test_adaptor_ipex.py
+++ b/test/ipex/test_adaptor_ipex.py
@@ -4,11 +4,12 @@ import shutil
 import torch
 import torch.utils.data as data
 import unittest
+from neural_compressor import set_workspace
 from neural_compressor.experimental import common
-from packaging.version import Version
 from neural_compressor.utils.utility import LazyImport
 from neural_compressor.conf.pythonic_config import config
 from neural_compressor.utils.pytorch import load
+from packaging.version import Version
 from transformers import (
     AutoModelForSequenceClassification,
     AutoTokenizer,
@@ -88,6 +89,7 @@ class TestPytorchIPEX_1_10_Adaptor(unittest.TestCase):
         config.quantization.backend = 'ipex'
         config.quantization.approach = 'post_training_static_quant'
         config.quantization.use_bf16 = False
+        set_workspace("./saved")
 
     @classmethod
     def tearDownClass(self):
@@ -123,6 +125,7 @@ class TestPytorchIPEX_1_12_Adaptor(unittest.TestCase):
         config.quantization.accuracy_criterion.higher_is_better = False
         config.quantization.approach = 'post_training_static_quant'
         config.quantization.use_bf16 = False
+        set_workspace("./saved")
 
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
## Type of Change

Support dictionary inputs for IPEX quantization 
No API changed

## Description

Support dictionary inputs for IPEX quantization, since IPEX had support it in master branch.

## Expected Behavior & Potential Risk

Quantize model  successfully with IPEX backend and dictionary inputs.

## How has this PR been tested?

UT tested

## Dependency Change?

IPEX commit ID: 2.1.0+gite5b169e
