### PR TITLE
Fix UT for stock TF adaptor bf16 convert

### DIFF
--- a/test/adaptor/tensorflow_adaptor/test_bf16_convert.py
+++ b/test/adaptor/tensorflow_adaptor/test_bf16_convert.py
@@ -436,14 +436,11 @@ class TestBF16Convert(unittest.TestCase):
         quantizer.calib_dataloader = common.DataLoader(dataset)
         quantizer.model = self.test_fp32_graph
         output_graph = quantizer.fit()
-        # TODO enable the below check after enable PR #1464 merged
-        # cast_op_count = 0
-        # for node in output_graph.graph_def.node:
-        #     if node.op == 'Cast':
-        #         cast_op_count += 1
-        #     if node.op == 'Log':
-        #         self.assertEqual(node.attr["T"].type, dtypes.bfloat16.as_datatype_enum)
-        # self.assertTrue(cast_op_count == 0)
+        cast_op_count = 0
+        for node in output_graph.graph_def.node:
+            if node.op == 'Cast':
+                cast_op_count += 1
+        self.assertTrue(cast_op_count == 0)
 
     @unittest.skipIf(tf.version.VERSION.find("up") == -1, "Only supports tf 1.x")
     def test_bf16_rnn(self):

--- a/test/adaptor/tensorflow_adaptor/test_bf16_convert.py
+++ b/test/adaptor/tensorflow_adaptor/test_bf16_convert.py
@@ -438,7 +438,7 @@ class TestBF16Convert(unittest.TestCase):
         output_graph = quantizer.fit()
         cast_op_count = 0
         for node in output_graph.graph_def.node:
-            if node.op == 'Cast':
+            if node.op == "Cast":
                 cast_op_count += 1
         self.assertTrue(cast_op_count == 0)
 


### PR DESCRIPTION
## Type of Change

bug fix

## Description

BF16 convert on stock tensorflow only support ['Conv2D', 'Conv3D', 'MatMul', 'BatchMatMul', 'MaxPool', 'MaxPool3D', 'AvgPool', 'AvgPool3D', 'DepthwiseConv2dNative'], no 'Log' op. 'Log' op can only be converted to bf16 on SPR based tensorflow. Therefore, check for 'Log' op is skipped here. In addition, there should be no cast here.

## Expected Behavior & Potential Risk

UT pass

## How has this PR been tested?

trigger this ut

## Dependency Change?

None