### PR TITLE
Adding jit trace to llm example

### DIFF
--- a/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/requirements.txt
@@ -4,3 +4,5 @@ sentencepiece
 transformers
 torch
 tqdm
+cupy
+optimum

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/run_clm_no_trainer.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/run_clm_no_trainer.py
@@ -61,8 +61,8 @@ from transformers.utils.versions import require_version
 from neural_compressor.training import prepare_compression
 from neural_compressor.training import WeightPruningConfig
 from timers import CPUTimer, GPUTimer
-from neural_compressor.compression import model_slim
-from neural_compressor.compression import parse_auto_slim_config
+from neural_compressor.compression.pruner import model_slim
+from neural_compressor.compression.pruner import parse_auto_slim_config
 
     
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

The slimed model cannot be loaded using the form_pertrain() method. In order to solve the situation that the model is not compatible with the downstream examples, consider directly converting the slimed_model to jit_model.
