### PR TITLE
Revert "Copy the model for smoothquant in quantization (#1001)"

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3267,11 +3267,14 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
         assert not self.version.release < Version("2.1").release, \
             "IPEX version >= 2.1 is required for SmoothQuant."
 
-        try:
-            self.tmp_model = copy.deepcopy(model)
-        except Exception as e:  # pragma: no cover
-            logger.warning("Fail to deep copy the model due to {}, inplace is used now.".format(
-                repr(e)))
+        if not self.performance_only:
+            try:
+                self.tmp_model = copy.deepcopy(model)
+            except Exception as e:  # pragma: no cover
+                logger.warning("Fail to deep copy the model due to {}, inplace is used now.".format(
+                    repr(e)))
+                self.tmp_model = model
+        else:
             self.tmp_model = model
         q_model = self.tmp_model._model
 


### PR DESCRIPTION
This reverts commit ca10b33dcc0c6932b2c9ce843d67d2cddf5ac82f.

## Type of Change

No API changed

## Description

For performance_only, we don't copy the model in the quantization process, but in the process of get_quantizable_ops, it need to improve the behavior in IPEX.
