### PR TITLE
Update the Dataloader Usage of TF examples

### DIFF
--- a/examples/keras/image_recognition/resnet50/quantization/ptq/README.md
+++ b/examples/keras/image_recognition/resnet50/quantization/ptq/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 
 The pretrained model is provided by [Keras Applications](https://keras.io/api/applications/). prepare the model, Run as follow: 
  ```
- prepare_model.py --output_model=/path/to/model
+python prepare_model.py --output_model=/path/to/model
  ```
 `--output_model ` the model should be saved as SavedModel format or H5 format.
 

--- a/examples/keras/image_recognition/vgg16/quantization/ptq/README.md
+++ b/examples/keras/image_recognition/vgg16/quantization/ptq/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 
 The pretrained model is provided by [Keras Applications](https://keras.io/api/applications/). prepare the model, Run as follow: 
  ```
- prepare_model.py   --output_model=/path/to/model
+python prepare_model.py   --output_model=/path/to/model
  ```
 `--output_model ` the model should be saved as SavedModel format or H5 format.
 

--- a/examples/keras/image_recognition/vgg19/quantization/ptq/README.md
+++ b/examples/keras/image_recognition/vgg19/quantization/ptq/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 
 The pretrained model is provided by [Keras Applications](https://keras.io/api/applications/). prepare the model, Run as follow: 
  ```
- prepare_model.py   --output_model=/path/to/model
+python prepare_model.py   --output_model=/path/to/model
  ```
 `--output_model ` the model should be saved as SavedModel format or H5 format.
 

--- a/examples/tensorflow/image_recognition/SavedModel/efficientnet_v2_b0/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/SavedModel/efficientnet_v2_b0/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/SavedModel/mobilenet_v1/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/SavedModel/mobilenet_v1/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/SavedModel/mobilenet_v2/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/SavedModel/mobilenet_v2/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/ViT/pruning/magnitude/main.py
+++ b/examples/tensorflow/image_recognition/ViT/pruning/magnitude/main.py
@@ -111,10 +111,10 @@ def evaluate(model, adaptor, eval_dataloader):
 
 if __name__ == '__main__':
     training_set, test_set = prepare_dataset()
-    train_dataloader = DataLoader(dataset=training_set, batch_size=128,
-                                        framework='tensorflow', distributed=FLAGS.train_distributed)
-    eval_dataloader = DataLoader(dataset=test_set, batch_size=256,
-                                        framework='tensorflow', distributed=FLAGS.evaluation_distributed)
+    train_dataloader = DataLoader(framework='tensorflow', dataset=training_set,
+                                        batch_size=128, distributed=FLAGS.train_distributed)
+    eval_dataloader = DataLoader(framework='tensorflow', dataset=test_set,
+                                        batch_size=256, distributed=FLAGS.evaluation_distributed)
 
     framework_specific_info = {
         'device': 'cpu', 'random_seed': 9527, 

--- a/examples/tensorflow/image_recognition/resnet_v2/pruning/magnitude/main.py
+++ b/examples/tensorflow/image_recognition/resnet_v2/pruning/magnitude/main.py
@@ -409,10 +409,10 @@ def evaluate(model, adaptor, eval_dataloader):
     return eval_func(model)
 
 if __name__ == '__main__':
-    train_dataloader = DataLoader(dataset=TrainDataset(), batch_size=32, 
-                                    framework='tensorflow', distributed=FLAGS.train_distributed)
-    eval_dataloader = DataLoader(dataset=EvalDataset(), batch_size=32, 
-                                    framework='tensorflow', distributed=FLAGS.evaluation_distributed)
+    train_dataloader = DataLoader(framework='tensorflow', dataset=TrainDataset(), 
+                                    batch_size=32, distributed=FLAGS.train_distributed)
+    eval_dataloader = DataLoader(framework='tensorflow', dataset=EvalDataset(), 
+                                    batch_size=32, distributed=FLAGS.evaluation_distributed)
 
     if FLAGS.prune:
         generate_pretrained_model()

--- a/examples/tensorflow/image_recognition/resnet_v2/quantization/qat/main.py
+++ b/examples/tensorflow/image_recognition/resnet_v2/quantization/qat/main.py
@@ -373,7 +373,7 @@ def evaluate(model):
         return latency
 
     from neural_compressor.data import DataLoader
-    dataloader = DataLoader(dataset=Dataset(), framework='tensorflow', batch_size=FLAGS.batch_size)
+    dataloader = DataLoader(framework='tensorflow', dataset=Dataset(), batch_size=FLAGS.batch_size)
     latency = eval_func(dataloader)
     if FLAGS.benchmark and FLAGS.mode == 'performance':
         print("Batch size = {}".format(FLAGS.batch_size))

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet121/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet121/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet161/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet161/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/densenet169/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/densenet169/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/efficientnet-b0/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/efficientnet-b0/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_resnet_v2/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_resnet_v2/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v1/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v1/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v2/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v2/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v3/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/inception_v4/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/inception_v4/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v1/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v1/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/export/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v3/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v3/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet101/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet101/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/mixed_precision/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/mixed_precision/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_101/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_101/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_152/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_152/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_50/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet_v2_50/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg16/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg16/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg19/quantization/ptq/main.py
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg19/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/nlp/bert_base_mrpc/quantization/ptq/run_classifier.py
+++ b/examples/tensorflow/nlp/bert_base_mrpc/quantization/ptq/run_classifier.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2022 The Google AI Language Team Authors.
+# Copyright 2023 The Google AI Language Team Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1108,8 +1108,9 @@ def main(_):
             latency = np.array(latency_list[warmup:]).mean() / FLAGS.eval_batch_size
             return latency
 
-        from neural_compressor.data import DefaultDataLoader
-        dataloader = DefaultDataLoader(dataset, collate_fn=collate_fn, batch_size=FLAGS.eval_batch_size)
+        from neural_compressor.data import DataLoader
+        dataloader = DataLoader(framework='tensorflow', dataset=dataset, 
+                          batch_size=FLAGS.eval_batch_size, collate_fn=collate_fn)
         latency = eval_func(dataloader)
         if FLAGS.benchmark and FLAGS.mode == 'performance':
             print("Batch size = {}".format(FLAGS.eval_batch_size))
@@ -1152,8 +1153,8 @@ def main(_):
             inputs=["input_file", "batch_size"],
             outputs=["loss/Softmax:0", "IteratorGetNext:3"],
             calibration_sampling_size=[500],)
-        calib_dataloader=DataLoader(dataset=dataset, collate_fn=collate_fn, framework='tensorflow')
-        eval_dataloader=DataLoader(dataset=dataset, collate_fn=collate_fn, framework='tensorflow')
+        calib_dataloader=DataLoader(framework='tensorflow', dataset=dataset, collate_fn=collate_fn)
+        eval_dataloader=DataLoader(framework='tensorflow', dataset=dataset, collate_fn=collate_fn)
         q_model = quantization.fit(model=model, conf=config, calib_dataloader=calib_dataloader,
                         eval_dataloader=eval_dataloader, eval_metric=Accuracy())
 

--- a/examples/tensorflow/nlp/bert_large_squad/quantization/ptq/tune_squad.py
+++ b/examples/tensorflow/nlp/bert_large_squad/quantization/ptq/tune_squad.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/nlp/bert_large_squad_model_zoo/quantization/ptq/tune_squad.py
+++ b/examples/tensorflow/nlp/bert_large_squad_model_zoo/quantization/ptq/tune_squad.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/nlp/distilbert_base/quantization/ptq/run_inference.py
+++ b/examples/tensorflow/nlp/distilbert_base/quantization/ptq/run_inference.py
@@ -2,7 +2,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/main.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/main.py
@@ -1,3 +1,20 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import os.path
 import transformers
 import tensorflow as tf
@@ -27,7 +44,7 @@ class Evaluator:
         self.dataset = dataset
         self.tokenizer = tokenizer
         self.device = device
-        self.dataloader = INCDataloader(dataset, tokenizer, batch_size, device)
+        self.dataloader = CustomDataloader(dataset, tokenizer, batch_size, device)
 
     def evaluate(self, model):
         # model.eval()
@@ -74,7 +91,7 @@ class Evaluator:
         print(acc, flush=True)
         return acc
 
-class INCDataloader:
+class CustomDataloader:
     # for_calib=True in quantization, only input_id is needed, =False in evaluation need label
     def __init__(self, dataset, tokenizer, batch_size=1, device='cpu', for_calib=False):
         self.dataset = dataset
@@ -161,7 +178,7 @@ evaluator = Evaluator(eval_dataset, tokenizer, 'cpu')
 calib_dataset = load_dataset('lambada', split='train')
 # calib_dataset = eval_dataset  # TODO for debug
 calib_dataset = calib_dataset.shuffle(seed=42)
-calib_dataloader = INCDataloader(calib_dataset, tokenizer, device='cpu', batch_size=1, for_calib=True)
+calib_dataloader = CustomDataloader(calib_dataset, tokenizer, device='cpu', batch_size=1, for_calib=True)
 
 def eval_func(model):
     acc = evaluator.evaluate_tf_v1(model)

--- a/examples/tensorflow/nlp/transformer_lt_mlperf/quantization/ptq/run_inference.py
+++ b/examples/tensorflow/nlp/transformer_lt_mlperf/quantization/ptq/run_inference.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ from google.protobuf import text_format
 from utils import tokenizer
 from utils.tokenizer import Subtokenizer
 from utils import metrics
-from neural_compressor.data import DATALOADERS
+from neural_compressor.data import DataLoader
 from neural_compressor.utils.utility import dump_elapsed_time
 from neural_compressor.utils import logger
 
@@ -219,8 +219,8 @@ def collate_fn(batch):
 def eval_func(infer_graph):
     dataset = Dataset(FLAGS.input_file, FLAGS.vocab_file)
     sorted_keys = dataset.sorted_keys
-    dataloader = DATALOADERS['tensorflow'] \
-        (dataset, batch_size=FLAGS.batch_size, collate_fn=collate_fn)
+    dataloader = DataLoader(framework='tensorflow', dataset=dataset, 
+                                batch_size=FLAGS.batch_size, collate_fn=collate_fn)
     input_tensors = list(map(infer_graph.get_tensor_by_name, INPUT_TENSOR_NAMES))
     output_tensors = list(map(infer_graph.get_tensor_by_name, OUTPUT_TENSOR_NAMES))
 
@@ -306,12 +306,11 @@ def main(unused_args):
     if FLAGS.tune:
         from neural_compressor import quantization
         from neural_compressor.config import PostTrainingQuantConfig
-        from neural_compressor.data import DataLoader
         dataset = Dataset(FLAGS.input_file, FLAGS.vocab_file)
-        calib_dataloader = DataLoader(dataset = dataset,
-                                      framework ='tensorflow',
-                                      collate_fn = collate_fn,
-                                      batch_size = FLAGS.batch_size)
+        calib_dataloader = DataLoader(framework ='tensorflow',
+                                      dataset = dataset,
+                                      batch_size = FLAGS.batch_size,
+                                      collate_fn = collate_fn)
 
         conf = PostTrainingQuantConfig(inputs=['input_tokens'],
                                         outputs=['model/Transformer/strided_slice_15', 'model/Transformer/strided_slice_16'],

--- a/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_inception_resnet_v2/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_inception_resnet_v2/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,9 @@ import time
 import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
+from neural_compressor.data import DataLoader
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform,DataLoader
+from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform
 
 arg_parser = ArgumentParser(description='Parse args')
 

--- a/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet101/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet101/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,9 @@ import time
 import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
+from neural_compressor.data import DataLoader
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform,DataLoader
+from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform
 
 arg_parser = ArgumentParser(description='Parse args')
 

--- a/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/export/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/export/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,9 @@ import time
 import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
+from neural_compressor.data import DataLoader
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform,DataLoader
+from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform
 
 arg_parser = ArgumentParser(description='Parse args')
 

--- a/examples/tensorflow/object_detection/tensorflow_models/mask_rcnn_inception_v2/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/mask_rcnn_inception_v2/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,9 +22,10 @@ import time
 import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
+from neural_compressor.data import DataLoader
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import COCORecordDataset,ComposeTransform, \
-                LabelBalanceCOCORecordFilter,TensorflowResizeWithRatio,DataLoader
+from neural_compressor.data import COCORecordDataset,ComposeTransform
+from neural_compressor.data import LabelBalanceCOCORecordFilter,TensorflowResizeWithRatio
 
 arg_parser = ArgumentParser(description='Parse args')
 

--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/export/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/export/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ import time
 import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
+from neural_compressor.data import DataLoader
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform,DataLoader
+from neural_compressor.data import COCORecordDataset
+from neural_compressor.data import ComposeTransform,ResizeTFTransform
 
 arg_parser = ArgumentParser(description='Parse args')
 

--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet34/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet34/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,8 +23,9 @@ import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import COCORecordDataset, ComposeTransform, RescaleTFTransform, \
-    DataLoader, NormalizeTFTransform, ResizeTFTransform
+from neural_compressor.data import DataLoader
+from neural_compressor.data import COCORecordDataset, NormalizeTFTransform
+from neural_compressor.data import ComposeTransform, ResizeTFTransform, RescaleTFTransform
 
 arg_parser = ArgumentParser(description='Parse args')
 

--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet50_v1/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet50_v1/quantization/ptq/main.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ import time
 import numpy as np
 import tensorflow as tf
 from argparse import ArgumentParser
+from neural_compressor.data import DataLoader
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import COCORecordDataset,ComposeTransform,ResizeTFTransform,DataLoader
+from neural_compressor.data import COCORecordDataset
+from neural_compressor.data import ComposeTransform, ResizeTFTransform
 
 arg_parser = ArgumentParser(description='Parse args')
 

--- a/examples/tensorflow/object_detection/yolo_v3/quantization/ptq/infer_detections.py
+++ b/examples/tensorflow/object_detection/yolo_v3/quantization/ptq/infer_detections.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +20,13 @@ import time
 import numpy as np
 import tensorflow as tf
 from absl import app, flags
+
+from neural_compressor.data import DataLoader
 from neural_compressor.metric import COCOmAPv2
-from neural_compressor.data import TensorflowResizeWithRatio, ParseDecodeCocoTransform
 from neural_compressor.data import LabelBalanceCOCORecordFilter
-from neural_compressor.data import ComposeTransform, COCORecordDataset, DataLoader
+from neural_compressor.data import ComposeTransform, COCORecordDataset
+from neural_compressor.data import TensorflowResizeWithRatio, ParseDecodeCocoTransform
+
 from coco_constants import LABEL_MAP
 from utils import non_max_suppression
 

--- a/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/inference.py
+++ b/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/inference.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tensorflow/style_transfer/arbitrary_style_transfer/quantization/ptq/style_tune.py
+++ b/examples/tensorflow/style_transfer/arbitrary_style_transfer/quantization/ptq/style_tune.py
@@ -1,7 +1,7 @@
 #
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import tensorflow.compat.v1 as tf
 from PIL import Image
 import time
 from neural_compressor.experimental import Quantization
-from neural_compressor.data import DATALOADERS, Datasets
+from neural_compressor.data import DataLoader, Datasets
 from neural_compressor.adaptor.tf_utils.util import _parse_ckpt_bn_input
 
 flags = tf.flags
@@ -154,7 +154,7 @@ def main(args=None):
         else: 
             dataset = Datasets('tensorflow')['dummy_v2'](\
                 input_shape=[(256, 256, 3), (256, 256, 3)], label_shape=(1, ))
-        dataloader = DATALOADERS['tensorflow'](dataset=dataset, batch_size=FLAGS.batch_size)
+        dataloader = DataLoader(framework='tensorflow', dataset=dataset, batch_size=FLAGS.batch_size)
         tf.import_graph_def(frozen_graph, name='')
         style_transfer(sess, dataloader)
 


### PR DESCRIPTION
## Type of Change

Feature  
API not changed

## Description

Unify the dataloader interface in examples, as how the docs describe:
https://github.com/intel/neural-compressor/blob/master/docs/source/dataloader.md#use-intel-neural-compressor-dataloader-api 

## Expected Behavior & Potential Risk

Extension tests are needed in case of unproper usage of dataloader

## How has this PR been tested?

Extension tests for all changed models


## Dependency Change?

No
