### PR TITLE
Improve sq equal check with out_pre_sq and out_post_sq

### DIFF
--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -771,13 +771,17 @@ class TorchSmoothQuant:
             return self.model
 
     def output_is_equal(self, out1, out2, atol=1e-05):
-        if isinstance(out1, tuple):
-            return all(torch.all(torch.isclose(out1[i], out2[i], atol=atol)) for i in range(len(out1)))
-        elif isinstance(out1, dict):
-            return all(torch.all(torch.isclose(out1[k], out2[k], atol=atol)) for k in out1.keys())
-        elif isinstance(out1, torch.Tensor):
-            return torch.all(torch.isclose(out1, out2, atol=atol))
-        return False
+        try:
+            if isinstance(out1, tuple):
+                return all(torch.all(torch.isclose(out1[i], out2[i], atol=atol)) for i in range(len(out1)))
+            elif isinstance(out1, dict):
+                return all(torch.all(torch.isclose(out1[k], out2[k], atol=atol)) for k in out1.keys())
+            elif isinstance(out1, torch.Tensor):
+                return torch.all(torch.isclose(out1, out2, atol=atol))
+            return False
+        except:
+            logger.warning("Automatically check failed, Please check equal manually between out_pre_sq and out_post_sq if necessary.")
+            return True
 
     def recover(self):
         """

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -780,7 +780,8 @@ class TorchSmoothQuant:
                 return torch.all(torch.isclose(out1, out2, atol=atol))
             return False
         except:
-            logger.warning("Automatically check failed, Please check equal manually between out_pre_sq and out_post_sq if necessary.")
+            logger.warning("Automatically check failed, \
+                            Please check equal manually between out_pre_sq and out_post_sq if necessary.")
             return True
 
     def recover(self):


### PR DESCRIPTION
## Type of Change

root cause: `torch.isclose()` doesn't support `torch.isclose(tuple(),tuple())`.
check equal out_pre_sq and out_post_sq is necessary, we will improve the calculate method later, welcome to raise a PR if you have a good idea @maktukmak , this PR just provide the workaround for output style is tuple(tuple()).

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
