### PR TITLE
Fix Regression of ssd_resnet50_v1 Example for TF New API

### DIFF
--- a/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet50_v1/quantization/ptq/main.py
+++ b/examples/tensorflow/object_detection/tensorflow_models/ssd_resnet50_v1/quantization/ptq/main.py
@@ -105,10 +105,29 @@ def main(_):
     if args.tune:
         from neural_compressor import quantization
         from neural_compressor.config import PostTrainingQuantConfig
-        config = PostTrainingQuantConfig(
-            inputs=["image_tensor"],
-            outputs=["num_detections", "detection_boxes", "detection_scores", "detection_classes"],
-            calibration_sampling_size=[10, 50, 100, 200])
+        op_name_dict = {
+                'FeatureExtractor/resnet_v1_50/fpn/bottom_up_block5/Conv2D': {
+                    'activation':  {'dtype': ['fp32']},
+                },
+                'WeightSharedConvolutionalBoxPredictor_2/BoxPredictionTower/conv2d_0/Conv2D': {
+                    'activation':  {'dtype': ['fp32']},
+                },
+                'WeightSharedConvolutionalBoxPredictor_2/ClassPredictionTower/conv2d_0/Conv2D': {
+                    'activation':  {'dtype': ['fp32']},
+                },
+            }
+        # only for TF newAPI
+        if tf.version.VERSION in ['2.11.0202242', '2.11.0202250', '2.11.0202317', '2.11.0202323']:
+            config = PostTrainingQuantConfig(
+                inputs=["image_tensor"],
+                outputs=["num_detections", "detection_boxes", "detection_scores", "detection_classes"],
+                calibration_sampling_size=[10, 50, 100, 200],
+                op_name_dict=op_name_dict)
+        else:
+            config = PostTrainingQuantConfig(
+                inputs=["image_tensor"],
+                outputs=["num_detections", "detection_boxes", "detection_scores", "detection_classes"],
+                calibration_sampling_size=[10, 50, 100, 200])
         q_model = quantization.fit(model=args.input_graph, conf=config, 
                                     calib_dataloader=calib_dataloader, eval_func=evaluate)
         q_model.save(args.output_model)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Three Conv2D Ops is changed from qint8 to quint8 after this commit: https://github.com/intel/neural-compressor/commit/7fb76c450b95c19d0eba1b52d0dac8633e0e2319. 
Then, the accuracy dropped a lot.

This PR is to fallback them to fp32 so that the accuracy will be correct.
Maybe we should consider adding 'qint8' or quint8 for op_wise_config.

## Expected Behavior & Potential Risk

Fix bug and accuracy.

## How has this PR been tested?

Extension test.

## Dependency Change?

No
