### PR TITLE
Fix TF2.13.0 TF models quantize failed issue due to no attribute 'convert_variables_to_constants'

### DIFF
--- a/examples/tensorflow/oob_models/quantization/ptq/tf_savemodel_benchmark.py
+++ b/examples/tensorflow/oob_models/quantization/ptq/tf_savemodel_benchmark.py
@@ -23,9 +23,8 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.python.client import timeline
 from tensorflow.python.tools import optimize_for_inference_lib
-from tensorflow.python.framework import graph_util
 from tensorflow.core.protobuf import rewriter_config_pb2
-
+from tensorflow.compat.v1 import graph_util
 
 def get_dynamic_inputshape(model_dir,dshape):
     # judge object_detection model

--- a/examples/tensorflow/oob_models/quantization/ptq/utils.py
+++ b/examples/tensorflow/oob_models/quantization/ptq/utils.py
@@ -18,8 +18,8 @@
 
 import os
 import numpy as np
-from tensorflow.python.framework import graph_util
 from tensorflow.python.platform import gfile
+from tensorflow.compat.v1 import graph_util
 
 try:
     import tensorflow.compat.v1 as tf_v1

--- a/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/inference.py
+++ b/examples/tensorflow/recommendation/wide_deep_large_ds/quantization/ptq/inference.py
@@ -32,12 +32,13 @@ import json
 import datetime
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
 from tensorflow.python.framework import ops
 from tensorflow.core.framework import graph_pb2
 from google.protobuf import text_format
 from argparse import ArgumentParser
 from tensorflow.python.tools.optimize_for_inference_lib import optimize_for_inference
+from tensorflow.compat.v1 import graph_util
+
 
 def load_graph(model_file):
     """This is a function to load TF graph from pb file

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/fuse_decomposed_bn.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/generic/fuse_decomposed_bn.py
@@ -26,7 +26,7 @@ from tensorflow.core.framework import attr_value_pb2
 from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.platform import flags as flags_lib
 from tensorflow.python.platform import tf_logging

--- a/neural_compressor/model/tensorflow_model.py
+++ b/neural_compressor/model/tensorflow_model.py
@@ -399,7 +399,7 @@ def _get_graph_from_saved_model_v1(model):
         raise ValueError("SavedModels with assets/ directory are not supported.")
 
     from tensorflow.python.saved_model import loader
-    from tensorflow.python.framework import graph_util as tf_graph_util
+    from tensorflow.compat.v1 import graph_util as tf_graph_util
     graph = ops.Graph()
     import tensorflow as tf
     with session.Session(graph=graph) as sess:
@@ -1128,7 +1128,7 @@ class TensorflowCheckpointModel(TensorflowBaseModel):
         if self.model_type == 'graph_def':
             return self.sess.graph.as_graph_def()
         from neural_compressor.adaptor.tf_utils.util import _parse_ckpt_bn_input
-        from tensorflow.python.framework import graph_util
+        from tensorflow.compat.v1 import graph_util
         graph_def = self.sess.graph.as_graph_def()
         graph_def = _parse_ckpt_bn_input(graph_def)
         return graph_util.convert_variables_to_constants(

--- a/test/adaptor/tensorflow_adaptor/test_bf16_convert.py
+++ b/test/adaptor/tensorflow_adaptor/test_bf16_convert.py
@@ -434,7 +434,7 @@ class TestBF16Convert(unittest.TestCase):
 
             graph = sess.graph
 
-            from tensorflow.python.framework import graph_util
+            from tensorflow.compat.v1 import graph_util
             graph_def = graph_util.convert_variables_to_constants(
                 sess,
                 graph.as_graph_def(),

--- a/test/adaptor/tensorflow_adaptor/test_smooth_quant_tf.py
+++ b/test/adaptor/tensorflow_adaptor/test_smooth_quant_tf.py
@@ -6,7 +6,7 @@ from neural_compressor.data.dataloaders.dataloader import DataLoader
 from neural_compressor.quantization import fit
 from neural_compressor.config import PostTrainingQuantConfig
 from neural_compressor.utils.utility import set_random_seed
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 class TestSmoothQuantTF(unittest.TestCase):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_bias_correction.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_bias_correction.py
@@ -7,7 +7,7 @@ from neural_compressor.adaptor.tf_utils.transform_graph.bias_correction import B
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 class TestBiasCorrection(unittest.TestCase):
     def test_bias_correction(self):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_convert_layout.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_convert_layout.py
@@ -1,7 +1,7 @@
 import unittest
 from neural_compressor.adaptor.tf_utils.graph_rewriter.generic import convert_layout
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from neural_compressor.adaptor.tf_utils.util import version1_gte_version2
 
 class TestConvertLayout(unittest.TestCase):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_data_pipline.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_data_pipline.py
@@ -8,7 +8,7 @@ from neural_compressor.adaptor.tf_utils.quantize_graph_common import QuantizeGra
 from neural_compressor.adaptor.tf_utils.util import get_tensor_by_name, iterator_sess_run
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 class TestDataPipelineConvert(unittest.TestCase):
 
     def test_data_pipeline(self):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_fold_batch_norm.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_fold_batch_norm.py
@@ -5,7 +5,7 @@ from neural_compressor.adaptor.tf_utils.quantize_graph_common import QuantizeGra
 from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.fold_batch_norm import FoldBatchNormNodesOptimizer
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 class TestFoldBatchnorm(unittest.TestCase):
     tf.compat.v1.disable_eager_execution()
     x = tf.compat.v1.placeholder(tf.float32, [1, 224, 224, 3], name="input")

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_column_wise_mul.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_column_wise_mul.py
@@ -7,7 +7,7 @@ from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.fuse_column_wise_
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 class TestColumnWiseMulFusion(unittest.TestCase):
 

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_concat.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_concat.py
@@ -12,7 +12,7 @@ from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 def build_fake_yaml():

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_conv_add_relu_fusion.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_conv_add_relu_fusion.py
@@ -7,7 +7,7 @@ from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 class TestConvAddRelu(unittest.TestCase):
     @disable_random()
     def test_conv_add_relu(self):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_conv_fusion.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_conv_fusion.py
@@ -14,7 +14,7 @@ from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_conv_math.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_conv_math.py
@@ -8,7 +8,7 @@ from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.fuse_conv_with_ma
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 class TestConvWithMath(unittest.TestCase):
     @disable_random()
     def test_convert_conv_with_math(self):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_convert_layout.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_convert_layout.py
@@ -6,7 +6,7 @@ import unittest
 from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.convert_layout import ConvertLayoutOptimizer
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from neural_compressor.adaptor.tf_utils.util import version1_lt_version2
 
 class TestConvertLayout(unittest.TestCase):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_convert_leakyrelu.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_convert_leakyrelu.py
@@ -8,7 +8,7 @@ from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.convert_leakyrelu
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 class TestConvertLeaklyRelu(unittest.TestCase):
     @disable_random()

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_convert_nan.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_convert_nan.py
@@ -8,7 +8,7 @@ from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.convert_nan_to_ra
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import tensor_util
 
 class TestNanConvert(unittest.TestCase):

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_debug_mode.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_debug_mode.py
@@ -5,7 +5,7 @@ import yaml
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 import logging
 logger = logging.getLogger("neural_compressor")

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_expanddims_optimizer.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_expanddims_optimizer.py
@@ -5,7 +5,7 @@ import numpy as np
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_fetch_weight_from_reshape.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_fetch_weight_from_reshape.py
@@ -5,7 +5,7 @@ import numpy as np
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.core.framework import attr_value_pb2
 from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_fuse_gelu.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_fuse_gelu.py
@@ -7,7 +7,7 @@ from neural_compressor.adaptor.tf_utils.util import disable_random
 from neural_compressor.adaptor.tf_utils.util import version1_lt_version2
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 @unittest.skipIf(tf.version.VERSION.find('up') == -1, 
         "Only supports tf 1.15.up2 and 1.15.up3 and SprBase")

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_insert_logging.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_insert_logging.py
@@ -8,7 +8,7 @@ from neural_compressor.adaptor.tf_utils.quantize_graph.quantize_graph_for_intel_
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_meta_pass.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_meta_pass.py
@@ -7,7 +7,7 @@ import yaml
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_pad_conv.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_pad_conv.py
@@ -5,7 +5,7 @@ import yaml
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_post_cse_optimize.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_post_cse_optimize.py
@@ -6,7 +6,7 @@ import numpy as np
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_switch_optimizer.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_graph_switch_optimizer.py
@@ -7,7 +7,7 @@ import numpy as np
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.ops import control_flow_ops
 
 def build_fake_yaml():

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_move_squeeze_after_relu.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_move_squeeze_after_relu.py
@@ -8,7 +8,7 @@ import numpy as np
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 def build_fake_yaml():

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_quantize_input.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_quantize_input.py
@@ -6,7 +6,7 @@ from neural_compressor.adaptor.tensorflow import TensorFlowAdaptor
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_query_yaml.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_query_yaml.py
@@ -8,7 +8,7 @@ from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 def build_fake_yaml_on_grappler():

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_rnn.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_rnn.py
@@ -7,7 +7,7 @@ from neural_compressor.adaptor.tf_utils.util import disable_random
 from neural_compressor.adaptor.tf_utils.graph_util import GraphRewriterHelper as Helper
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_set_tensor.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_set_tensor.py
@@ -7,7 +7,7 @@ from neural_compressor.adaptor.tensorflow import TensorFlowAdaptor
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/adaptor/tensorflow_adaptor/test_tensorflow_strip_equivalent_nodes.py
+++ b/test/adaptor/tensorflow_adaptor/test_tensorflow_strip_equivalent_nodes.py
@@ -7,7 +7,7 @@ import os
 import yaml
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from neural_compressor.adaptor.tf_utils.util import disable_random
 from neural_compressor.experimental import Quantization, common
 

--- a/test/config/test_config_regex.py
+++ b/test/config/test_config_regex.py
@@ -6,7 +6,7 @@ import unittest
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/graph_optimization/test_graph_optimization.py
+++ b/test/graph_optimization/test_graph_optimization.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 import tensorflow as tf
 from tensorflow.core.framework import graph_pb2
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/itex/test_smooth_quant_itex.py
+++ b/test/itex/test_smooth_quant_itex.py
@@ -6,7 +6,7 @@ from neural_compressor.data.dataloaders.dataloader import DataLoader
 from neural_compressor.quantization import fit
 from neural_compressor.config import PostTrainingQuantConfig
 from neural_compressor.utils.utility import set_random_seed
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 class TestItexSmoothQuantTF(unittest.TestCase):

--- a/test/itex/test_tensorflow_itex_2.x.py
+++ b/test/itex/test_tensorflow_itex_2.x.py
@@ -11,7 +11,7 @@ from neural_compressor import set_random_seed
 from neural_compressor.adaptor.tf_utils.util import version1_lt_version2
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 class TestItexNewAPI(unittest.TestCase):
     @classmethod

--- a/test/itex/test_tensorflow_itex_basic.py
+++ b/test/itex/test_tensorflow_itex_basic.py
@@ -12,7 +12,7 @@ from neural_compressor.experimental import Quantization, Benchmark, common
 from neural_compressor.adaptor.tf_utils.util import version1_lt_version2, version1_gte_version2
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml(fake_yaml, save_path, **kwargs):
     y = yaml.load(fake_yaml, Loader=yaml.SafeLoader)

--- a/test/itex/test_tensorflow_qdq_convert_to_onnx_qdq.py
+++ b/test/itex/test_tensorflow_qdq_convert_to_onnx_qdq.py
@@ -12,7 +12,7 @@ from neural_compressor.experimental import Quantization, common, Benchmark
 from neural_compressor.adaptor.tf_utils.util import version1_lt_version2, version1_gte_version2
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml(fake_yaml, save_path, **kwargs):
     y = yaml.load(fake_yaml, Loader=yaml.SafeLoader)

--- a/test/model/test_model.py
+++ b/test/model/test_model.py
@@ -316,7 +316,7 @@ class TestTensorflowModel(unittest.TestCase):
         from tensorflow.python.training.tracking.tracking import AutoTrackable 
         assert isinstance(model.model, AutoTrackable), "The model getter of TensorflowSavedModelModel is not correctly run."
 
-        from tensorflow.python.framework import graph_util  
+        from tensorflow.compat.v1 import graph_util  
         graph_def = graph_util.convert_variables_to_constants(
             sess=model.sess,
             input_graph_def=model.graph_def,

--- a/test/quantization/test_quantization.py
+++ b/test/quantization/test_quantization.py
@@ -158,7 +158,7 @@ def build_fake_yaml6():
 
 def build_fake_model():
     import tensorflow as tf
-    from tensorflow.python.framework import graph_util
+    from tensorflow.compat.v1 import graph_util
     try:
         graph = tf.Graph()
         graph_def = tf.GraphDef()
@@ -301,7 +301,7 @@ class TestQuantization(unittest.TestCase):
 
     def test_resume(self):
         import tensorflow as tf
-        from tensorflow.python.framework import graph_util
+        from tensorflow.compat.v1 import graph_util
         tf.compat.v1.disable_eager_execution()
         tf.compat.v1.reset_default_graph()
         tf.compat.v1.set_random_seed(1)

--- a/test/quantization/test_tensorflow_recipe.py
+++ b/test/quantization/test_tensorflow_recipe.py
@@ -7,7 +7,7 @@ import yaml
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml_disable_first_quantization():
     fake_yaml = '''

--- a/test/quantization/test_tensorflow_recover.py
+++ b/test/quantization/test_tensorflow_recover.py
@@ -9,7 +9,7 @@ from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
 from tensorflow.python.platform import gfile
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import tensor_util
 
 import logging

--- a/test/tfnewapi/test_smooth_quant_newapi.py
+++ b/test/tfnewapi/test_smooth_quant_newapi.py
@@ -6,7 +6,7 @@ from neural_compressor.data.dataloaders.dataloader import DataLoader
 from neural_compressor.quantization import fit
 from neural_compressor.config import PostTrainingQuantConfig
 from neural_compressor.utils.utility import set_random_seed
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 class TestSmoothQuantTFNewApi(unittest.TestCase):

--- a/test/tfnewapi/test_tensorflow_bias_correction.py
+++ b/test/tfnewapi/test_tensorflow_bias_correction.py
@@ -8,7 +8,7 @@ from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''

--- a/test/tfnewapi/test_tensorflow_fuse_reshape_transpose.py
+++ b/test/tfnewapi/test_tensorflow_fuse_reshape_transpose.py
@@ -8,7 +8,7 @@ import numpy as np
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow.compat.v1 as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 def build_fake_yaml():

--- a/test/tfnewapi/test_tensorflow_graph_biasadd_add_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_biasadd_add_fusion.py
@@ -7,7 +7,7 @@ import yaml
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
 

--- a/test/tfnewapi/test_tensorflow_graph_conv_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_conv_fusion.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 from neural_compressor.adaptor.tf_utils.quantize_graph.qdq.optimize_qdq import OptimizeQDQGraph
 from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.strip_unused_nodes import StripUnusedNodesOptimizer
 from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.fold_batch_norm import FoldBatchNormNodesOptimizer
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import function
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random

--- a/test/tfnewapi/test_tensorflow_graph_conv_requantize_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_conv_requantize_fusion.py
@@ -8,7 +8,7 @@ import numpy as np
 import tensorflow as tf
 import logging
 
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
 

--- a/test/tfnewapi/test_tensorflow_graph_depthwiseconv_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_depthwiseconv_fusion.py
@@ -11,7 +11,7 @@ from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 from neural_compressor.adaptor.tf_utils.util import disable_random
 

--- a/test/tfnewapi/test_tensorflow_graph_dq_cast_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_dq_cast_fusion.py
@@ -3,7 +3,7 @@ import os
 import yaml
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 

--- a/test/tfnewapi/test_tensorflow_graph_fuse_gelu_newapi.py
+++ b/test/tfnewapi/test_tensorflow_graph_fuse_gelu_newapi.py
@@ -6,7 +6,7 @@ from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.fuse_gelu import 
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 class TestGeluFusion(unittest.TestCase):
     def gelu(self, input_tensor, mul_value=0.5, addv2_value=1.0, sqrt_value=2.0):

--- a/test/tfnewapi/test_tensorflow_graph_fuse_pad_conv_fp32.py
+++ b/test/tfnewapi/test_tensorflow_graph_fuse_pad_conv_fp32.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import yaml
 import tensorflow as tf
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from neural_compressor.adaptor.tf_utils.util import disable_random
 
 

--- a/test/tfnewapi/test_tensorflow_graph_qdq_bn_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_bn_fusion.py
@@ -7,7 +7,7 @@ import yaml
 import numpy as np
 import tensorflow as tf
 import logging
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.core.framework import attr_value_pb2
 from tensorflow.python.framework import dtypes
 from neural_compressor.adaptor.tf_utils.util import disable_random

--- a/test/tfnewapi/test_tensorflow_graph_qdq_concat_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_concat_fusion.py
@@ -10,7 +10,7 @@ from neural_compressor.adaptor.tf_utils.util import read_graph
 from neural_compressor.adaptor.tf_utils.quantize_graph.quantize_graph_for_intel_cpu import QuantizeGraphForIntel
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 
 def build_fake_yaml():

--- a/test/tfnewapi/test_tensorflow_graph_qdq_conv3d_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_conv3d_fusion.py
@@ -11,7 +11,7 @@ import logging
 from neural_compressor.adaptor.tf_utils.quantize_graph.quantize_graph_for_intel_cpu import QuantizeGraphForIntel
 from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.strip_unused_nodes import StripUnusedNodesOptimizer
 from neural_compressor.adaptor.tf_utils.graph_rewriter.generic.fold_batch_norm import FoldBatchNormNodesOptimizer
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import function
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random

--- a/test/tfnewapi/test_tensorflow_graph_qdq_conv_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_conv_fusion.py
@@ -8,7 +8,7 @@ import numpy as np
 import tensorflow as tf
 import logging
 
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import function
 from neural_compressor.adaptor.tf_utils.util import disable_random
 

--- a/test/tfnewapi/test_tensorflow_graph_qdq_depthwiseconv_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_depthwiseconv_fusion.py
@@ -11,7 +11,7 @@ from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 from neural_compressor.adaptor.tf_utils.util import disable_random
 

--- a/test/tfnewapi/test_tensorflow_graph_qdq_new_conv_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_new_conv_fusion.py
@@ -7,7 +7,7 @@ import yaml
 import tensorflow as tf
 import logging
 
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import function
 from neural_compressor.adaptor.tf_utils.util import disable_random
 

--- a/test/tfnewapi/test_tensorflow_graph_qdq_pooling_fusion.py
+++ b/test/tfnewapi/test_tensorflow_graph_qdq_pooling_fusion.py
@@ -9,7 +9,7 @@ import tensorflow.compat.v1 as tf
 from tensorflow.python.framework import dtypes
 from neural_compressor.adaptor.tensorflow import TensorflowQuery
 from neural_compressor.adaptor.tf_utils.util import disable_random
-from tensorflow.python.framework import graph_util
+from tensorflow.compat.v1 import graph_util
 
 def build_fake_yaml():
     fake_yaml = '''


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

TF doesn't support tensorflow.python.framework.graph_util again, must use tensorflow.compat.v1.graph_util 

## Expected Behavior & Potential Risk

TF unit test and model test can run successfully with tensorflow 2.13.0.

## How has this PR been tested?

UT, pre-CI and model test.

## Dependency Change?

No.
