### PR TITLE
Support new spr-base version and fix version check issue

### DIFF
--- a/neural_compressor/adaptor/tensorflow.py
+++ b/neural_compressor/adaptor/tensorflow.py
@@ -33,7 +33,7 @@ from ..conf.dotdict import deep_get
 from ..data.dataloaders.base_dataloader import BaseDataLoader
 
 tensorflow = LazyImport('tensorflow')
-spr_base_verions = ('2.11.0202242', '2.11.0202250', '2.11.0202317')
+spr_base_verions = ('2.11.0202242', '2.11.0202250', '2.11.0202317', '2.11.0202323')
 
 @adaptor_registry
 class TensorFlowAdaptor(Adaptor):
@@ -1887,7 +1887,8 @@ class TensorflowQuery(QueryBackendCapability):
             if self.version in sub_data['version']['name']:
                 return sub_data
             else:
-                if sub_data['version']['name'] == ['2.11.0202242', '2.11.0202250', '2.11.0202317']:
+                if sub_data['version']['name'] == ['2.11.0202242', '2.11.0202250', \
+                                                   '2.11.0202317', '2.11.0202323']:
                     continue
                 sorted_list = copy.deepcopy(sub_data['version']['name'])
                 sorted_list.remove('default') if 'default' in sorted_list else None

--- a/neural_compressor/adaptor/tensorflow.yaml
+++ b/neural_compressor/adaptor/tensorflow.yaml
@@ -16,7 +16,7 @@
 ---
 -
   version:
-    name: ['2.11.0202242', '2.11.0202250', '2.11.0202317']
+    name: ['2.11.0202242', '2.11.0202250', '2.11.0202317', '2.11.0202323']
 
   bf16: ["_MklLayerNorm", "Conv2D", "Conv2DBackpropFilter", "Conv2DBackpropInput", "Conv3D", "Conv3DBackpropFilterV2", "Conv3DBackpropInputV2",
           "DepthwiseConv2dNative", "DepthwiseConv2dNativeBackpropFilter", "DepthwiseConv2dNativeBackpropInput", "GRUBlockCell",

--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -71,7 +71,7 @@ from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.insert_print_node
 from .graph_util import GraphRewriterHelper as Helper
 
 
-TF_SUPPORTED_MAX_VERSION = '2.11.0'
+TF_SUPPORTED_MAX_VERSION = '2.12.0'
 TF_SUPPORTED_MIN_VERSION = '1.14.0'
 
 logger = logging.getLogger("neural_compressor")

--- a/neural_compressor/adaptor/tf_utils/graph_converter_without_calib.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter_without_calib.py
@@ -45,10 +45,11 @@ from .graph_rewriter.bf16.bf16_convert import BF16Convert
 from .graph_rewriter.int8.post_quantized_op_cse import PostCseOptimizer
 from .graph_rewriter.int8.meta_op_optimizer import MetaInfoChangingMemOpOptimizer
 from .graph_rewriter.int8.rnn_convert import QuantizedRNNConverter
-from .util import version1_gte_version2,version1_gt_version2,version1_eq_version2,version1_lt_version2
+from .util import version1_gte_version2,version1_gt_version2,version1_eq_version2
+from .util import version1_lt_version2, version1_lte_version2
 from .util import TF_SPR_BASE_VERSIONS
 
-TF_SUPPORTED_MAX_VERSION = '2.11.0'
+TF_SUPPORTED_MAX_VERSION = '2.12.0'
 TF_SUPPORTED_MIN_VERSION = '1.14.0'
 
 logger = logging.getLogger("neural_compressor")
@@ -112,7 +113,7 @@ class GraphConverterWithoutCalib:
                 from tensorflow.python.util._pywrap_util_port import IsMklEnabled
             else:
                 from tensorflow.python._pywrap_util_port import IsMklEnabled
-            if IsMklEnabled() and (TF_SUPPORTED_MIN_VERSION <= tf.version.VERSION):
+            if IsMklEnabled() and (version1_lte_version2(TF_SUPPORTED_MIN_VERSION, tf.version.VERSION)):
                 is_supported_version = True
                 
             if version1_gte_version2(tf.version.VERSION, '2.6.0') and os.getenv('TF_ENABLE_ONEDNN_OPTS') == '1':
@@ -121,7 +122,7 @@ class GraphConverterWithoutCalib:
             if version1_gte_version2(tf.version.VERSION, '2.9.0'):
                 is_supported_version = True
 
-            if version1_eq_version2(tf.version.VERSION, '1.15.0-up3'):
+            if tf.version.VERSION == '1.15.0-up3':
                 is_supported_version = True
 
             if tf.version.VERSION in TF_SPR_BASE_VERSIONS:

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/convert_add_to_biasadd.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/convert_add_to_biasadd.py
@@ -35,7 +35,7 @@ class ConvertAddToBiasAddOptimizer(GraphRewriterBase):
         graph_info = g.parse_graph()
 
         import tensorflow as tf
-        if tf.version.VERSION not in ('2.11.0202242', '2.11.0202250', '2.11.0202317'):
+        if tf.version.VERSION not in ('2.11.0202242', '2.11.0202250', '2.11.0202317', '2.11.0202323'):
             target_nodes = g.query_fusion_pattern_nodes([['MatMul', 'Conv2D'], ['Add', 'AddV2']])
         else:
             target_nodes = g.query_fusion_pattern_nodes([['MatMul'], ['Add', 'AddV2']])

--- a/neural_compressor/adaptor/tf_utils/util.py
+++ b/neural_compressor/adaptor/tf_utils/util.py
@@ -31,7 +31,7 @@ from .graph_util import GraphAnalyzer
 from .graph_util import GraphRewriterHelper
 from pkg_resources import parse_version
 
-TF_SPR_BASE_VERSIONS = ('2.11.0202242', '2.11.0202250', '2.11.0202317')
+TF_SPR_BASE_VERSIONS = ('2.11.0202242', '2.11.0202250', '2.11.0202317', '2.11.0202323')
 
 def version1_lt_version2(version1, version2):
     """Check if version1 is less than version2."""

--- a/test/tfnewapi/test_tensorflow_graph_conv_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_conv_fusion.py
@@ -613,7 +613,7 @@ class TestConvBiasAddAddReluFusion(unittest.TestCase):
 
 
     @disable_random()
-    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317'], "deconv2d quantization only support 2.11")
+    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317', '2.11.0202323'], "deconv2d quantization only support 2.11")
     def test_deconv2d_biasadd_fusion(self):
         x = tf.compat.v1.placeholder(tf.float32, [1,2,2,1], name="input")
         conv_weights2 = tf.compat.v1.get_variable("weight2", [3,3,1,1], 
@@ -650,7 +650,7 @@ class TestConvBiasAddAddReluFusion(unittest.TestCase):
             self.assertEqual(found_deconv2d_fusion, True)
 
     @disable_random()
-    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317'], "deconv2d quantization only support 2.11")
+    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317', '2.11.0202323'], "deconv2d quantization only support 2.11")
     def test_single_deconv2d_fusion(self):
         x = tf.compat.v1.placeholder(tf.float32, [1,2,2,1], name="input")
         conv_weights2 = tf.compat.v1.get_variable("weight2", [3,3,1,1], 
@@ -685,7 +685,7 @@ class TestConvBiasAddAddReluFusion(unittest.TestCase):
             self.assertEqual(found_deconv2d_fusion, True)
 
     @disable_random()
-    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317'], "deconv2d quantization only support 2.11")
+    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317', '2.11.0202323'], "deconv2d quantization only support 2.11")
     def test_deconv3d_biasadd_fusion(self):
         x = tf.compat.v1.placeholder(tf.float32, [1, 2, 2, 2, 1], name="input")
         conv3d_weights = tf.compat.v1.get_variable("weight_conv3d_1", [3, 3, 3, 1, 1],
@@ -721,7 +721,7 @@ class TestConvBiasAddAddReluFusion(unittest.TestCase):
             self.assertEqual(found_deconv3d_fusion, True)
 
     @disable_random()
-    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317'], "deconv2d quantization only support 2.11")
+    @unittest.skipIf(tf.__version__ not in ["2.11.0202242", "2.11.0202250", '2.11.0202317', '2.11.0202323'], "deconv2d quantization only support 2.11")
     def test_single_deconv3d_fusion(self):
         x = tf.compat.v1.placeholder(tf.float32, [1, 2, 2, 2, 1], name="input")
         conv3d_weights = tf.compat.v1.get_variable("weight_conv3d_1", [3, 3, 3, 1, 1],


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Support new spr-base version 2.11.0202323;
Update the max support tensorflow version to 2.12.0;
Fix version check issue on SPR for '1.15.0-up3'.

## Expected Behavior & Potential Risk

New spr-base version supported and version issue fixed.

## How has this PR been tested?

UT and pre-CI test.

## Dependency Change?

No.
