### PR TITLE
Fix bugs in ONNXRT hf examples

### DIFF
--- a/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/language_modeling/quantization/ptq_static/main.py
@@ -188,9 +188,7 @@ def main():
     parser.add_argument('-i', "--iter", default=0, type=int,
                         help='For accuracy measurement only.')
     args = parser.parse_args()
-
-    device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
-    args.device = device
+    args.device = torch.device("cpu")
 
     # Setup logging
     logging.basicConfig(format = '%(asctime)s - %(levelname)s - %(name)s -   %(message)s',

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/main.py
@@ -298,9 +298,6 @@ def main():
 
     tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name or model_args.model_name_or_path)
 
-    training_args.do_eval = True
-    training_args.do_predict = False
-
     # Prepare the dataset downloading, preprocessing and metric creation to perform the evaluation step(s)
     # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
     # or just provide the name of one of the public datasets available on the hub at

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/run_benchmark.sh
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/run_benchmark.sh
@@ -51,6 +51,7 @@ function run_benchmark {
             --overwrite_output_dir \
             --dataset_name=squad \
             --batch_size=${batch_size} \
+            --do_eval \
             --benchmark \
              ${extra_cmd}
             

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/run_quant.sh
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_dynamic/run_quant.sh
@@ -57,6 +57,7 @@ function run_tuning {
             --model_name_or_path=${model_name_or_path} \
             --num_heads ${num_heads} \
             --hidden_size ${hidden_size} \
+            --do_eval \
             --tune \
             ${extra_cmd}
 }

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/main.py
@@ -301,9 +301,6 @@ def main():
 
     tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name or model_args.model_name_or_path)
 
-    training_args.do_eval = True
-    training_args.do_predict = False
-
     # Prepare the dataset downloading, preprocessing and metric creation to perform the evaluation step(s)
     # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
     # or just provide the name of one of the public datasets available on the hub at

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/run_benchmark.sh
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/run_benchmark.sh
@@ -51,6 +51,7 @@ function run_benchmark {
             --overwrite_output_dir \
             --dataset_name=squad \
             --batch_size=${batch_size} \
+            --do_eval \
             --benchmark \
              ${extra_cmd}
             

--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/run_quant.sh
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/run_quant.sh
@@ -60,6 +60,7 @@ function run_tuning {
             --model_name_or_path=${model_name_or_path} \
             --num_heads ${num_heads} \
             --hidden_size ${hidden_size} \
+            --do_eval \
             --tune \
             ${extra_cmd}
 }


### PR DESCRIPTION
## Type of Change

bug fix
API bot change

## Description

Fix bugs:
1. ONNXRT hf question answering examples failed with `dataclasses.FrozenInstanceError: cannot assign to field do_eval`
2. ONNXRT hf language modeling examples failed with `AttributeError: 'Namespace' object has no attribute 'no_cuda'`

## Expected Behavior & Potential Risk

fix bugs

## How has this PR been tested?

extension test

## Dependency Change?

no
