### PR TITLE
remove Conv2d in white list in WOQ adaptor

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -4450,7 +4450,7 @@ class PyTorchWeightOnlyAdaptor(TemplateAdaptor):
             assert False, "Unsupported this device {}".format(self.device)
         self.query_handler = PyTorchQuery(local_config_file=os.path.join(os.path.dirname(__file__), query_config_file))
 
-        self.white_list = [torch.nn.Linear, torch.nn.Conv2d]
+        self.white_list = [torch.nn.Linear]
         # Contains parameters for algorithms such as AWQ, GPTQ, etc.
         self.recipes = framework_specific_info["recipes"]
         self.optype_statistics = None


### PR DESCRIPTION
## Type of Change

bug fix

## Description

[model with Conv failed in woq mode](https://github.com/intel/neural-compressor/issues/1100)
It's a history issue. we plan to support Conv in woq mode before, but finally decide to skip Conv.