### PR TITLE
Fix tensorflow and transformers versions

### DIFF
--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow
+tensorflow<=2.12.0
 datasets
-transformers
+transformers<=4.29.2


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

Fix tensorflow and transformers versions for gpt2-medium

## Expected Behavior & Potential Risk

gpt2-medium with the latest version of transformers get the input signature <input_ids, attention_mask, token_type_ids> but the token_type_ids should not occur.

Currently the only way to deal with it is to use old version transformers.

## How has this PR been tested?

python main.py --model_name_or_path gpt2-medium

## Dependency Change?

None
