### PR TITLE
Support ipex mixed precision

### DIFF
--- a/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
+++ b/examples/pytorch/nlp/huggingface_models/question-answering/quantization/ptq_static/ipex/run_qa.py
@@ -642,8 +642,14 @@ def main():
         from neural_compressor.config import PostTrainingQuantConfig
         from neural_compressor import quantization
         dummy_input_ids = torch.ones((training_args.per_device_eval_batch_size, data_args.max_seq_length), dtype=torch.long)
+        dummy_token_type_ids = torch.ones((training_args.per_device_eval_batch_size, data_args.max_seq_length), dtype=torch.long)
         dummy_attention_mask = torch.ones((training_args.per_device_eval_batch_size, data_args.max_seq_length), dtype=torch.long)
-        example_inputs = {"input_ids": dummy_input_ids, "attention_mask": dummy_attention_mask}
+        if model.config.model_type == "distilbert":
+            example_inputs = {"input_ids": dummy_input_ids, "attention_mask": dummy_attention_mask}
+        elif model.config.model_type == "bert":
+            example_inputs = {"input_ids": dummy_input_ids, "token_type_ids":dummy_token_type_ids, "attention_mask": dummy_attention_mask}
+        else:
+            example_inputs = None  # please provide correct example_inputs if necessary.
         conf = PostTrainingQuantConfig(backend="ipex", calibration_sampling_size=800, example_inputs=example_inputs)
         q_model = quantization.fit(model,
                                    conf,

--- a/neural_compressor/adaptor/torch_utils/mixed_precision.py
+++ b/neural_compressor/adaptor/torch_utils/mixed_precision.py
@@ -32,9 +32,15 @@ def ipex_mixed_precision(model, calib_dataloader=None, example_inputs=None):
 
     with torch.no_grad(), torch.cpu.amp.autocast():
         if isinstance(example_inputs, dict):
-            mp_model = torch.jit.trace(mp_model, example_kwarg_inputs=example_inputs)
+            try:
+                mp_model = torch.jit.trace(mp_model, example_kwarg_inputs=example_inputs)
+            except:
+                mp_model = torch.jit.trace(mp_model, example_kwarg_inputs=example_inputs, strict=False)
         else:
-            mp_model = torch.jit.trace(mp_model, example_inputs)
+            try:
+                mp_model = torch.jit.trace(mp_model, example_inputs)
+            except:
+                mp_model = torch.jit.trace(mp_model, example_inputs, strict=False)
         mp_model = torch.jit.freeze(mp_model.eval())
     model._model = mp_model
     return model

--- a/neural_compressor/adaptor/torch_utils/mixed_precision.py
+++ b/neural_compressor/adaptor/torch_utils/mixed_precision.py
@@ -31,7 +31,10 @@ def ipex_mixed_precision(model, calib_dataloader=None, example_inputs=None):
     mp_model = ipex.optimize(mp_model, dtype=torch.bfloat16)
 
     with torch.no_grad(), torch.cpu.amp.autocast():
-        mp_model = torch.jit.trace(mp_model, example_inputs)
+        if isinstance(example_inputs, dict):
+            mp_model = torch.jit.trace(mp_model, example_kwarg_inputs=example_inputs)
+        else:
+            mp_model = torch.jit.trace(mp_model, example_inputs)
         mp_model = torch.jit.freeze(mp_model.eval())
     model._model = mp_model
     return model

--- a/neural_compressor/adaptor/torch_utils/mixed_precision.py
+++ b/neural_compressor/adaptor/torch_utils/mixed_precision.py
@@ -16,16 +16,13 @@
 # limitations under the License.
 
 from neural_compressor.utils.utility import LazyImport
-from neural_compressor.adaptor.pytorch import get_example_inputs
 ipex = LazyImport("intel_extension_for_pytorch")
 torch = LazyImport("torch")
 
-def ipex_mixed_precision(model, calib_dataloader=None, example_inputs=None):
+def ipex_mixed_precision(model, example_inputs=None):
     """The function is used for ipex mixed precision quantization."""
     model.eval()
     mp_model = model._model
-    if calib_dataloader is not None:
-        example_inputs = get_example_inputs(mp_model, calib_dataloader)
     if example_inputs is None:
         assert False, "please provide the correct example_inputs for torchscript mode"
     mp_model = ipex.optimize(mp_model, dtype=torch.bfloat16)

--- a/neural_compressor/adaptor/torch_utils/mixed_precision.py
+++ b/neural_compressor/adaptor/torch_utils/mixed_precision.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from neural_compressor.utils.utility import LazyImport
+from neural_compressor.adaptor.pytorch import get_example_inputs
+ipex = LazyImport("intel_extension_for_pytorch")
+torch = LazyImport("torch")
+
+def ipex_mixed_precision(model, calib_dataloader=None, example_inputs=None):
+    """The function is used for ipex mixed precision quantization."""
+    model.eval()
+    mp_model = model._model
+    if calib_dataloader is not None:
+        example_inputs = get_example_inputs(mp_model, calib_dataloader)
+    if example_inputs is None:
+        assert False, "please provide the correct example_inputs for torchscript mode"
+    mp_model = ipex.optimize(mp_model, dtype=torch.bfloat16)
+
+    with torch.no_grad(), torch.cpu.amp.autocast():
+        mp_model = torch.jit.trace(mp_model, example_inputs)
+        mp_model = torch.jit.freeze(mp_model.eval())
+    model._model = mp_model
+    return model

--- a/neural_compressor/config.py
+++ b/neural_compressor/config.py
@@ -1638,8 +1638,8 @@ class MixedPrecisionConfig(object):
         device (str, optional): Device for execution.
                                 Support 'cpu' and 'gpu', default is 'cpu'.
         backend (str, optional): Backend for model execution.
-                                 Support 'default', 'itex', 'onnxrt_trt_ep', 'onnxrt_cuda_ep',
-                                 default is 'default'.
+                                 Support 'default', 'itex', 'ipex', 'onnxrt_trt_ep', 'onnxrt_cuda_ep',
+                                 default is 'default', 'ipex' doesn't support tune.
         precisions ([str, list], optional): Target precision for mix precision conversion.
                                    Support 'bf16' and 'fp16', default is 'bf16'.
         model_name (str, optional): The name of the model. Default value is empty.
@@ -1676,6 +1676,7 @@ class MixedPrecisionConfig(object):
                               }
                           },
                       }
+        example_inputs (tensor|list|tuple|dict, optional): Example inputs used for tracing model. Defaults to None.
 
     Example:
         from neural_compressor import mix_precision
@@ -1696,7 +1697,8 @@ class MixedPrecisionConfig(object):
                  accuracy_criterion=accuracy_criterion,
                  excluded_precisions=[],
                  op_name_dict={},
-                 op_type_dict={}):
+                 op_type_dict={},
+                 example_inputs=None):
         """Init a MixedPrecisionConfig object."""
         self.inputs = inputs
         self.outputs = outputs
@@ -1711,6 +1713,7 @@ class MixedPrecisionConfig(object):
         self._framework = None
         self.op_name_dict = op_name_dict
         self.op_type_dict = op_type_dict
+        self.example_inputs = example_inputs
 
     @property
     def precisions(self):
@@ -1863,6 +1866,17 @@ class MixedPrecisionConfig(object):
         else:
             assert False, ("Type of op_type_dict should be dict but not {}".format(
                 type(op_type_dict)))
+
+    @property
+    def example_inputs(self):
+        """Get strategy_kwargs."""
+        return self._example_inputs
+
+    @example_inputs.setter
+    def example_inputs(self, example_inputs):
+        """Set example_inputs."""
+        self._example_inputs = example_inputs
+
 
 class ExportConfig:
     """Common Base Config for Export.

--- a/neural_compressor/strategy/auto_mixed_precision.py
+++ b/neural_compressor/strategy/auto_mixed_precision.py
@@ -131,7 +131,7 @@ class AutoMixedPrecisionTuneStrategy(TuneStrategy):
         """Traverse the tuning space according to auto-mixed precision strategy."""
         if self.config.backend == "ipex":
             self.best_qmodel = ipex_mixed_precision(
-                self.model, self.calib_dataloader, self.config.example_inputs)
+                self.model, self.config.example_inputs)
             if self.eval_dataloader or self.eval_func:
                 self._evaluate(self.best_qmodel)
             return

--- a/neural_compressor/strategy/strategy.py
+++ b/neural_compressor/strategy/strategy.py
@@ -33,6 +33,7 @@ import numpy as np
 import yaml
 
 from neural_compressor.adaptor.tensorflow import TensorFlowAdaptor
+from neural_compressor.config import MixedPrecisionConfig
 from .utils.constant import FALLBACK_RECIPES_SET
 from .utils.tuning_space import TuningSpace
 from .utils.tuning_structs import OpTuningConfig
@@ -322,6 +323,10 @@ class TuneStrategy(metaclass=TuneStrategyMeta):
         self._eval_baseline()
 
     def _check_tuning_status(self):
+        # ipex mix precision doesn't support tune.
+        if isinstance(self.config, MixedPrecisionConfig) and self.config.backend == "ipex":
+            logger.info("Intel extension for pytorch mixed precision doesn't support tune.")
+            return
         # got eval func
         if self.eval_func:
             self._not_tuning = False


### PR DESCRIPTION
## Type of Change

feature: 
1. add `example_inputs` for `MixPrecisionConfig` api.
2. improve ipex backend mix precision quantization, use `ipex.optimize()` to get bfloat16 model and make it to torchscript mode.
3. accept `tuple` and `dict` type as example_inputs to make torchscript model for mixed precision.
4. improve QA ipex example（support bert and distilbert）to make mixed precision now.

## Description
usage:
```
        conf = MixedPrecisionConfig(backend="ipex", example_inputs=torch.randn(1, 3, 224, 224))
        output_model = mix_precision.fit(
            self.pt_model,
            conf,
            eval_func=eval,  #optional
        )
```
`example_inputs` is necessary for ipex mixed precision quantization.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
