### PR TITLE
Fix precision tuning bug for ONNX CUDA EP

### DIFF
--- a/neural_compressor/strategy/utils/constant.py
+++ b/neural_compressor/strategy/utils/constant.py
@@ -25,7 +25,7 @@ TUNING_ITEMS_LST = [('activation','scheme'), ('activation','algorithm'), ('activ
                     ('weight','scheme'), ('weight','algorithm'), ('weight','granularity'),
                     ('weight','bits'), ('weight','group_size'), 'sampling_size']
 
-PRECISION_SET_V2_0 = {'fp32', 'bf16'}
+PRECISION_SET_V2_0 = {'fp32', 'bf16', 'fp16'}
 
 auto_query_order = ['static', 'dynamic', 'bf16', 'fp16', 'fp32']
 static_query_order = ['static', 'bf16', 'fp16', 'fp32']

--- a/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
+++ b/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
@@ -1235,7 +1235,7 @@ class TestAdaptorONNXRT(unittest.TestCase):
         q_model = quantization.fit(self.distilbert_model, config, 
             calib_dataloader=DummyNLPDataloader_dict("distilbert-base-uncased-finetuned-sst-2-english"),
             eval_func=eval)
-        self.assertTrue('QLinearMatMul' not in [i.op_type for i in q_model.nodes()])
+        self.assertTrue('QLinearMatMul' in [i.op_type for i in q_model.nodes()])
 
         config = PostTrainingQuantConfig(approach='static', recipes={'optypes_to_exclude_output_quant': ['MatMul']})
         q_model = quantization.fit(self.matmul_model, config,

--- a/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
+++ b/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
@@ -1231,6 +1231,12 @@ class TestAdaptorONNXRT(unittest.TestCase):
             calib_dataloader=self.matmul_dataloader, eval_func=eval)
         self.assertTrue('QLinearMatMul' not in [i.op_type for i in q_model.nodes()])
 
+        config = PostTrainingQuantConfig(approach='static', backend='onnxrt_cuda_ep', device='gpu', quant_level=1)
+        q_model = quantization.fit(self.distilbert_model, config, 
+            calib_dataloader=DummyNLPDataloader_dict("distilbert-base-uncased-finetuned-sst-2-english"),
+            eval_func=eval)
+        self.assertTrue('QLinearMatMul' not in [i.op_type for i in q_model.nodes()])
+
         config = PostTrainingQuantConfig(approach='static', recipes={'optypes_to_exclude_output_quant': ['MatMul']})
         q_model = quantization.fit(self.matmul_model, config,
             calib_dataloader=self.matmul_dataloader, eval_func=eval)


### PR DESCRIPTION
## Type of Change

bug fix
API not change

## Description

```
config = PostTrainingQuantConfig(backend='onnxrt_cuda_ep', device='gpu', quant_level=1)
q_model = quantization.fit(model, config, calib_dataloader=dataloader)
```
failed with error:

![image](https://github.com/intel/neural-compressor/assets/83261447/84bc57f4-9f95-4d5e-93e5-9629256740dc)


## Expected Behavior & Potential Risk

Fix the failure

## How has this PR been tested?

onnx bert_base_MRPC example with CUDA EP

## Dependency Change?

No
