### PR TITLE
remove invalid print

### DIFF
--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -250,7 +250,7 @@ def check_cfg_and_qconfig(tune_cfg, cfgs, op_infos_from_cfgs, output_tensor_ids_
                                 if pre_op_output['id'] == input_tensor_id:
                                     pre_op_output_infos[index]['inf_dtype'] = input_tensor_dtype
                                 else:
-                                    print('Do not find the input id', input_tensor_id)
+                                    pass
                             pre_op_infos['output_tensor_infos'] = pre_op_output_infos
                             cfgs[pre_op_module][pre_op_state][pre_op_index] = pre_op_infos
                         else:


### PR DESCRIPTION
## Type of Change

remove the invalid print.
the pre_op_out may not in the q_op_info, it will cause not find the pre_op, we don't need to modify the pre_op_output optype for the condtion.
the print cause some confuse, so remove it.

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
