### PR TITLE
remove recover when sq check failed

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -1300,7 +1300,6 @@ class TemplateAdaptor(Adaptor):
             calib_iter=calib_iter,
             **kwargs
         )
-        model._model._smoothquant_optimized = True
         return model
 
     def qdq_quantize(self, model, tune_cfg):
@@ -1483,7 +1482,8 @@ class PyTorchAdaptor(TemplateAdaptor):
         if recipe_cfgs and recipe_cfgs.get('smooth_quant', False) \
           and not recipe_cfgs['smooth_quant_args']['folding'] \
           and self.approach != 'post_training_dynamic_quant':
-            return self.qdq_quantize(q_model, tune_cfg)
+            if model._model._smoothquant_optimized:
+                return self.qdq_quantize(q_model, tune_cfg)
 
         # For tensorboard display
         self.tune_cfg = tune_cfg
@@ -2514,7 +2514,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
           and self.version.release >= Version("2.1").release \
           and not recipe_cfgs['smooth_quant_args']['folding'] \
           and self.approach != 'post_training_dynamic_quant':
-            return self.qdq_quantize(model, tune_cfg, dataloader, q_func)
+            if model._model._smoothquant_optimized:
+                return self.qdq_quantize(model, tune_cfg, dataloader, q_func)
 
         assert self.approach != 'quant_aware_training', \
             "Intel PyTorch Extension didn't support quantization aware training mode"

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -761,7 +761,7 @@ class TorchSmoothQuant:
                 if not self.output_is_equal(out_post_sq, out_pre_sq):
                     logger.warning(
                         "Mathematical equivelancy of Smoothquant is not preserved. "
-                        "Please kindly report this issue to github.")
+                        "Please kindly report this issue to https://github.com/intel/neural-compressor.")
                     # self.recover()
                     # self.model._smoothquant_optimized = False
             else:

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -780,7 +780,7 @@ class TorchSmoothQuant:
                 return torch.all(torch.isclose(out1, out2, atol=atol))
             return False
         except:
-            logger.warning("Automatically check failed, Please check equal manually "
+            logger.warning("Automatically check failed, Please check equivelancy manually "
                            "between out_pre_sq and out_post_sq if necessary.")
             return True
 

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -752,6 +752,8 @@ class TorchSmoothQuant:
 
             self.weight_scale_info, self.absorb_scales_info = self._adjust_parameters(self.absorb_to_layer,
                                                                                       input_maxes, alpha)
+
+            self.model._smoothquant_optimized = True
             if example_inputs != None:
                 # Check mathematical equivelancy
                 out_post_sq = model_forward_per_sample(self.model, example_inputs, self.device)
@@ -759,18 +761,16 @@ class TorchSmoothQuant:
                 if not self.output_is_equal(out_post_sq, out_pre_sq):
                     logger.warning(
                         "Mathematical equivelancy of Smoothquant is not preserved. "
-                        " Please kindly report this issue to github, sq is skipped")
-                    self.recover()
-                # else:
-                #     logger.info("Mathematical equivelancy of Smoothquant is preserved.")
-
+                        "Please kindly report this issue to github.")
+                    # self.recover()
+                    # self.model._smoothquant_optimized = False
             else:
                 logger.warning(" Could not get example input, equivelancy check is skipped")
 
             self.input_values, self.output_values = {}, {}
             return self.model
 
-    def output_is_equal(self, out1, out2, atol=1e-05):
+    def output_is_equal(self, out1, out2, atol=1e-04):
         try:
             if isinstance(out1, tuple):
                 return all(torch.all(torch.isclose(out1[i], out2[i], atol=atol)) for i in range(len(out1)))
@@ -780,8 +780,8 @@ class TorchSmoothQuant:
                 return torch.all(torch.isclose(out1, out2, atol=atol))
             return False
         except:
-            logger.warning("Automatically check failed, \
-                            Please check equal manually between out_pre_sq and out_post_sq if necessary.")
+            logger.warning("Automatically check failed, Please check equal manually "
+                           "between out_pre_sq and out_post_sq if necessary.")
             return True
 
     def recover(self):

--- a/test/algorithm/test_smooth_quant_onnx.py
+++ b/test/algorithm/test_smooth_quant_onnx.py
@@ -50,6 +50,26 @@ class TestORTSq(unittest.TestCase):
 
     def test_sq(self):
         sq = ORTSmoothQuant(copy.deepcopy(self.model), self.dataloader)
+        model = sq.transform(calib_iter=5, scales_per_op=False)
+        self.assertEqual(len([i for i in model.model.graph.node if i.op_type == 'Mul']), 1)
+        sq.recover()
+        self.assertEqual(len(sq.model.nodes()), len(self.model.graph.node))
+        for init in self.model.graph.initializer:
+            tensor = numpy_helper.to_array(init)
+            sq_tensor = numpy_helper.to_array(sq.model.get_initializer(init.name))
+            self.assertAlmostEqual(tensor[0][0], sq_tensor[0][0], 4)
+
+        sq = ORTSmoothQuant(copy.deepcopy(self.model), self.dataloader)
+        model = sq.transform(calib_iter=5, folding=False, scales_per_op=False)
+        self.assertEqual(len([i for i in model.model.graph.node if i.op_type == 'Mul']), 2)
+        sq.recover()
+        self.assertEqual(len(sq.model.nodes()), len(self.model.graph.node))
+        for init in self.model.graph.initializer:
+            tensor = numpy_helper.to_array(init)
+            sq_tensor = numpy_helper.to_array(sq.model.get_initializer(init.name))
+            self.assertAlmostEqual(tensor[0][0], sq_tensor[0][0], 4)
+
+        sq = ORTSmoothQuant(copy.deepcopy(self.model), self.dataloader)
         model = sq.transform(calib_iter=5, folding=False, scales_per_op=True)
         self.assertEqual(len([i for i in model.model.graph.node if i.op_type == 'Mul']), 3)
         sq.recover()
@@ -72,6 +92,17 @@ class TestORTSq(unittest.TestCase):
         sq = ORTSmoothQuant(copy.deepcopy(self.model), self.dataloader)
         model = sq.transform(calib_iter=5, scales_per_op=True, alpha='auto')
         self.assertEqual(len([i for i in model.model.graph.node if i.op_type == 'Mul']), 3)
+        sq.recover()
+        self.assertEqual(len(sq.model.nodes()), len(self.model.graph.node))
+        for init in self.model.graph.initializer:
+            tensor = numpy_helper.to_array(init)
+            sq_tensor = numpy_helper.to_array(sq.model.get_initializer(init.name))
+            self.assertAlmostEqual(tensor[0][0], sq_tensor[0][0], 4)
+
+
+        sq = ORTSmoothQuant(copy.deepcopy(self.model), self.dataloader)
+        model = sq.transform(calib_iter=5, alpha='auto', scales_per_op=False)
+        self.assertEqual(len([i for i in model.model.graph.node if i.op_type == 'Mul']), 1)
         sq.recover()
         self.assertEqual(len(sq.model.nodes()), len(self.model.graph.node))
         for init in self.model.graph.initializer:

--- a/test/algorithm/test_smooth_quant_onnx.py
+++ b/test/algorithm/test_smooth_quant_onnx.py
@@ -7,33 +7,6 @@ import shutil
 from neural_compressor.data import Datasets, DATALOADERS
 from neural_compressor.adaptor.ox_utils.smooth_quant import ORTSmoothQuant
 
-def build_onnx_model():
-    A = helper.make_tensor_value_info('A', TensorProto.FLOAT, [1, 5, 5])
-    C = helper.make_tensor_value_info('C', TensorProto.FLOAT, [1, 5, 2])
-    H = helper.make_tensor_value_info('H', TensorProto.FLOAT, [1, 5, 2])
-
-    g_value = np.random.uniform(low=0.001, high=0.5, size=(25)).astype(np.float32)
-    G_init = helper.make_tensor('G', TensorProto.FLOAT, [5, 5], g_value.reshape(25).tolist())
-    matmul_node = onnx.helper.make_node('MatMul', ['A', 'G'], ['C'], name='Matmul')
-
-    b_value = np.random.uniform(low=0.001, high=0.5, size=(10)).astype(np.float32)
-    B_init = helper.make_tensor('B', TensorProto.FLOAT, [5, 2], b_value.reshape(10).tolist())
-    matmul_node2 = onnx.helper.make_node('MatMul', ['C', 'B'], ['I'], name='Matmul2')
-
-    e_value = np.random.uniform(low=0.001, high=0.5, size=(10)).astype(np.float32)
-    E_init = helper.make_tensor('E', TensorProto.FLOAT, [5, 2], e_value.reshape(10).tolist())
-    matmul_node3 = onnx.helper.make_node('MatMul', ['C', 'E'], ['K'], name='Matmul3')
-
-    add = onnx.helper.make_node('Add', ['I', 'E'], ['D'], name='add')
-
-    f_value = np.random.uniform(low=0.001, high=0.5, size=(10)).astype(np.float32)
-    F_init = helper.make_tensor('F', TensorProto.FLOAT, [5, 2], f_value.reshape(10).tolist())
-    add2 = onnx.helper.make_node('Add', ['D', 'F'], ['H'], name='add2')
-
-    graph = helper.make_graph([matmul_node, matmul_node2, matmul_node3, add, add2], 'test_graph_1', [A], [H], [B_init, E_init, F_init, G_init])
-    model = helper.make_model(graph)
-    model = helper.make_model(graph, **{'opset_imports': [helper.make_opsetid('', 13)]})
-    return model
 
 def build_onnx_model():
     A = helper.make_tensor_value_info('A', TensorProto.FLOAT, [1, 5, 5])
@@ -62,6 +35,7 @@ def build_onnx_model():
     model = helper.make_model(graph)
     model = helper.make_model(graph, **{'opset_imports': [helper.make_opsetid('', 13)]})
     return model
+
 
 class TestORTSq(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Type of Change

bug fix

## Description

opt-125m requires large atol when checking output, to avoid this error again, we remove recover func and use log instead.

## Expected Behavior & Potential Risk

UT pass

## How has this PR been tested?

local test

## Dependency Change?

N/A
