### PR TITLE
Enhance ONNXRT backend setting

### DIFF
--- a/neural_compressor/adaptor/onnxrt.py
+++ b/neural_compressor/adaptor/onnxrt.py
@@ -83,7 +83,7 @@ class ONNXRUNTIMEAdaptor(Adaptor):
                 self.format = "integerops"
                 if "format" in framework_specific_info and framework_specific_info["format"].lower() == "qdq":
                     logger.warning("Dynamic approach doesn't support QDQ format.")
-        
+
         # do not load TensorRT if backend is not TensorrtExecutionProvider
         if self.backend != "TensorrtExecutionProvider":
             os.environ["ORT_TENSORRT_UNAVAILABLE"] = "1"

--- a/neural_compressor/model/model.py
+++ b/neural_compressor/model/model.py
@@ -83,9 +83,9 @@ def get_model_fwk_name(model):
 
                 so.register_custom_ops_library(get_library_path())
             if isinstance(model, str):
-                ort.InferenceSession(model, so, providers=ort.get_available_providers())
+                ort.InferenceSession(model, so, providers=["CPUExecutionProvider"])
             else:
-                ort.InferenceSession(model.SerializeToString(), so, providers=ort.get_available_providers())
+                ort.InferenceSession(model.SerializeToString(), so, providers=["CPUExecutionProvider"])
         except Exception as e:  # pragma: no cover
             if "Message onnx.ModelProto exceeds maximum protobuf size of 2GB" in str(e):
                 logger.warning("Please use model path instead of onnx model object to quantize")

--- a/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
+++ b/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
@@ -1657,6 +1657,15 @@ class TestAdaptorONNXRT(unittest.TestCase):
 
         self.assertEqual(mock_warning.call_count, 2)
 
+    def test_cuda_ep_env_set(self):
+        config = PostTrainingQuantConfig(approach="static", backend="onnxrt_cuda_ep", device="gpu", quant_level=1)
+        q_model = quantization.fit(
+            self.distilbert_model,
+            config,
+            calib_dataloader=DummyNLPDataloader_dict("distilbert-base-uncased-finetuned-sst-2-english")
+        )
+        self.assertEqual(os.environ.get("ORT_TENSORRT_UNAVAILABLE"), "1")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
+++ b/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
@@ -1659,11 +1659,13 @@ class TestAdaptorONNXRT(unittest.TestCase):
 
     def test_cuda_ep_env_set(self):
         config = PostTrainingQuantConfig(approach="static", backend="onnxrt_cuda_ep", device="gpu", quant_level=1)
-        q_model = quantization.fit(
+        quantization.fit(
             self.distilbert_model,
             config,
             calib_dataloader=DummyNLPDataloader_dict("distilbert-base-uncased-finetuned-sst-2-english")
         )
+        
+        # check TENSORRT is not loaded if backend is not onnxrt_trt_ep
         self.assertEqual(os.environ.get("ORT_TENSORRT_UNAVAILABLE"), "1")
 
 

--- a/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
+++ b/test/adaptor/onnxrt_adaptor/test_adaptor_onnxrt.py
@@ -1662,9 +1662,9 @@ class TestAdaptorONNXRT(unittest.TestCase):
         quantization.fit(
             self.distilbert_model,
             config,
-            calib_dataloader=DummyNLPDataloader_dict("distilbert-base-uncased-finetuned-sst-2-english")
+            calib_dataloader=DummyNLPDataloader_dict("distilbert-base-uncased-finetuned-sst-2-english"),
         )
-        
+
         # check TENSORRT is not loaded if backend is not onnxrt_trt_ep
         self.assertEqual(os.environ.get("ORT_TENSORRT_UNAVAILABLE"), "1")
 


### PR DESCRIPTION
## Type of Change

bug fix
API not change

## Description

1. If backend is not TensorrtExecutionProvider, set `os.environ["ORT_TENSORRT_UNAVAILABLE"] = "1"` to do not load TensorRT
2. Force provider to `CPUExecutionProvider` when get model framework and detect domain to avoid warning like `Failed to create  XXXExecutionProvider`

## How has this PR been tested?

CI test and extension test of CUDA EP

## Dependency Change?

no
