### PR TITLE
fix smooth quant calibration issue

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3043,7 +3043,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                         smooth_quant_args = self.recipes.get('smooth_quant_args', {})
                         folding = smooth_quant_args.get('folding', False)
                         if not folding:
-                            static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
+                            x_observer = torch.ao.quantization.MinMaxObserver()
+                            static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5, act_observer=x_observer)
                             if not hasattr(tmp_model, '_smoothquant_optimized') \
                               or not tmp_model._smoothquant_optimized:
                                 # to make sure ipex_config.json is based on pre-optimized model
@@ -3216,7 +3217,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                 module._recover_sq_linear()
 
         # Rebuild the config json after pre-optimize algo (SmoothQuant), model is changed.
-        static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
+        x_observer = torch.ao.quantization.MinMaxObserver()
+        static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5, act_observer=x_observer)
         q_model = ipex.quantization.prepare(q_model, static_qconfig, \
                                 example_inputs=self.example_inputs, inplace=True)
 

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3121,7 +3121,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                         folding = smooth_quant_args.get('folding', False)
                         if not folding:
                             x_observer = torch.ao.quantization.MinMaxObserver()
-                            static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5, act_observer=x_observer)
+                            static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5, \
+                                                                                  act_observer=x_observer)
                             if not hasattr(tmp_model, '_smoothquant_optimized') \
                               or not tmp_model._smoothquant_optimized:
                                 # to make sure ipex_config.json is based on pre-optimized model


### PR DESCRIPTION
## Type of Change

for opt and some models, when make smoothquant calibration with ipex, the inference only 1 time success due to the default histogramobserver.
will offline test llama, gptj, bloom.

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
