### PR TITLE
Add quick started notebook to examples README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,9 @@ Examples
 Intel® Neural Compressor validated examples with multiple compression techniques, including quantization, pruning, knowledge distillation and orchestration. Part of the validated cases can be found in the example tables, and the release data is available [here](../docs/source/validated_model_list.md).
 > Note: The example marked with `*` means it still use 1.x API.
 
+# Quick Get Started Notebook Examples
+* [Quick Get Started Notebook of Intel® Neural Compressor for ONNXRuntime](/examples/notebook/onnxruntime/Quick_Started_Notebook_of_INC_for_ONNXRuntime.ipynb)
+
 # Helloworld Examples
 
 * [tf_example1](/examples/helloworld/tf_example1): quantize with built-in dataloader and metric.

--- a/examples/notebook/onnxruntime/Quick_Started_Notebook_of_INC_for_ONNXRuntime.ipynb
+++ b/examples/notebook/onnxruntime/Quick_Started_Notebook_of_INC_for_ONNXRuntime.ipynb
@@ -5,7 +5,7 @@
    "id": "c6630f47-ca2e-4423-b862-778606165dcc",
    "metadata": {},
    "source": [
-    "# Intel® Neural Compressor Sample for ONNXRuntime\n",
+    "# Quick Get Started Notebook of Intel® Neural Compressor for ONNXRuntime\n",
     "\n",
     "\n",
     "This notebook is designed to provide an easy-to-follow guide for getting started with the [Intel® Neural Compressor](https://github.com/intel/neural-compressor) (INC) library for [ONNXRuntime](https://github.com/microsoft/onnxruntime) framework.\n",


### PR DESCRIPTION
## Type of Change

documentation
API not change

## Description

Add the link of quick started notebook to examples README.md

## Expected Behavior & Potential Risk

Users can jump to the link of quick started notebook through examples README.md

## How has this PR been tested?

CI test

## Dependency Change?

no
