### PR TITLE
limit transformers version for TF examples due to compatible issue

### DIFF
--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
@@ -1,3 +1,3 @@
 tensorflow
 datasets
-transformers
+transformers<=4.29.2


### PR DESCRIPTION
## Type of Change

bug fix

## Description

limit transformers version <= 4.29.2 for TF examples due to transformers 4.30.0 compatible issue

## Expected Behavior & Potential Risk

example test pass

## How has this PR been tested?

extension test

## Dependency Change?

No
