### PR TITLE
Fix bert_base_mrpc smoothquant check_shape issue

### DIFF
--- a/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
+++ b/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
@@ -116,7 +116,7 @@ class SmoothQuantCalibration:
                     # we should check and pair them
                     def check_shape(tensor, data):
                         # scalar or 1 dim default True
-                        if tensor.shape is None or len(tensor.shape.dims) == 1 or not hasattr(data, "shape"):
+                        if tensor.shape is None or tensor.shape.dims is None or len(tensor.shape.dims) == 1 or not hasattr(data, "shape"):
                             return True
                         tensor_shape = tuple(tensor.shape)
                         data_shape = tuple(data.shape)

--- a/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
+++ b/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
@@ -116,7 +116,12 @@ class SmoothQuantCalibration:
                     # we should check and pair them
                     def check_shape(tensor, data):
                         # scalar or 1 dim default True
-                        if tensor.shape is None or tensor.shape.dims is None or len(tensor.shape.dims) == 1 or not hasattr(data, "shape"):
+                        if (
+                            tensor.shape is None
+                            or tensor.shape.dims is None
+                            or len(tensor.shape.dims) == 1
+                            or not hasattr(data, "shape")
+                        ):
                             return True
                         tensor_shape = tuple(tensor.shape)
                         data_shape = tuple(data.shape)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

tensor.shape.dims is None and check_shape cause an issue

## Expected Behavior & Potential Risk

check_shape return True when tensor.shape.dims is None

## How has this PR been tested?

recipes={"smooth_quant": True, "smooth_quant_args": {'alpha': 0.5}} in PTQConfig, test bert_base_mrpc 

## Dependency Change?

None