### PR TITLE
Copy the model for smoothquant in quantization

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3267,14 +3267,11 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
         assert not self.version.release < Version("2.1").release, \
             "IPEX version >= 2.1 is required for SmoothQuant."
 
-        if not self.performance_only:
-            try:
-                self.tmp_model = copy.deepcopy(model)
-            except Exception as e:  # pragma: no cover
-                logger.warning("Fail to deep copy the model due to {}, inplace is used now.".format(
-                    repr(e)))
-                self.tmp_model = model
-        else:
+        try:
+            self.tmp_model = copy.deepcopy(model)
+        except Exception as e:  # pragma: no cover
+            logger.warning("Fail to deep copy the model due to {}, inplace is used now.".format(
+                repr(e)))
             self.tmp_model = model
         q_model = self.tmp_model._model
 


### PR DESCRIPTION
## Type of Change

Copy the model for smoothquant in quantization  
No API changed

## Description

The smoothquant method needs a deep copy of the model in the process of getting quantizable ops, so we also add a deep copy in the quantization process.

## Expected Behavior & Potential Risk

Quantize flan-t5 successfully with smoothquant. 

## How has this PR been tested?

Local tested

