### PR TITLE
Support mixed precision op name/type dict option

### DIFF
--- a/neural_compressor/config.py
+++ b/neural_compressor/config.py
@@ -1650,6 +1650,32 @@ class MixedPrecisionConfig(object):
         accuracy_criterion (AccuracyCriterion object, optional): Accuracy constraint settings,
                                                                  it won't work if there is no accuracy tuning process.
         excluded_precisions (list, optional): Precisions to be excluded during mix precision conversion, default is [].
+        op_type_dict (dict, optional): Tuning constraints on optype-wise  for advance user to reduce tuning space.
+                      User can specify the quantization config by op type:
+                      example:
+                      {
+                          'Conv': {
+                              'weight': {
+                                  'dtype': ['fp32']
+                              },
+                              'activation': {
+                                  'dtype': ['fp32']
+                              }
+                          }
+                      }
+        op_name_dict (dict, optional): Tuning constraints on op-wise for advance user to reduce tuning space.
+                      User can specify the quantization config by op name:
+                      example:
+                      {
+                          "layer1.0.conv1": {
+                              "activation": {
+                                  "dtype": ["fp32"]
+                              },
+                              "weight": {
+                                  "dtype": ["fp32"]
+                              }
+                          },
+                      }
 
     Example:
         from neural_compressor import mix_precision
@@ -1804,10 +1830,12 @@ class MixedPrecisionConfig(object):
 
     @property
     def op_name_dict(self):
+        """Get op name dict."""
         return self._op_name_dict
 
     @op_name_dict.setter
     def op_name_dict(self, op_name_dict):
+        """Set op name dict."""
         if op_name_dict is None:
             self._op_name_dict = op_name_dict
         elif isinstance(op_name_dict, dict):
@@ -1820,10 +1848,12 @@ class MixedPrecisionConfig(object):
 
     @property
     def op_type_dict(self):
+        """Get op type dict."""
         return self._op_type_dict
 
     @op_type_dict.setter
     def op_type_dict(self, op_type_dict):
+        """Set op type dict."""
         if op_type_dict is None:
             self._op_type_dict = op_type_dict
         elif isinstance(op_type_dict, dict):

--- a/neural_compressor/config.py
+++ b/neural_compressor/config.py
@@ -1638,7 +1638,7 @@ class MixedPrecisionConfig(object):
         device (str, optional): Device for execution.
                                 Support 'cpu' and 'gpu', default is 'cpu'.
         backend (str, optional): Backend for model execution.
-                                 Support 'default', 'itex', 'ipex', 'onnxrt_trt_ep', 'onnxrt_cuda_ep',
+                                 Support 'default', 'itex', 'onnxrt_trt_ep', 'onnxrt_cuda_ep',
                                  default is 'default'.
         precisions ([str, list], optional): Target precision for mix precision conversion.
                                    Support 'bf16' and 'fp16', default is 'bf16'.
@@ -1668,7 +1668,9 @@ class MixedPrecisionConfig(object):
                  outputs=[],
                  tuning_criterion=tuning_criterion,
                  accuracy_criterion=accuracy_criterion,
-                 excluded_precisions=[]):
+                 excluded_precisions=[],
+                 op_name_dict={},
+                 op_type_dict={}):
         """Init a MixedPrecisionConfig object."""
         self.inputs = inputs
         self.outputs = outputs
@@ -1681,6 +1683,8 @@ class MixedPrecisionConfig(object):
         self.use_bf16 = "bf16" in self.precisions
         self.model_name = model_name
         self._framework = None
+        self.op_name_dict = op_name_dict
+        self.op_type_dict = op_type_dict
 
     @property
     def precisions(self):
@@ -1798,6 +1802,37 @@ class MixedPrecisionConfig(object):
             self._excluded_precisions = excluded_precisions
             self._use_bf16 = "bf16" not in excluded_precisions
 
+    @property
+    def op_name_dict(self):
+        return self._op_name_dict
+
+    @op_name_dict.setter
+    def op_name_dict(self, op_name_dict):
+        if op_name_dict is None:
+            self._op_name_dict = op_name_dict
+        elif isinstance(op_name_dict, dict):
+            for k, v in op_name_dict.items():
+                ops_schema.validate(v)
+            self._op_name_dict = op_name_dict
+        else:
+            assert False, ("Type of op_name_dict should be dict but not {}, ".format(
+                type(op_name_dict)))
+
+    @property
+    def op_type_dict(self):
+        return self._op_type_dict
+
+    @op_type_dict.setter
+    def op_type_dict(self, op_type_dict):
+        if op_type_dict is None:
+            self._op_type_dict = op_type_dict
+        elif isinstance(op_type_dict, dict):
+            for k, v in op_type_dict.items():
+                ops_schema.validate(v)
+            self._op_type_dict = op_type_dict
+        else:
+            assert False, ("Type of op_type_dict should be dict but not {}".format(
+                type(op_type_dict)))
 
 class ExportConfig:
     """Common Base Config for Export.

--- a/test/mixed_precision/test_mixed_precision.py
+++ b/test/mixed_precision/test_mixed_precision.py
@@ -374,6 +374,7 @@ class TestMixedPrecision(unittest.TestCase):
     @unittest.skipIf(PT_VERSION.release < Version("1.11.0").release,
       "Please use PyTroch 1.11 or higher version for mixed precision.")
     def test_mixed_precision_with_eval_func_pt(self):
+        torch = LazyImport("torch")
         def eval(model):
             return 0.5
 
@@ -384,7 +385,30 @@ class TestMixedPrecision(unittest.TestCase):
             eval_func=eval,
         )
         self.assertTrue(isinstance(output_model.model.fc, BF16ModuleWrapper))
-
+        op_name_dict = {"fc":{
+                                "activation": {"dtype": ["fp32"]},
+                                "weight": {"dtype": ["fp32"]},
+                                    }
+                        }
+        conf = MixedPrecisionConfig(op_name_dict=op_name_dict)
+        output_model = mix_precision.fit(
+            self.pt_model,
+            conf,
+            eval_func=eval,
+        )
+        self.assertTrue(isinstance(output_model.model.fc.weight.dtype, type(torch.float32)))
+        op_type_dict = {"Linear":{
+                                "activation": {"dtype": ["fp32"]},
+                                "weight": {"dtype": ["fp32"]},
+                                    }
+                        }
+        conf = MixedPrecisionConfig(op_type_dict=op_type_dict)
+        output_model = mix_precision.fit(
+            self.pt_model,
+            conf,
+            eval_func=eval,
+        )
+        self.assertTrue(isinstance(output_model.model.fc.weight.dtype, type(torch.float32)))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Type of Change

feature: add op name/type dict option to `MixPrecisionConfig` api, the request from [How to ignore custom layer during quantization · Issue #953 · intel/neural-compressor (github.com)](https://github.com/intel/neural-compressor/issues/953)

## Description
set the op to fp32 datatype when mixprecision quantization
usage:
```
# op_name_dict
        op_name_dict = {"fc":{
                                "activation": {"dtype": ["fp32"]},
                                "weight": {"dtype": ["fp32"]},
                                    }
                        }
        conf = MixedPrecisionConfig(op_name_dict=op_name_dict)
        output_model = mix_precision.fit(
            model,
            conf,
            eval_func=eval,
        )
# op_dype_dict
        op_type_dict = {"Linear":{
                                "activation": {"dtype": ["fp32"]},
                                "weight": {"dtype": ["fp32"]},
                                    }
                        }
        conf = MixedPrecisionConfig(op_type_dict=op_type_dict)
        output_model = mix_precision.fit(
            model,
            conf,
            eval_func=eval,
        )
```

## Expected Behavior & Potential Risk

CI pass

## How has this PR been tested?

CI & local test

## Dependency Change?

No
