### PR TITLE
replace opencv with opencv-python-headless

### DIFF
--- a/conda_meta/basic/meta.yaml
+++ b/conda_meta/basic/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2" %}
+{% set version = "2.2.1" %}
 {% set buildnumber = 0 %}
 package:
   name: neural-compressor
@@ -23,7 +23,7 @@ requirements:
     - py-cpuinfo
     - pandas
     - pycocotools
-    - opencv
+    - opencv-python-headless
     - psutil
     - Pillow
     - requests

--- a/conda_meta/neural_insights/meta.yaml
+++ b/conda_meta/neural_insights/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2" %}
+{% set version = "2.2.1" %}
 {% set buildnumber = 0 %}
 package:
   name: neural-insights

--- a/conda_meta/neural_solution/meta.yaml
+++ b/conda_meta/neural_solution/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2" %}
+{% set version = "2.2.1" %}
 {% set buildnumber = 0 %}
 package:
   name: neural-solution

--- a/neural_compressor/version.py
+++ b/neural_compressor/version.py
@@ -16,4 +16,4 @@
 # limitations under the License.
 
 """Intel® Neural Compressor: An open-source Python library supporting popular model compression techniques."""
-__version__ = "2.2"
+__version__ = "2.2.1"

--- a/neural_solution/version.py
+++ b/neural_solution/version.py
@@ -16,4 +16,4 @@
 # limitations under the License.
 
 """Neural Solution."""
-__version__ = "2.2"
+__version__ = "2.2.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ psutil
 Pillow
 pycocotools-windows; sys_platform != 'linux'
 pycocotools; sys_platform == 'linux'
-opencv-python
+opencv-python-headless
 prettytable
 deprecated >= 1.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ py-cpuinfo
 requests
 psutil
 Pillow
-pycocotools-windows; sys_platform != 'linux'
-pycocotools; sys_platform == 'linux'
+pycocotools-windows; sys_platform == 'win32' and python_version <= '3.8'
+pycocotools; sys_platform != 'win32' or python_version > '3.8'
 opencv-python-headless
 prettytable
 deprecated >= 1.2.13


### PR DESCRIPTION
## Type of Change

others

## Description

1. replace opencv with opencv-python-headless
2. enhance pycocotools installation
3. bump release version into v2.2.1

## Expected Behavior & Potential Risk

To avoid issue 'ImportError: libGL.so.1' cased by opencv-python. Support for ONNXRT integration https://github.com/microsoft/onnxruntime/pull/16288 

## How has this PR been tested?

CI and minimal release test. 

## Dependency Change?

Yes, but they build from the some source code, so no need to update the BoM. 
