### PR TITLE
Update ipex quantization ut

### DIFF
--- a/test/ipex/test_adaptor_ipex.py
+++ b/test/ipex/test_adaptor_ipex.py
@@ -85,6 +85,7 @@ class Dataloader:
     def __iter__(self):
         yield torch.randn(1, 3, 224, 224)
 
+
 @unittest.skipIf(
     PT_VERSION < Version("1.12.0").release, "Please use Intel extension for Pytorch version higher or equal to 1.12"
 )


### PR DESCRIPTION
## Type of Change

due to IPEX [1.10, 1.12) quantization source code has removed in ipex adaptor, so remove the ut.
IPEX api change history: 1.10, 1,12
we only support IPEX version >=1.12 now.

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
