### PR TITLE
Fixed mismatch absorb layers due to tracing and named modules

### DIFF
--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -722,6 +722,13 @@ class TorchSmoothQuant:
                     save_input_output = True
 
                 input_maxes = self._calibrate(self.absorb_to_layer, calib_iter, save_input_output)
+
+                # Check if input_maxes match self.absorb_to_layer (due to self._get_all_layer_names use layer tree instead of forward_path)
+                if not folding:
+                    diff_modules = set(self.absorb_to_layer.keys()).difference(input_maxes.keys())
+                    for d in diff_modules:
+                        del self.absorb_to_layer[d]
+                        
                 if alpha == 'auto':
                     self.alpha_per_layer = self._auto_tune_alpha(input_maxes, **auto_alpha_args)  ##save the alpha
 


### PR DESCRIPTION
## Type of Change

A temporary fix for Smoothquant feature

## Description

The issue happens when folding is False and the model has torch.nn.MultiheadAttention. In that case, INC can't detect linear layers in torch.nn.MultiheadAttention and there happens to be a mismatch between input_maxes and absorb_to_layers. This PR matches those two dictionaries.

