### PR TITLE
Fix GPTQ related ut-tests

### DIFF
--- a/test/adaptor/pytorch_adaptor/test_weight_only_adaptor.py
+++ b/test/adaptor/pytorch_adaptor/test_weight_only_adaptor.py
@@ -14,8 +14,8 @@ from neural_compressor.adaptor.torch_utils.model_wrapper import MulLinear, Weigh
 class Model(torch.nn.Module):
     def __init__(self):
         super(Model, self).__init__()
-        self.fc1 = torch.nn.Linear(30, 40)
-        self.fc2 = torch.nn.Linear(40, 30)
+        self.fc1 = torch.nn.Linear(30, 50)
+        self.fc2 = torch.nn.Linear(50, 30)
         self.fc3 = torch.nn.Linear(30, 5)
 
     def forward(self, x):
@@ -410,8 +410,9 @@ class TestPytorchWeightOnlyAdaptor(unittest.TestCase):
                 'gptq_args':{'percdamp': 0.01, 'act_order': False},
             },
         )
+        model_1 = copy.deepcopy(self.gptj)
         input = (torch.ones([1, 512], dtype=torch.long))
-        q_model = quantization.fit(self.gptj, conf, calib_dataloader=dataloader,)
+        q_model = quantization.fit(model_1, conf, calib_dataloader=dataloader,)
         q_model.save('saved')
         out1 = q_model.model(*input)
         compressed_model = q_model.export_compressed_model()


### PR DESCRIPTION
## Type of Change

fix bug for ut

## Description

When transformer is 4.32.0, the gptj model cannot infer torch.Tensor([1, 512], dtype = torch.int64), while it is successfully for transformers == 4.31.0

Divide tensor and tuple datasets in GPTQ API.

## Expected Behavior & Potential Risk

GPTQ UT all bug-free

## How has this PR been tested?

PreCI

## Dependency Change?

will check transformers version
