### PR TITLE
Fix tf2.13.0 Keras model quantization failed issue

### DIFF
--- a/docs/source/releases_info.md
+++ b/docs/source/releases_info.md
@@ -19,6 +19,8 @@ The MSE tuning strategy does not work with the PyTorch adaptor layer. This strat
 
 The diagnosis function does not work with ONNX Runtime 1.13.1 for QDQ format quantization of ONNX models. It can not dump the output value of QDQ pairs since framework limitation.
 
+Keras version 2.13.0 is experiencing an open issue [18284](https://github.com/keras-team/keras/issues/18284) related to the absence of a `safe_mode` parameter in `tf.keras.models.model_from_json()`. This deficiency could potentially hinder the successful quantization of certain Keras models.
+
 ## Incompatible Changes
 
 [Neural Compressor v1.2](https://github.com/intel/neural-compressor/tree/v1.2) introduces incompatible changes in user facing APIs. Please refer to [incompatible changes](incompatible_changes.md) to know which incompatible changes are made in v1.2.
@@ -29,4 +31,4 @@ The diagnosis function does not work with ONNX Runtime 1.13.1 for QDQ format qua
 
 [Neural Compressor v2.0](https://github.com/intel/neural-compressor/tree/v2.0) renames the `DATASETS` class as `Datasets`, please notice use cases like `from neural_compressor.data import Datasets`. Details please check the [PR](https://github.com/intel/neural-compressor/pull/244/files).
 
-[Neural Compressor v2.2](https://github.com/intel/neural-compressor/tree/v2.2) from this release, binary `neural-compressor-full` is deprecated, we deliver 3 binaries named `neural-compressor`, `neural-solution` and `neural-insights`. 
+[Neural Compressor v2.2](https://github.com/intel/neural-compressor/tree/v2.2) from this release, binary `neural-compressor-full` is deprecated, we deliver 3 binaries named `neural-compressor`, `neural-solution` and `neural-insights`.

--- a/neural_compressor/adaptor/keras_utils/conv2d.py
+++ b/neural_compressor/adaptor/keras_utils/conv2d.py
@@ -21,8 +21,14 @@ from tensorflow.keras import activations
 from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
-from keras.layers.convolutional.base_conv import Conv # pylint: disable=E0401
+
 from tensorflow import quantization
+
+from neural_compressor.adaptor.tf_utils.util import version1_gte_version2
+if version1_gte_version2(tf.__version__, '2.13.0'):
+    from keras.src.layers.convolutional.base_conv import Conv # pylint: disable=E0401
+else:
+    from keras.layers.convolutional.base_conv import Conv # pylint: disable=E0401
 
 class QConv2D(Conv):
     def __init__(self, filters, kernel_size, strides=(1, 1), padding='valid',

--- a/neural_compressor/adaptor/keras_utils/depthwise_conv2d.py
+++ b/neural_compressor/adaptor/keras_utils/depthwise_conv2d.py
@@ -21,9 +21,16 @@ from tensorflow.keras import activations
 from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
-from keras.utils import tf_utils, conv_utils # pylint: disable=E0401
-from keras.layers.convolutional.base_depthwise_conv import DepthwiseConv # pylint: disable=E0401
+
 from tensorflow import quantization
+
+from neural_compressor.adaptor.tf_utils.util import version1_gte_version2
+if version1_gte_version2(tf.__version__, '2.13.0'):
+    from keras.src.utils import tf_utils, conv_utils # pylint: disable=E0401
+    from keras.src.layers.convolutional.base_depthwise_conv import DepthwiseConv # pylint: disable=E0401
+else:
+    from keras.utils import tf_utils, conv_utils # pylint: disable=E0401
+    from keras.layers.convolutional.base_depthwise_conv import DepthwiseConv # pylint: disable=E0401
 
 class QDepthwiseConv2D(DepthwiseConv):
     def __init__(

--- a/neural_compressor/adaptor/keras_utils/separable_conv2d.py
+++ b/neural_compressor/adaptor/keras_utils/separable_conv2d.py
@@ -21,9 +21,15 @@ from tensorflow.keras import activations
 from tensorflow.keras import constraints
 from tensorflow.keras import initializers
 from tensorflow.keras import regularizers
-from keras.utils import conv_utils # pylint: disable=E0401
-from keras.layers.convolutional.base_separable_conv import SeparableConv # pylint: disable=E0401
 from tensorflow import quantization
+
+from neural_compressor.adaptor.tf_utils.util import version1_gte_version2
+if version1_gte_version2(tf.__version__, '2.13.0'):
+    from keras.src.utils import conv_utils # pylint: disable=E0401
+    from keras.src.layers.convolutional.base_separable_conv import SeparableConv # pylint: disable=E0401
+else:
+    from keras.utils import conv_utils # pylint: disable=E0401
+    from keras.layers.convolutional.base_separable_conv import SeparableConv # pylint: disable=E0401
 
 class QSeparableConv2D(SeparableConv):
     def __init__(


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Keras API changed for tf 2.13.0, adapt the API for different tensorflow versions.

## Expected Behavior & Potential Risk

The Keras model can be quantized successfully for TF 2.13.0 and other TF versions.

Potential Risk:
There is an open issue for Keras 2.13.0.
https://github.com/tensorflow/tensorflow/issues/61211

    raise ValueError(
ValueError: Requested the deserialization of a Lambda layer with a Python `lambda` inside it. This carries a potential risk of arbitrary code execution and thus it is disallowed by default. If you trust the source of the saved model, you can pass `safe_mode=False` to the loading function in order to allow Lambda layer loading.
2023-08-23 03:37:46 [ERROR] Specified timeout or max trials is reached! Not found any quantized model which meet accuracy goal. Exit.

## How has this PR been tested?

UT, example test and pre-CI.

## Dependency Change?

No.