### PR TITLE
Update python version limitation for onnxruntime-extensions package

### DIFF
--- a/examples/onnxrt/body_analysis/onnx_model_zoo/arcface/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/body_analysis/onnx_model_zoo/arcface/quantization/ptq_static/requirements.txt
@@ -1,3 +1,3 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/body_analysis/onnx_model_zoo/emotion_ferplus/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/body_analysis/onnx_model_zoo/emotion_ferplus/quantization/ptq_static/requirements.txt
@@ -1,5 +1,5 @@
 onnx
 onnxruntime
-onnxruntime_extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0
 pandas

--- a/examples/onnxrt/body_analysis/onnx_model_zoo/ultraface/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/body_analysis/onnx_model_zoo/ultraface/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime_extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 scipy

--- a/examples/onnxrt/image_recognition/mobilenet_v2/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/mobilenet_v2/quantization/ptq_static/requirements.txt
@@ -2,6 +2,5 @@ onnx
 onnxruntime
 torch
 torchvision
-onnxruntime-extensions; python_version < '3.10'
-
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.1.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/mobilenet_v3/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/mobilenet_v3/quantization/ptq_static/requirements.txt
@@ -1,6 +1,5 @@
 onnx
 onnxruntime
 tf2onnx
-onnxruntime-extensions; python_version < '3.10'
-
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.1.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/alexnet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/alexnet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/caffenet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/caffenet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/densenet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/densenet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/efficientnet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/efficientnet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/fcn/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/fcn/quantization/ptq_static/requirements.txt
@@ -2,4 +2,4 @@ onnx
 onnxruntime
 torchvision
 pillow>=8.2.0
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/googlenet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/googlenet/quantization/ptq_static/requirements.txt
@@ -2,4 +2,4 @@ onnx
 onnxruntime
 opencv-python
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/inception/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/inception/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/mnist/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/mnist/quantization/ptq_static/requirements.txt
@@ -1,5 +1,5 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
 tqdm

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/mobilenet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/mobilenet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/resnet50/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/resnet50/quantization/ptq_static/requirements.txt
@@ -2,5 +2,5 @@ onnx
 onnxruntime
 torch
 torchvision
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/shufflenet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/shufflenet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/squeezenet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/squeezenet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
 pillow>=8.2.0
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/vgg16/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/vgg16/quantization/ptq_static/requirements.txt
@@ -2,5 +2,5 @@ onnx
 onnxruntime
 torch
 torchvision
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/onnx_model_zoo/zfnet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/onnx_model_zoo/zfnet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/image_recognition/resnet50_mlperf/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/resnet50_mlperf/quantization/ptq_static/requirements.txt
@@ -2,6 +2,5 @@ onnx
 onnxruntime
 torch
 torchvision
-onnxruntime-extensions; python_version < '3.10'
-
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/resnet50_torchvision/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/resnet50_torchvision/quantization/ptq_static/requirements.txt
@@ -2,6 +2,5 @@ onnx
 onnxruntime
 torch
 torchvision
-onnxruntime-extensions; python_version < '3.10'
-
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/image_recognition/unet/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/unet/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime_extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 protobuf==3.20.3

--- a/examples/onnxrt/image_recognition/vgg16/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/image_recognition/vgg16/quantization/ptq_static/requirements.txt
@@ -1,7 +1,6 @@
 onnx
 onnxruntime
-onnxruntime_extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 torch
 torchvision
-
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/bert/quantization/ptq_dynamic/requirements.txt
@@ -5,4 +5,4 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/bert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/bert/quantization/ptq_static/requirements.txt
@@ -5,4 +5,4 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/distilbert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/distilbert/quantization/ptq_dynamic/requirements.txt
@@ -5,5 +5,5 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 tokenizers>=0.12.0

--- a/examples/onnxrt/nlp/distilbert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/distilbert/quantization/ptq_static/requirements.txt
@@ -5,5 +5,5 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 tokenizers>=0.12.0

--- a/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_dynamic/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime
 coloredlogs
 torch
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime
 coloredlogs
 torch
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/requirements.txt
@@ -1,6 +1,6 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 transformers
 accelerate
 tensorboard

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/requirements.txt
@@ -1,6 +1,6 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 transformers
 accelerate
 tensorboard

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/mix_precision/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/mix_precision/requirements.txt
@@ -4,6 +4,6 @@ onnx
 onnxruntime >= 1.14.0
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 numpy
 optimum[exporters]

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_dynamic/requirements.txt
@@ -5,7 +5,7 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 numpy==1.23.5
 sentencepiece
 protobuf<=3.20.3

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
@@ -5,7 +5,7 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 numpy==1.23.5
 sentencepiece
 protobuf<=3.20.3

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/gptj/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/gptj/quantization/ptq_dynamic/requirements.txt
@@ -3,5 +3,5 @@ transformers
 accelerate
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 datasets

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/gptj/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/gptj/quantization/ptq_static/requirements.txt
@@ -3,5 +3,5 @@ transformers
 accelerate
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 datasets

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/ptq_static/requirements.txt
@@ -5,7 +5,7 @@ transformers
 accelerate
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 datasets
 optimum
 evaluate

--- a/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlm/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlm/quantization/ptq_dynamic/requirements.txt
@@ -17,4 +17,4 @@ torchvision
 setuptools
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlm/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlm/quantization/ptq_static/requirements.txt
@@ -17,4 +17,4 @@ torchvision
 setuptools
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv2/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv2/quantization/ptq_dynamic/requirements.txt
@@ -15,7 +15,7 @@ torchvision
 setuptools
 onnx
 onnxruntime
-onnxruntime-extensions
+onnxruntime-extensions; python_version < '3.11'
 pytesseract
 #detectron2  # TODO export require it, resolve it later
 # git+https://github.com/facebookresearch/detectron2.git

--- a/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv2/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv2/quantization/ptq_static/requirements.txt
@@ -15,7 +15,7 @@ torchvision
 setuptools
 onnx
 onnxruntime
-onnxruntime-extensions
+onnxruntime-extensions; python_version < '3.11'
 pytesseract
 #detectron2  # TODO export require it, resolve it later
 # git+https://github.com/facebookresearch/detectron2.git

--- a/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv3/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv3/quantization/ptq_dynamic/requirements.txt
@@ -16,4 +16,4 @@ torchvision
 setuptools
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv3/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/token_classification/layoutlmv3/quantization/ptq_static/requirements.txt
@@ -16,4 +16,4 @@ torchvision
 setuptools
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/mobilebert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/mobilebert/quantization/ptq_dynamic/requirements.txt
@@ -5,4 +5,4 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/mobilebert/quantization/ptq_static/requirements.txt
@@ -5,4 +5,4 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/onnx_model_zoo/BiDAF/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/BiDAF/quantization/ptq_dynamic/requirements.txt
@@ -2,6 +2,6 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 nltk
 tqdm

--- a/examples/onnxrt/nlp/onnx_model_zoo/bert-squad/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/bert-squad/quantization/ptq_dynamic/requirements.txt
@@ -2,6 +2,6 @@ onnx
 onnxruntime
 intel-tensorflow==2.12.0
 torch
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.1.0 # not directly required, pinned by Snyk to avoid a vulnerability
 tqdm

--- a/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/gpt2/quantization/ptq_dynamic/requirements.txt
@@ -4,5 +4,5 @@ onnxruntime
 coloredlogs
 torch
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 tqdm

--- a/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_dynamic/requirements.txt
@@ -3,6 +3,6 @@ onnxruntime
 intel-tensorflow==2.12.0
 tf2onnx
 torch
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.1.0 # not directly required, pinned by Snyk to avoid a vulnerability
 tqdm

--- a/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/onnx_model_zoo/mobilebert/quantization/ptq_static/requirements.txt
@@ -3,6 +3,6 @@ onnxruntime
 intel-tensorflow==2.12.0
 tf2onnx
 torch
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.1.0 # not directly required, pinned by Snyk to avoid a vulnerability
 tqdm

--- a/examples/onnxrt/nlp/roberta/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/roberta/quantization/ptq_dynamic/requirements.txt
@@ -5,4 +5,4 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/nlp/roberta/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/roberta/quantization/ptq_static/requirements.txt
@@ -5,4 +5,4 @@ onnx
 onnxruntime
 coloredlogs
 sympy
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/onnxrt/object_detection/onnx_model_zoo/DUC/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/DUC/quantization/ptq_static/requirements.txt
@@ -1,5 +1,5 @@
 onnx
 onnxruntime
-onnxruntime_extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
 opencv-python

--- a/examples/onnxrt/object_detection/onnx_model_zoo/faster_rcnn/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/faster_rcnn/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/onnx_model_zoo/mask_rcnn/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/mask_rcnn/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/onnx_model_zoo/ssd/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/ssd/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/onnx_model_zoo/ssd_mobilenet_v1/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/ssd_mobilenet_v1/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/onnx_model_zoo/tiny_yolov3/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/tiny_yolov3/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime_extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/onnx_model_zoo/yolov3/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/yolov3/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/onnx_model_zoo/yolov4/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/onnx_model_zoo/yolov4/quantization/ptq_static/requirements.txt
@@ -1,4 +1,4 @@
 onnx
 onnxruntime
-onnxruntime_extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/ssd_mobilenet_v1/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/ssd_mobilenet_v1/quantization/ptq_static/requirements.txt
@@ -2,5 +2,5 @@ onnx
 onnxruntime
 torch
 torchvision
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/onnxrt/object_detection/ssd_mobilenet_v2/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/object_detection/ssd_mobilenet_v2/quantization/ptq_static/requirements.txt
@@ -2,5 +2,5 @@ onnx
 onnxruntime
 torch
 torchvision
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 pillow>=8.2.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/mobilenet_v2/export/requirements.txt
@@ -3,4 +3,4 @@ intel-extension-for-tensorflow[cpu]
 tf2onnx>=1.10.1
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1/export/requirements.txt
@@ -3,4 +3,4 @@ intel-extension-for-tensorflow[cpu]
 tf2onnx>=1.10.1
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/resnet50_v1_5/export/requirements.txt
@@ -3,4 +3,4 @@ intel-extension-for-tensorflow[cpu]
 tf2onnx>=1.10.1
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/requirements.txt
+++ b/examples/tensorflow/image_recognition/tensorflow_models/vgg16/export/requirements.txt
@@ -3,4 +3,4 @@ intel-extension-for-tensorflow[cpu]
 tf2onnx>=1.10.1
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/export/requirements.txt
+++ b/examples/tensorflow/object_detection/tensorflow_models/faster_rcnn_resnet50/export/requirements.txt
@@ -3,4 +3,4 @@ intel-extension-for-tensorflow[cpu]
 tf2onnx>=1.10.1
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/export/requirements.txt
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_mobilenet_v1/export/requirements.txt
@@ -3,4 +3,4 @@ intel-extension-for-tensorflow[cpu]
 tf2onnx>=1.10.1
 onnx
 onnxruntime
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'

--- a/neural_compressor/adaptor/onnxrt.py
+++ b/neural_compressor/adaptor/onnxrt.py
@@ -708,7 +708,7 @@ class ONNXRUNTIMEAdaptor(Adaptor):
         sess_options.graph_optimization_level = optimization_levels[level]
         sess_options.optimized_model_filepath = os.path.join(self.work_space, \
             "Optimized_model.onnx")
-        if sys.version_info < (3,10) and find_spec('onnxruntime_extensions'): # pragma: no cover
+        if sys.version_info < (3,11) and find_spec('onnxruntime_extensions'): # pragma: no cover
             from onnxruntime_extensions import get_library_path
             sess_options.register_custom_ops_library(get_library_path())
         if not model.is_large_model:
@@ -1233,7 +1233,7 @@ class ONNXRUNTIMEAdaptor(Adaptor):
             cores_per_instance = int(os.environ.get('CORES_PER_INSTANCE'))
             assert cores_per_instance > 0, "benchmark cores_per_instance should greater than 0"
             sess_options.intra_op_num_threads = cores_per_instance
-        if sys.version_info < (3,10) and find_spec('onnxruntime_extensions'): # pragma: no cover
+        if sys.version_info < (3,11) and find_spec('onnxruntime_extensions'): # pragma: no cover
             from onnxruntime_extensions import get_library_path
             sess_options.register_custom_ops_library(get_library_path())
         session = ort.InferenceSession(self.work_space + 'eval.onnx',

--- a/neural_compressor/adaptor/ox_utils/calibration.py
+++ b/neural_compressor/adaptor/ox_utils/calibration.py
@@ -213,7 +213,7 @@ class ONNXRTAugment:
         """Gather intermediate model outputs after running inference."""
         # conduct inference session and get intermediate outputs
         so = onnxruntime.SessionOptions()
-        if sys.version_info < (3, 10) and find_spec('onnxruntime_extensions'):  # pragma: no cover
+        if sys.version_info < (3, 11) and find_spec('onnxruntime_extensions'):  # pragma: no cover
             from onnxruntime_extensions import get_library_path
             so.register_custom_ops_library(get_library_path())
 

--- a/neural_compressor/adaptor/ox_utils/weight_only.py
+++ b/neural_compressor/adaptor/ox_utils/weight_only.py
@@ -298,7 +298,7 @@ def prepare_inputs(model, n_samples, dataloader):
     from neural_compressor.adaptor.ox_utils.util import to_numpy
     
     so = ort.SessionOptions()
-    if sys.version_info < (3, 10) and find_spec('onnxruntime_extensions'):  # pragma: no cover
+    if sys.version_info < (3, 11) and find_spec('onnxruntime_extensions'):  # pragma: no cover
         from onnxruntime_extensions import get_library_path
         so.register_custom_ops_library(get_library_path())
     if model.is_large_model:

--- a/neural_compressor/model/model.py
+++ b/neural_compressor/model/model.py
@@ -74,7 +74,7 @@ def get_model_fwk_name(model):
         from importlib.util import find_spec
         try:
             so = ort.SessionOptions()
-            if sys.version_info < (3,10) and \
+            if sys.version_info < (3,11) and \
                 find_spec('onnxruntime_extensions'): # pragma: no cover
                 from onnxruntime_extensions import get_library_path
                 so.register_custom_ops_library(get_library_path())

--- a/neural_insights/components/model/onnxrt/model.py
+++ b/neural_insights/components/model/onnxrt/model.py
@@ -217,7 +217,7 @@ class OnnxrtModel(Model):
         """Ensure all requirements are installed."""
         check_module("onnx")
         check_module("onnxruntime")
-        if sys.version_info < (3, 10):  # pragma: no cover
+        if sys.version_info < (3, 11):  # pragma: no cover
             check_module("onnxruntime_extensions")
 
     @property

--- a/neural_insights/test/requirements.txt
+++ b/neural_insights/test/requirements.txt
@@ -1,4 +1,4 @@
 intel-tensorflow
 onnxruntime
 onnx
-onnxruntime-extensions
+onnxruntime-extensions; python_version < '3.11'

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -15,7 +15,7 @@ accelerate
 tensorflow_model_optimization
 horovod
 tensorflow-addons
-onnxruntime-extensions; python_version < '3.10'
+onnxruntime-extensions; python_version < '3.11'
 dynast==1.3.0
 intel-extension-for-pytorch
 tf2onnx


### PR DESCRIPTION
## Type of Change

enahncement
API not change

## Description

[onnxruntime-extensions](https://pypi.org/project/onnxruntime-extensions/#files) is avaliable for python 3.10 now. 
Update onnxruntime-extensions python version limitation from `<3.10` to `<3.11` .
 
## Expected Behavior & Potential Risk

CI test pass

## How has this PR been tested?

CI test

## Dependency Change?

No
