### PR TITLE
fix TF 2.13 incompatible keras engine invocation with older transformers

### DIFF
--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
@@ -1,3 +1,3 @@
 tensorflow
 datasets
-transformers<=4.29.2
+transformers


### PR DESCRIPTION
## Type of Change

bug fix
## Description

fix TF 2.13 incompatible keras engine invocation with older transformers

## Expected Behavior & Potential Risk

SQ example pass

Baseline | Tune 1 result
0.6389   |    0.6342

## How has this PR been tested?

SQ test

## Dependency Change?

None