### PR TITLE
Fixed trace issue when input is dictionary

### DIFF
--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -816,9 +816,9 @@ class GraphTrace:
     def trace(self, model, dummy_input):
         traced_model = None
         optimize_numerics = False
-        if isinstance(dummy_input, dict):
+        if isinstance(dummy_input, dict) or isinstance(dummy_input, UserDict):
             try:
-                traced_model = torch.jit.trace(model, dummy_input["input_ids"], strict=False)
+                traced_model = torch.jit.trace(model, example_kwarg_inputs=dict(dummy_input), strict=False)
                 traced_model = torch.jit.freeze(traced_model.eval(), optimize_numerics=optimize_numerics)
             except:
                 pass


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

When Smoothquant is on and folding is True, model tracing for obtaining quantizable ops does not work when the input is a dictionary.

## Expected Behavior & Potential Risk

Smoothquant will work when the input to the model is dictionary.


