### PR TITLE
Update ITREX version in ONNXRT WOQ example and fix bugs in hf models

### DIFF
--- a/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/question_answering/quantization/ptq_static/main.py
@@ -483,6 +483,8 @@ def main():
         if model_args.model_name_or_path == 'mrm8488/spanbert-finetuned-squadv1':
             fp32_op_names = ['/bert/embeddings/word_embeddings/Gather', 
                              '/bert/encoder/layer.[5-7|9]/output/dense/MatMul']
+        elif model_args.model_name_or_path == 'salti/bert-base-multilingual-cased-finetuned-squad':
+            fp32_op_names = ['/bert/encoder/layer.[4-5]/output/dense/MatMul']
         elif model_args.model_name_or_path == 'distilbert-base-uncased-distilled-squad':
             fp32_op_names = ['/distilbert/transformer/layer.[1-5]/ffn/lin[1-2]/MatMul']
         elif model_args.model_name_or_path == 'deepset/roberta-large-squad2':

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/ptq_static/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/ptq_static/main.py
@@ -25,7 +25,7 @@ from datasets import load_dataset
 import onnxruntime as ort
 from torch.nn.functional import pad
 from torch.utils.data import DataLoader
-from intel_extension_for_transformers.evaluation.lm_eval import evaluate
+from intel_extension_for_transformers.llm.evaluation.lm_eval import evaluate
 from optimum.onnxruntime import ORTModelForCausalLM
 from transformers import LlamaConfig, LlamaTokenizer
 

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/ptq_static/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/ptq_static/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/intel/intel-extension-for-transformers.git@b8302f99a93e5f09a80431cee2fb384755062664
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@83dbfbf6070324f3e5872f63e49d49ff7ef4c9b3
+intel-extension-for-transformers
 torch
 transformers
 accelerate

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/weight_only/README.md
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/weight_only/README.md
@@ -12,6 +12,8 @@ pip install -r requirements.txt
 ```
 > Note: Validated ONNX Runtime [Version](/docs/source/installation_guide.md#validated-software-environment).
 
+> Note: Weight-only quantization in Intel® Neural Compressor is still under development. We encourage you to use the `master` branch to access the latest features.
+
 ## 2. Prepare Model
 
 ```bash

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/weight_only/main.py
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/weight_only/main.py
@@ -26,7 +26,7 @@ from datasets import load_dataset
 import onnxruntime as ort
 from torch.nn.functional import pad
 from torch.utils.data import DataLoader
-from intel_extension_for_transformers.evaluation.lm_eval import evaluate
+from intel_extension_for_transformers.llm.evaluation.lm_eval import evaluate
 from optimum.onnxruntime import ORTModelForCausalLM
 from transformers import LlamaConfig, LlamaTokenizer
 

--- a/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/weight_only/requirements.txt
+++ b/examples/onnxrt/nlp/huggingface_model/text_generation/llama/quantization/weight_only/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/intel/intel-extension-for-transformers.git@b8302f99a93e5f09a80431cee2fb384755062664
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@83dbfbf6070324f3e5872f63e49d49ff7ef4c9b3
+intel-extension-for-transformers
 torch
 transformers
 accelerate


### PR DESCRIPTION
## Type of Change

bug fix
API not change

## Description

1. Update ITREX version in ONNXRT WOQ example since ITREX v1.2 was released.
2. Fix accuracy tuning failed of huggingface question answering models
2.1 Update outdated models on test machines (exported with torch1.13 -> exported with torch2.0)
2.2 Update PostTrainingQuantConfig setting

## How has this PR been tested?

CI, extension test

## Dependency Change?

no
