### PR TITLE
Fix for layernorm skip connections in sq

### DIFF
--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -858,7 +858,8 @@ class GraphTrace:
                     # Check if parent has multiple children of unsupported layers
                     set_inp_type = set(dict_inp[parent])
                     set_inp_type.discard('aten::size')
-                    if (set_inp_type.intersection(self.could_absorb_layers) == set_inp_type) or (set_inp_type.intersection(self.skip_ops_to_find_absorb) == set_inp_type):
+                    if ((set_inp_type.intersection(self.could_absorb_layers) == set_inp_type) or
+                       (set_inp_type.intersection(self.skip_ops_to_find_absorb) == set_inp_type)):
                         prev_absorb_layer.append(parent)
                     else:
                         prev_absorb_layer.append(None)


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

When folding is enabled in Smoothquant, layer norms are used as absorbing layers for linear layers. However, when there are skip connections from the layer_norms, i.e., the output of layer norm goes to multiple ops, smoothquant quant transform produces wrong results. 

An example graph is shown below:

![image](https://github.com/intel/neural-compressor/assets/31421551/759317ec-2fcc-46ef-b729-6f96370e94a2)

which occurs in the BridgeTower model. This PR checks if any layer norm ops have multiple children, in which case, it is not used as absorbing layer.

## Expected Behavior & Potential Risk

Smoothquant transform won't produce incorrect results when an absorb layer norm has skip connections


## Dependency Change?

This PR works best after applying the following PRs: #961 and #954 
