### PR TITLE
Align the model preparation for Codebert

### DIFF
--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/README.md
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/README.md
@@ -28,8 +28,8 @@ bash run_fine_tuning.sh --train_dataset_location=./dataset/train.jsonl --dataset
 
 Export model to ONNX format. 
 ```bash
-# TODO replace the model name after uploading the model to the hugging face
-optimum-cli export onnx --model Intel/TBD-MODEL-NAME --task text-classification onnx_model/
+# By default, the input model path is `checkpoint-best-acc/`.
+python prepare_model.py  --input_model=./checkpoint-best-acc  --output_model=./codebert-exported-onnx
 ```
 
 # Run

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/main.py
@@ -85,7 +85,6 @@ def evaluate(model, val_loader):
 
 def fine_tune(args):
     import os
-
     import numpy as np
     import torch
     from torch.utils.data import DataLoader
@@ -134,15 +133,13 @@ def fine_tune(args):
                     results["eval_acc"] = cur_acc
                     best_acc = results["eval_acc"]
                     print("  Best acc:%s", round(best_acc, 4))
-                    checkpoint_prefix = "checkpoint-best-acc-new"
+                    checkpoint_prefix = "checkpoint-best-acc"
                     output_dir = os.path.join("{}".format(checkpoint_prefix))
                     if not os.path.exists(output_dir):
                         os.makedirs(output_dir)
                     model_to_save = model.module if hasattr(model, "module") else model
-                    model.config.to_json_file(
-                        "config-{}-{}-{}".format(checkpoint_prefix, epoch, idx)
-                    )
-                    output_dir = os.path.join(output_dir, "{}".format("model.bin"))
+                    model.config.to_json_file("{}/config.json".format(checkpoint_prefix))
+                    output_dir = os.path.join(output_dir, "{}".format("pytorch_model.bin"))
                     torch.save(model_to_save.state_dict(), output_dir)
                     print("Saving model checkpoint to %s", output_dir)
 

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+import subprocess
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_model", type=str, required=False, default="checkpoint-best-acc/")
+    parser.add_argument("--output_model", type=str, required=False, default="onnx_model/")
+    return parser.parse_args()
+
+def prepare_model(input_model, output_model):
+    print("\nexport model...")
+    subprocess.run(
+        [
+            "optimum-cli",
+            "export",
+            "onnx",
+            "--model",
+            f"{input_model}",
+            "--task",
+            "text-classification",
+            f"{output_model}",
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert os.path.exists(output_model), f"{output_model} doesn't exist!"
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    prepare_model(args.input_model, args.output_model)

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
@@ -6,7 +6,7 @@ import subprocess
 def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("--input_model", type=str, required=False, default="checkpoint-best-acc/")
-    parser.add_argument("--output_model", type=str, required=False, default="onnx_model/")
+    parser.add_argument("--output_model", type=str, required=False, default="codebert-exported-onnx/")
     return parser.parse_args()
 
 def prepare_model(input_model, output_model):

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
@@ -11,6 +11,7 @@ def parse_arguments():
 
 def prepare_model(input_model, output_model):
     print("\nexport model...")
+    print(f"Try to export model from {input_model} to {output_model}")
     subprocess.run(
         ["pip", "install", "optimum"],
         stdout=subprocess.PIPE,

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/prepare_model.py
@@ -12,15 +12,19 @@ def parse_arguments():
 def prepare_model(input_model, output_model):
     print("\nexport model...")
     subprocess.run(
+        ["pip", "install", "optimum"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    subprocess.run(
         [
             "optimum-cli",
             "export",
             "onnx",
             "--model",
             f"{input_model}",
-            "--task",
-            "text-classification",
             f"{output_model}",
+            "--task=text-classification",
         ],
         stdout=subprocess.PIPE,
         text=True,

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/requirements.txt
@@ -1,4 +1,3 @@
-optimum[exporters]
 torch
 transformers
 accelerate

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_dynamic/requirements.txt
@@ -1,3 +1,4 @@
+optimum[exporters]
 torch
 transformers
 accelerate

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/README.md
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/README.md
@@ -28,8 +28,8 @@ bash run_fine_tuning.sh --train_dataset_location=./dataset/train.jsonl --dataset
 
 Export model to ONNX format. 
 ```bash
-# TODO replace the model name after uploading the model to the hugging face
-optimum-cli export onnx --model Intel/TBD-MODEL-NAME --task text-classification onnx_model/
+# By default, the input model is `checkpoint-best-acc/`.
+python prepare_model.py --output_model="codebert-exported.onnx"
 ```
 
 # Run

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/README.md
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/README.md
@@ -28,8 +28,8 @@ bash run_fine_tuning.sh --train_dataset_location=./dataset/train.jsonl --dataset
 
 Export model to ONNX format. 
 ```bash
-# By default, the input model is `checkpoint-best-acc/`.
-python prepare_model.py --output_model="codebert-exported.onnx"
+# By default, the input model path is `checkpoint-best-acc/`.
+python prepare_model.py  --input_model=./checkpoint-best-acc  --output_model=./codebert-exported-onnx
 ```
 
 # Run

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/main.py
@@ -85,7 +85,6 @@ def evaluate(model, val_loader):
 
 def fine_tune(args):
     import os
-
     import numpy as np
     import torch
     from torch.utils.data import DataLoader
@@ -134,15 +133,13 @@ def fine_tune(args):
                     results["eval_acc"] = cur_acc
                     best_acc = results["eval_acc"]
                     print("  Best acc:%s", round(best_acc, 4))
-                    checkpoint_prefix = "checkpoint-best-acc-new"
+                    checkpoint_prefix = "checkpoint-best-acc"
                     output_dir = os.path.join("{}".format(checkpoint_prefix))
                     if not os.path.exists(output_dir):
                         os.makedirs(output_dir)
                     model_to_save = model.module if hasattr(model, "module") else model
-                    model.config.to_json_file(
-                        "config-{}-{}-{}".format(checkpoint_prefix, epoch, idx)
-                    )
-                    output_dir = os.path.join(output_dir, "{}".format("model.bin"))
+                    model.config.to_json_file("{}/config.json".format(checkpoint_prefix))
+                    output_dir = os.path.join(output_dir, "{}".format("pytorch_model.bin"))
                     torch.save(model_to_save.state_dict(), output_dir)
                     print("Saving model checkpoint to %s", output_dir)
 

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
@@ -1,0 +1,34 @@
+import argparse
+import os
+import subprocess
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input_model", type=str, required=False, default="checkpoint-best-acc/")
+    parser.add_argument("--output_model", type=str, required=False, default="onnx_model/")
+    return parser.parse_args()
+
+def prepare_model(input_model, output_model):
+    print("\nexport model...")
+    subprocess.run(
+        [
+            "optimum-cli",
+            "export",
+            "onnx",
+            "--model",
+            f"{input_model}",
+            "--task",
+            "text-classification",
+            f"{output_model}",
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    assert os.path.exists(output_model), f"{output_model} doesn't exist!"
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    prepare_model(args.input_model, args.output_model)

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
@@ -6,7 +6,7 @@ import subprocess
 def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("--input_model", type=str, required=False, default="checkpoint-best-acc/")
-    parser.add_argument("--output_model", type=str, required=False, default="onnx_model/")
+    parser.add_argument("--output_model", type=str, required=False, default="codebert-exported-onnx/")
     return parser.parse_args()
 
 def prepare_model(input_model, output_model):

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
@@ -11,6 +11,7 @@ def parse_arguments():
 
 def prepare_model(input_model, output_model):
     print("\nexport model...")
+    print(f"Try to export model from {input_model} to {output_model}")
     subprocess.run(
         ["pip", "install", "optimum"],
         stdout=subprocess.PIPE,

--- a/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
+++ b/examples/onnxrt/nlp/huggingface_model/code_detection/quantization/ptq_static/prepare_model.py
@@ -12,15 +12,19 @@ def parse_arguments():
 def prepare_model(input_model, output_model):
     print("\nexport model...")
     subprocess.run(
+        ["pip", "install", "optimum"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    subprocess.run(
         [
             "optimum-cli",
             "export",
             "onnx",
             "--model",
             f"{input_model}",
-            "--task",
-            "text-classification",
             f"{output_model}",
+            "--task=text-classification",
         ],
         stdout=subprocess.PIPE,
         text=True,

--- a/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_classification/quantization/ptq_static/requirements.txt
@@ -9,3 +9,4 @@ onnxruntime-extensions; python_version < '3.11'
 numpy==1.23.5
 sentencepiece
 protobuf<=3.20.3
+optimum[exporters]


### PR DESCRIPTION
## Type of Change

Example
API changed or not: None

## Description
This PR is a follow-up to [PR 1221](https://github.com/intel/neural-compressor/pull/1121).

We will not be able to upstream this model because of the licensing restrictions. Users need to fine-tune it by themselves.
Once we have the fine-tuned model, the `prepare_model.py`  can be tested manually.

- [x] Updated the `README.md`
- [x] Added the `prepare_model.py`
- [x] Both dynamic & static


## How has this PR been tested?

Pre-CI and Ext test

## Dependency Change?

None
