### PR TITLE
Update DyNAS-T to 1.6

### DIFF
--- a/.azure-pipelines/scripts/ut/env_setup.sh
+++ b/.azure-pipelines/scripts/ut/env_setup.sh
@@ -84,7 +84,7 @@ pip install horovod
 if [[ $(echo "${test_case}" | grep -c "others") != 0 ]];then
     pip install tf_slim xgboost accelerate==0.21.0
 elif [[ $(echo "${test_case}" | grep -c "nas") != 0 ]]; then
-    pip install dynast==1.5.1
+    pip install dynast==1.6.0rc1
 elif [[ $(echo "${test_case}" | grep -c "tf pruning") != 0 ]]; then
     pip install tensorflow-addons
 fi

--- a/.azure-pipelines/scripts/ut/run_basic_api.sh
+++ b/.azure-pipelines/scripts/ut/run_basic_api.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 python -c "import neural_compressor as nc;print(nc.version.__version__)"
-test_case="run basic quantization/benchmark/export/mixed_precision/distillation/scheduler"
+test_case="run basic quantization/benchmark/export/mixed_precision/distillation/scheduler/nas"
 echo "${test_case}"
 
 echo "specify fwk version..."
@@ -17,7 +17,7 @@ find ./export* -name "test*.py" | sed 's,\.\/,coverage run --source='"${lpot_pat
 find ./mixed_precision* -name "test*.py" | sed 's,\.\/,coverage run --source='"${lpot_path}"' --append ,g' | sed 's/$/ --verbose/'>> run.sh
 find ./distillation -name "test*.py" | sed 's,\.\/,coverage run --source='"${lpot_path}"' --append ,g' | sed 's/$/ --verbose/'>> run.sh
 find ./scheduler -name "test*.py" | sed 's,\.\/,coverage run --source='"${lpot_path}"' --append ,g' | sed 's/$/ --verbose/'>> run.sh
-# find ./nas -name "test*.py" | sed 's,\.\/,coverage run --source='"${lpot_path}"' --append ,g' | sed 's/$/ --verbose/'>> run.sh
+find ./nas -name "test*.py" | sed 's,\.\/,coverage run --source='"${lpot_path}"' --append ,g' | sed 's/$/ --verbose/'>> run.sh
 
 LOG_DIR=/neural-compressor/log_dir
 mkdir -p ${LOG_DIR}

--- a/.azure-pipelines/scripts/ut/run_basic_others.sh
+++ b/.azure-pipelines/scripts/ut/run_basic_others.sh
@@ -26,9 +26,9 @@ sed -i '/ distillation\//d' run.sh
 sed -i '/ scheduler\//d' run.sh
 sed -i '/ nas\//d' run.sh
 
-#echo "copy model for dynas..."
-#mkdir -p .torch/ofa_nets || true
-#cp -r /tf_dataset/ut-localfile/ofa_mbv3_d234_e346_k357_w1.2 .torch/ofa_nets || true
+echo "copy model for dynas..."
+mkdir -p .torch/ofa_nets || true
+cp -r /tf_dataset/ut-localfile/ofa_mbv3_d234_e346_k357_w1.2 .torch/ofa_nets || true
 
 LOG_DIR=/neural-compressor/log_dir
 mkdir -p ${LOG_DIR}

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,6 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 accelerate==0.21.0
-dynast==1.5.1
+dynast==1.6.0rc1
 horovod
 intel-extension-for-pytorch
 intel-tensorflow>=2.12.0


### PR DESCRIPTION
This version of DyNAS-T updates OFA super-network registry with new URLs (old ones are no longer valid) and mostly focuses on code improvements and documentation.

Tests previously disabled due to OFA URL change are reinstated. 