### PR TITLE
Support tf.Tensor as Labels for TopK Metric

### DIFF
--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -131,7 +131,8 @@ class GraphConverter:
         else:
             self._fp32_model = Model(self.model._model,
                                      **self.model.kwargs,
-                                     backend="itex" if itex_mode else "default")
+                                     backend="itex" if itex_mode and not \
+                                     isinstance(self.model, TensorflowSavedModelModel) else "default")
         self._fp32_model.graph_def = self.model.graph_def
         self._fp32_model.output_tensor_names = self.output_tensor_names
         self._fp32_model.input_tensor_names = self.input_tensor_names
@@ -155,7 +156,8 @@ class GraphConverter:
         else:
             self._sampling_model = Model(self.model._model,
                                          **self.model.kwargs,
-                                         backend="itex" if itex_mode else "default")
+                                         backend="itex" if itex_mode and not \
+                                         isinstance(self.model, TensorflowSavedModelModel) else "default")
         self._sampling_model.output_tensor_names = self.output_tensor_names
         self._sampling_model.input_tensor_names = self.input_tensor_names
 
@@ -341,7 +343,8 @@ class GraphConverter:
             else:
                 self._tmp_model = Model(self.model._model,
                                         **self.model.kwargs,
-                                        backend="itex" if self.itex_mode else "default")
+                                        backend="itex" if self.itex_mode and not \
+                                        isinstance(self.model, TensorflowSavedModelModel) else "default")
             self._tmp_model.graph_def = self.model.graph_def
             self._tmp_model.output_tensor_names = self.output_tensor_names
             self._tmp_model.input_tensor_names = self.input_tensor_names
@@ -620,7 +623,8 @@ class GraphConverter:
         if "backend" in self._tmp_model.kwargs:
             model = Model(tmp_path, **self._tmp_model.kwargs)
         else:
-            model = Model(tmp_path, **self._tmp_model.kwargs, backend="itex" if self.itex_mode else "default")
+            model = Model(tmp_path, **self._tmp_model.kwargs, backend="itex" if self.itex_mode and \
+                        not isinstance(self._tmp_model, TensorflowSavedModelModel) else "default")
         model.output_tensor_names = self.output_tensor_names
         model.input_tensor_names = self.input_tensor_names
 

--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -32,6 +32,7 @@ from neural_compressor.utils.utility import combine_histogram
 from neural_compressor.utils.utility import CaptureOutputToFile, CpuInfo
 from neural_compressor.conf.dotdict import deep_get
 from neural_compressor.model import Model
+from neural_compressor.model.tensorflow_model import TensorflowSavedModelModel
 from .transform_graph.insert_logging import InsertLogging
 from .transform_graph.rerange_quantized_concat import RerangeQuantizedConcat
 from .transform_graph.bias_correction import BiasCorrection

--- a/neural_compressor/metric/metric.py
+++ b/neural_compressor/metric/metric.py
@@ -921,6 +921,15 @@ class TensorflowTopK(BaseMetric):
             labels: The labels corresponding to the predictions.
             sample_weight: The sample weight.
         """
+        # extract the contents from tf.Tensor
+        if not isinstance(labels, int) and len(labels) > 0 \
+            and isinstance(labels[0], tf.Tensor):
+            temp_labels = []
+            for label_tensor in labels:
+                label_contents = label_tensor.numpy()
+                temp_labels.append(label_contents)
+            labels = temp_labels  
+            
         preds, labels = _topk_shape_validate(preds, labels)
 
         labels = labels.reshape([len(labels)])


### PR DESCRIPTION
## Type of Change

feature & bug fix
API not changed

## Description

The TopK metric will check shape before updating predictions and labels.
While doing the check, a tuple or list with tf.Tensor inside it will be expanded to unexpected dimension.
Therefore, we need to extract contents from tf.Tensor before applying the check.

## Expected Behavior & Potential Risk

Labels with tf.Tensor will reports no error when checking shape.

## How has this PR been tested?

PreCI

## Dependency Change?

No
