### PR TITLE
add deepcopy for SQ folding=True

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3064,7 +3064,7 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                     logger.warning("Smoothquant for ipex requires a deepcopy of model"
                                     + ", please avoid out of memory.")
                     try:
-                        tmp_model = copy.deepcopy(model)
+                        tmp_model = copy.deepcopy(model) # Deepcopy due to model changed when `ipex.quantization.prepare`
                     except Exception as e:  # pragma: no cover
                         logger.warning("Fail to deep copy the model due to {}, inplace is used now.".format(
                             repr(e)))

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3064,7 +3064,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                     logger.warning("Smoothquant for ipex requires a deepcopy of model"
                                     + ", please avoid out of memory.")
                     try:
-                        tmp_model = copy.deepcopy(model) # Deepcopy due to model changed when `ipex.quantization.prepare`
+                        # Deepcopy due to model changed when `ipex.quantization.prepare`
+                        tmp_model = copy.deepcopy(model)
                     except Exception as e:  # pragma: no cover
                         logger.warning("Fail to deep copy the model due to {}, inplace is used now.".format(
                             repr(e)))

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3060,8 +3060,7 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                 self.example_inputs = get_example_inputs(model, self.q_dataloader)
         else:
             if self.performance_only:
-                if self.recipes and self.recipes.get('smooth_quant', False) \
-                    and self.version.release >= Version("2.1").release:  # pragma: no cover
+                if self.recipes and self.recipes.get('smooth_quant', False):  # pragma: no cover
                     logger.warning("Smoothquant for ipex requires a deepcopy of model"
                                     + ", please avoid out of memory.")
                     try:


### PR DESCRIPTION
## Type of Change

bug fix
root cause: when `folding=True` and `eval_func` doesn't provide, the SQ input is ipex prepared model, it used `aten::alias` wrap the op and cause the `linear` and `conv` not to be recognized.
improve: add the deepcopy for this condition, because `folding=False` also need `deepcopy`, so remove the ipex version limitation.

remaining:
there is a remaining curious issue in UT `python test_smooth_quant.py TestSqLinearOpFuse.test_sq_quant_ipex`, for actual models(such as bloom, llama), `tmp_model` and `model` should use the same address. But the previous ut pass, the reason shows `tmp_model=model` create 2 address for `tmp_model` and `model` when get_quantizable ops, I think may be due to the small size, please root cause @xin3he 

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
