### PR TITLE
Fix find command on Windows with full path

### DIFF
--- a/neural_compressor/utils/utility.py
+++ b/neural_compressor/utils/utility.py
@@ -272,7 +272,7 @@ class CpuInfo(object):
         """Get number of sockets in platform."""
         cmd = "lscpu | grep 'Socket(s)' | cut -d ':' -f 2"
         if psutil.WINDOWS:
-            cmd = 'wmic cpu get DeviceID | find /c "CPU"'
+            cmd = r'wmic cpu get DeviceID | C:\Windows\System32\find.exe /C "CPU"'
 
         with subprocess.Popen(
             args=cmd,


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

Some Windows users may install w64devkit that and set path to its /bin will have `find` command path as `<path to w64devkit-xxx>/w64devkit/bin/find.exe`, and it does not accept -C as a parameter.

## Expected Behavior & Potential Risk

More robust by providing the full path to `find`

## How has this PR been tested?

Related PR https://github.com/intel/intel-extension-for-transformers/pull/377

```
from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
```

## Dependency Change?

None