### PR TITLE
fallback add for ipex by default

### DIFF
--- a/neural_compressor/adaptor/pytorch_ipex.yaml
+++ b/neural_compressor/adaptor/pytorch_ipex.yaml
@@ -39,6 +39,15 @@
           'Conv1d': *cap_s8_1_12_Conv2d,
           'Conv3d': *cap_s8_1_12_Conv2d,
           'Linear': *cap_s8_1_12_Conv2d,
+          # Fallback add to fp32 by default, to avoid accuracy issue happening on LLMs.
+          'add': &cap_s8_1_12_add {
+            'activation': {
+                        'dtype': ['fp32'],
+                        },
+            'weight': {
+                        'dtype': ['fp32'],
+                        },
+                    },
           'default': {
             'weight': {
                         'dtype': ['int8'],


### PR DESCRIPTION
## Type of Change

feature

## Description

INC focuses on accuracy first.
So we fallback add for ipex by default. Sometimes, add will cause accuracy drop to zero on LLMs.

## Expected Behavior & Potential Risk

add is not quantized by ipex

## How has this PR been tested?

No

## Dependency Change?

N/A
