### PR TITLE
fix skipconnection bugs when folding=true

### DIFF
--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -26,7 +26,7 @@ except:
     import logging
 
     logger = logging.getLogger()
-from collections import UserDict
+from collections import UserDict, defaultdict
 
 
 def forward_wrapper(model, input, device='cpu'):
@@ -835,6 +835,13 @@ def get_parent(node):
         return None
     return list(node.inputs())[0].node()
 
+def get_parents(node):
+    if node.inputs() == None:
+        return None
+    elif len(list(node.inputs())) == 0:
+        return None
+    return list(node.inputs())
+
 
 class GraphTrace:
     """
@@ -898,16 +905,28 @@ class GraphTrace:
                     break
         return nodes
 
-    def get_prev_absorb_layer(self, nodes):
+    def get_prev_absorb_layer(self, nodes, dict_parent_kind=None):
         prev_absorb_layer = []
         for node in nodes:
             parent = get_parent(node)
+            parent_scopeName = parent.scopeName()
             while 1:
                 if parent.kind() in self.skip_ops_to_find_absorb:
                     parent = get_parent(parent)
                     continue
                 if parent.kind() in self.could_absorb_layers:
-                    prev_absorb_layer.append(parent)
+                    if dict_parent_kind:
+                        parent_out_kinds = set(dict_parent_kind[parent_scopeName])
+                        parent_out_kinds.discard('aten::size')
+                        if parent_out_kinds == parent_out_kinds.intersection(self.could_absorb_layers):
+                            prev_absorb_layer.append(parent)
+                        elif parent_out_kinds.intersection(self.skip_ops_to_find_absorb):
+                            prev_absorb_layer.append(parent) ##TODO: check other scenarios
+                        else: # When parent to multiple ops, sq transformation could be wrong.
+                            print(f"lyt_debug_FOUND: {parent.kind()}, {parent_out_kinds}, {parent_scopeName}")
+                            prev_absorb_layer.append(None)
+                    else:
+                        prev_absorb_layer.append(parent)
                 else:
                     prev_absorb_layer.append(None)
                 break
@@ -927,10 +946,22 @@ class GraphTrace:
         traced_model = self.trace(model, example_input)
         if traced_model == None:
             return None, None
+
+        dict_parent_kind = defaultdict(list)
+        for node in traced_model.graph.nodes():
+            parents_list = get_parents(node)
+            node_kind = node.kind()
+            if parents_list: #save input_kinds of all parent nodes
+                for parent_ in parents_list:
+                    parent = parent_.node()
+                    parent_kind = parent.kind()
+                    if 'prim' not in parent_kind:
+                        dict_parent_kind[parent.scopeName()].append(node_kind)
+
         aten_op_types = self.mapping_torch_module_to_aten(op_types)
         nodes_types = self.get_nodes(traced_model, aten_op_types)
         nodes = [node_type[0] for node_type in nodes_types]
-        nodes_prev_absorb = self.get_prev_absorb_layer(nodes)
+        nodes_prev_absorb = self.get_prev_absorb_layer(nodes, dict_parent_kind)
         absorb_to_layer = {}
         no_absorb_layers = []
         for index, absorb in enumerate(nodes_prev_absorb):

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -920,10 +920,9 @@ class GraphTrace:
                         parent_out_kinds.discard('aten::size')
                         if parent_out_kinds == parent_out_kinds.intersection(self.could_absorb_layers):
                             prev_absorb_layer.append(parent)
-                        elif parent_out_kinds.intersection(self.skip_ops_to_find_absorb):
-                            prev_absorb_layer.append(parent) ##TODO: check other scenarios
+                        # elif parent_out_kinds.intersection(self.skip_ops_to_find_absorb):
+                        #     prev_absorb_layer.append(parent) ##TODO: check other scenarios
                         else: # When parent to multiple ops, sq transformation could be wrong.
-                            print(f"lyt_debug_FOUND: {parent.kind()}, {parent_out_kinds}, {parent_scopeName}")
                             prev_absorb_layer.append(None)
                     else:
                         prev_absorb_layer.append(parent)

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -920,8 +920,8 @@ class GraphTrace:
                         parent_out_kinds.discard('aten::size')
                         if parent_out_kinds == parent_out_kinds.intersection(self.could_absorb_layers):
                             prev_absorb_layer.append(parent)
-                        # elif parent_out_kinds.intersection(self.skip_ops_to_find_absorb):
-                        #     prev_absorb_layer.append(parent) ##TODO: check other scenarios
+                        elif parent_out_kinds.intersection(self.skip_ops_to_find_absorb):
+                            prev_absorb_layer.append(parent) ##TODO: check other scenarios
                         else: # When parent to multiple ops, sq transformation could be wrong.
                             prev_absorb_layer.append(None)
                     else:

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -949,12 +949,12 @@ class GraphTrace:
         dict_parent_kind = defaultdict(list)
         for node in traced_model.graph.nodes():
             parents_list = get_parents(node)
-            node_kind = node.kind()
+            node_kind, node_scopeName = node.kind(), node.scopeName()
             if parents_list: #save input_kinds of all parent nodes
                 for parent_ in parents_list:
                     parent = parent_.node()
                     parent_kind = parent.kind()
-                    if 'prim' not in parent_kind:
+                    if 'prim' not in parent_kind and parent.scopeName() != node_scopeName:
                         dict_parent_kind[parent.scopeName()].append(node_kind)
 
         aten_op_types = self.mapping_torch_module_to_aten(op_types)


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

detail description:
fix the skip-connection bugs when set folding=True.  When an op(e.g layernorm) outputs to multiple modules and one of them is not absorbable, this op should not be transformed by smoothquant. This pr fixes one scenario of this issue; solution of other scenarios is WIP.


## Expected Behavior & Potential Risk

no behavior expected to trigger by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)
do alpha=auto smoothquant on opt350m. fp32 acc remains unchanged after performing sq.

## Dependency Change?

no
