### PR TITLE
Fix bug in ONNXRT NLP example for onnxruntime1.14.1

### DIFF
--- a/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/main.py
@@ -398,6 +398,7 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
+        # optimize model
         from onnxruntime.transformers import optimizer
         from onnxruntime.transformers.fusion_options import FusionOptions
         opt_options = FusionOptions('bert')

--- a/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/main.py
@@ -398,20 +398,26 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions('bert')
-            opt_options.enable_embed_layer_norm = False
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions('bert')
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                'bert',
-                num_heads=12,
-                hidden_size=768,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            'bert',
+            num_heads=12,
+            hidden_size=768,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/bert/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/bert/quantization/ptq_static/main.py
@@ -405,20 +405,27 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions("bert")
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions("bert")
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                "bert",
-                num_heads=12,
-                hidden_size=768,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            "bert",
+            num_heads=12,
+            hidden_size=768,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/distilbert/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/distilbert/quantization/ptq_dynamic/main.py
@@ -380,20 +380,27 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions("bert")
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions("bert")
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                "bert",
-                num_heads=12,
-                hidden_size=768,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            "bert",
+            num_heads=12,
+            hidden_size=768,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/distilbert/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/distilbert/quantization/ptq_static/main.py
@@ -387,20 +387,27 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions("bert")
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions("bert")
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                "bert",
-                num_heads=12,
-                hidden_size=768,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            "bert",
+            num_heads=12,
+            hidden_size=768,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_dynamic/main.py
@@ -207,13 +207,13 @@ def main():
     
     logger.info("Training/evaluation parameters %s", args)
             
-    model = onnx.load(args.model_path)
     ds = load_and_cache_examples(args, tokenizer, evaluate=True)
 
     def eval_func(model):
         return evaluate(args, model, tokenizer)
 
     if args.benchmark:
+        model = onnx.load(args.model_path)
         if args.mode == 'performance':
             from neural_compressor.benchmark import fit
             from neural_compressor.config import BenchmarkConfig
@@ -227,7 +227,7 @@ def main():
             evaluate(args, model, tokenizer)
         
     if args.tune:
-        # GPT2 optimizer
+        # optimize model
         from onnxruntime.transformers import optimizer
         from onnxruntime.transformers.fusion_options import FusionOptions
         opt_options = FusionOptions('gpt2')
@@ -239,7 +239,16 @@ def main():
             num_heads=12,
             hidden_size=768,
             optimization_options=opt_options)
-        model = model_optimizer.model  
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            ort.InferenceSession(model.SerializeToString(), providers=ort.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
+            model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig
         from neural_compressor.config import AccuracyCriterion

--- a/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/main.py
@@ -206,13 +206,13 @@ def main():
     
     logger.info("Training/evaluation parameters %s", args)
             
-    model = onnx.load(args.model_path)
     ds = load_and_cache_examples(args, tokenizer, evaluate=True)
 
     def eval_func(model):
         return evaluate(args, model, tokenizer)
 
     if args.benchmark:
+        model = onnx.load(args.model_path)
         if args.mode == 'performance':
             from neural_compressor.benchmark import fit
             from neural_compressor.config import BenchmarkConfig
@@ -226,7 +226,7 @@ def main():
             evaluate(args, model, tokenizer)
         
     if args.tune:
-        # GPT2 optimizer
+        # optimize model
         from onnxruntime.transformers import optimizer
         from onnxruntime.transformers.fusion_options import FusionOptions
         opt_options = FusionOptions('gpt2')
@@ -238,7 +238,16 @@ def main():
             num_heads=12,
             hidden_size=768,
             optimization_options=opt_options)
-        model = model_optimizer.model  
+        model = model_optimizer.model
+
+        # check the optimized model is valid
+        try:
+            ort.InferenceSession(model.SerializeToString(), providers=ort.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
+            model = onnx.load(args.model_path)
 
         from neural_compressor import quantization
         from neural_compressor.config import AccuracyCriterion, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/main.py
@@ -453,20 +453,27 @@ def main():
         return metrics['f1']
 
     if model_args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions('bert')
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions('bert')
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                model_args.input_model,
-                'bert',
-                num_heads=model_args.num_heads,
-                hidden_size=model_args.hidden_size,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            model_args.input_model,
+            'bert',
+            num_heads=model_args.num_heads,
+            hidden_size=model_args.hidden_size,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(model_args.input_model)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/main.py
@@ -384,21 +384,28 @@ if __name__ == "__main__":
 
 
     if args.tune:
-        if ort.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            model_type = 'bart' if args.model_name_or_path == 'Intel/bart-large-mrpc' else 'bert'
-            opt_options = FusionOptions(model_type)
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        model_type = 'bart' if args.model_name_or_path == 'Intel/bart-large-mrpc' else 'bert'
+        opt_options = FusionOptions(model_type)
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                model_type,
-                num_heads=args.num_heads,
-                hidden_size=args.hidden_size,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            model_type,
+            num_heads=args.num_heads,
+            hidden_size=args.hidden_size,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+
+        # check the optimized model is valid
+        try:
+            ort.InferenceSession(model.SerializeToString(), providers=ort.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/requirements.txt
@@ -8,3 +8,4 @@ sympy
 onnxruntime-extensions; python_version < '3.10'
 numpy==1.23.5
 sentencepiece
+protobuf<=3.20.3

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/main.py
@@ -390,21 +390,28 @@ if __name__ == "__main__":
 
 
     if args.tune:
-        if ort.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            model_type = 'bart' if args.model_name_or_path == 'Intel/bart-large-mrpc' else 'bert'
-            opt_options = FusionOptions(model_type)
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        model_type = 'bart' if args.model_name_or_path == 'Intel/bart-large-mrpc' else 'bert'
+        opt_options = FusionOptions(model_type)
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                model_type,
-                num_heads=args.num_heads,
-                hidden_size=args.hidden_size,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            model_type,
+            num_heads=args.num_heads,
+            hidden_size=args.hidden_size,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            ort.InferenceSession(model.SerializeToString(), providers=ort.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                           "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
@@ -8,3 +8,4 @@ sympy
 onnxruntime-extensions; python_version < '3.10'
 numpy==1.23.5
 sentencepiece
+protobuf<=3.20.3

--- a/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmft/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmft/quantization/ptq_dynamic/main.py
@@ -418,6 +418,7 @@ def main():
             return outputs.metrics['f1']
 
         if model_args.tune:
+            # optimize model
             from onnxruntime.transformers import optimizer
             from onnxruntime.transformers.fusion_options import FusionOptions
             opt_options = FusionOptions('bert')
@@ -429,6 +430,15 @@ def main():
                 hidden_size=768,
                 optimization_options=opt_options)
             onnx_model = model_optimizer.model
+
+            # check the optimized model is valid
+            try:
+                onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+            except Exception as e:
+                logger.warning("Optimized model is invalid: {}. ".format(e))
+                logger.warning("Model optimizer will be skipped. " \
+                            "Try to upgrade onnxruntime to avoid this error")
+                onnx_model = onnx.load(model_args.input_model)
         
             from neural_compressor import quantization, PostTrainingQuantConfig
 

--- a/examples/onnxrt/nlp/mobilebert/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/mobilebert/quantization/ptq_dynamic/main.py
@@ -387,20 +387,27 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions("bert")
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions("bert")
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                "bert",
-                num_heads=4,
-                hidden_size=512,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            "bert",
+            num_heads=4,
+            hidden_size=512,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                        "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/main.py
@@ -394,7 +394,7 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
+        try:
             from onnxruntime.transformers import optimizer
             from onnxruntime.transformers.fusion_options import FusionOptions
             opt_options = FusionOptions("bert")
@@ -407,7 +407,9 @@ if __name__ == "__main__":
                 hidden_size=512,
                 optimization_options=opt_options)
             model = model_optimizer.model
-        else:
+        except Exception as e:
+            logger.warning("Model optimizer will be skipped due to error {}. " \
+                        "Try to upgrade onnxruntime to avoid this error".format(e))
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/main.py
@@ -394,22 +394,27 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        try:
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions("bert")
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions("bert")
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                "bert",
-                num_heads=4,
-                hidden_size=512,
-                optimization_options=opt_options)
-            model = model_optimizer.model
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            "bert",
+            num_heads=4,
+            hidden_size=512,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
         except Exception as e:
-            logger.warning("Model optimizer will be skipped due to error {}. " \
-                        "Try to upgrade onnxruntime to avoid this error".format(e))
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                        "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq_dynamic/gpt2.py
+++ b/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq_dynamic/gpt2.py
@@ -249,22 +249,27 @@ def main():
             evaluate(args, model, tokenizer)
         
     if args.tune:
-        try:
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions('gpt2')
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions('gpt2')
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                'gpt2',
-                num_heads=12,
-                hidden_size=768,
-                optimization_options=opt_options)
-            model = model_optimizer.model
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            'gpt2',
+            num_heads=12,
+            hidden_size=768,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+
+        # check the optimized model is valid
+        try:
+            ort.InferenceSession(model.SerializeToString(), providers=ort.get_available_providers())
         except Exception as e:
-            logger.warning("Model optimizer will be skipped due to error {}. " \
-                        "Try to upgrade onnxruntime to avoid this error".format(e))
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                        "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization

--- a/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq_dynamic/gpt2.py
+++ b/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq_dynamic/gpt2.py
@@ -249,7 +249,7 @@ def main():
             evaluate(args, model, tokenizer)
         
     if args.tune:
-        if ort.__version__ <= '1.13.1':
+        try:
             from onnxruntime.transformers import optimizer
             from onnxruntime.transformers.fusion_options import FusionOptions
             opt_options = FusionOptions('gpt2')
@@ -262,7 +262,9 @@ def main():
                 hidden_size=768,
                 optimization_options=opt_options)
             model = model_optimizer.model
-        else:
+        except Exception as e:
+            logger.warning("Model optimizer will be skipped due to error {}. " \
+                        "Try to upgrade onnxruntime to avoid this error".format(e))
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization

--- a/examples/onnxrt/nlp/roberta/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/roberta/quantization/ptq_dynamic/main.py
@@ -387,20 +387,27 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions("bert")
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions("bert")
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                "bert",
-                num_heads=12,
-                hidden_size=768,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            "bert",
+            num_heads=12,
+            hidden_size=768,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                        "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/examples/onnxrt/nlp/roberta/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/roberta/quantization/ptq_static/main.py
@@ -394,20 +394,27 @@ if __name__ == "__main__":
             print("Accuracy: %.5f" % acc_result)
 
     if args.tune:
-        if onnxruntime.__version__ <= '1.13.1':
-            from onnxruntime.transformers import optimizer
-            from onnxruntime.transformers.fusion_options import FusionOptions
-            opt_options = FusionOptions("bert")
-            opt_options.enable_embed_layer_norm = False
+        # optimize model
+        from onnxruntime.transformers import optimizer
+        from onnxruntime.transformers.fusion_options import FusionOptions
+        opt_options = FusionOptions("bert")
+        opt_options.enable_embed_layer_norm = False
 
-            model_optimizer = optimizer.optimize_model(
-                args.model_path,
-                "bert",
-                num_heads=12,
-                hidden_size=768,
-                optimization_options=opt_options)
-            model = model_optimizer.model
-        else:
+        model_optimizer = optimizer.optimize_model(
+            args.model_path,
+            "bert",
+            num_heads=12,
+            hidden_size=768,
+            optimization_options=opt_options)
+        model = model_optimizer.model
+        
+        # check the optimized model is valid
+        try:
+            onnxruntime.InferenceSession(model.SerializeToString(), providers=onnxruntime.get_available_providers())
+        except Exception as e:
+            logger.warning("Optimized model is invalid: {}. ".format(e))
+            logger.warning("Model optimizer will be skipped. " \
+                        "Try to upgrade onnxruntime to avoid this error")
             model = onnx.load(args.model_path)
 
         from neural_compressor import quantization, PostTrainingQuantConfig

--- a/neural_compressor/adaptor/ox_utils/quantizer.py
+++ b/neural_compressor/adaptor/ox_utils/quantizer.py
@@ -90,6 +90,9 @@ class Quantizer:
         self.quantized_value_map = {}
         self.new_value_info = {}
 
+        # List of recalculated quantize weight for Gather op.
+        self.recalculate_quantized_value = []
+
         # QuantizeRange tensor name and zero tensor name for scale and zero point calculation.
         # Used when static is False
         self.fixed_qrange_uint8_name = "fixed_quantization_range_uint8"

--- a/neural_compressor/model/onnx_model.py
+++ b/neural_compressor/model/onnx_model.py
@@ -563,6 +563,10 @@ class ONNXModel(BaseModel):
                     self.match_parent_path(
                         start_node,
                         ["Add", "MatMul", "Reshape", "Transpose", "Reshape", "MatMul"],
+                        [0, None, 0, 0, 0, 0]),
+                    self.match_parent_path(
+                        start_node,
+                        ["Add", "MatMul", "Reshape", "Transpose", "Reshape", "MatMul"],
                         [1, None, 0, 0, 0, 0]),
                     ]
 


### PR DESCRIPTION
## Type of Change

bug fix
API not change

## Description
1. onnxruntime 1.14.1 optimize failed in some NLP models. The bug is fixed in https://github.com/microsoft/onnxruntime/issues/14959. In this PR, the optimized model will be checked for validity. If the optimized model is invalid, optimizer will be skipped.
2. refine block_wise info query in ORT.
3. refine int8 tensor recalculation in Gather op.

- [ILITV-2928](https://jira.devtools.intel.com/browse/ILITV-2928) [release test v2.2rc1][onnxrt v1.14.1] hf_deberta/hf_deberta_dynamic can't reach accuracy goal
- [ILITV-2927](https://jira.devtools.intel.com/browse/ILITV-2927) [release test v2.2rc1][onnxrt v1.14.1] hf_layoutlmv3 can't reach accuracy goal

## Expected Behavior & Potential Risk

pass extension test for onnx NLP models

## How has this PR been tested?

extension test 

## Dependency Change?

no
