### PR TITLE
Fix reshape issue for Bayesian strategy

### DIFF
--- a/neural_compressor/strategy/bayesian.py
+++ b/neural_compressor/strategy/bayesian.py
@@ -172,7 +172,7 @@ def acq_max(ac, gp, y_max, bounds, random_seed, n_warmup=10000, n_iter=10):
     for x_try in x_seeds:
         # Find the minimum of minus the acquisition function
         res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
-                       x_try.reshape(1, -1),
+                       x_try.flatten(),
                        bounds=bounds,
                        method="L-BFGS-B")
 


### PR DESCRIPTION
## Type of Change

bug fix
API no change

## Description

Fixed reshape issue for Bayesian strategy.
Replace reshape(1, -1) with flatten().

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

no
