### PR TITLE
Support wider range of models, especially CHN LLMs.

### DIFF
--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/ptq_weight_only/run-gptq-llm.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/ptq_weight_only/run-gptq-llm.py
@@ -219,7 +219,7 @@ if __name__ == '__main__':
         tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, trust_remote_code=True)
         model = AutoModel.from_pretrained(args.model_name_or_path, trust_remote_code=True)
     else:
-        tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, use_fast=True)
+        tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, use_fast=True, trust_remote_code=True)
         model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, low_cpu_mem_usage=True, trust_remote_code=True)
     model = model.eval()
 

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/ptq_weight_only/run-gptq-llm.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/ptq_weight_only/run-gptq-llm.py
@@ -224,7 +224,7 @@ if __name__ == '__main__':
     # model
     if re.search("chatglm", args.model_name_or_path.lower()): # chatglm requires a different way to be loaded
         tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, trust_remote_code=True)
-        model = AutoModel.from_pretrained(args.model_name_or_path, trust_remote_code=True)
+        model = AutoModel.from_pretrained(args.model_name_or_path, trust_remote_code=True).float().cpu()
     else:
         tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, use_fast=True, trust_remote_code=True)
         model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, low_cpu_mem_usage=True, trust_remote_code=True)

--- a/neural_compressor/adaptor/torch_utils/gptq.py
+++ b/neural_compressor/adaptor/torch_utils/gptq.py
@@ -217,7 +217,6 @@ class GPTQuantizer(object):
         # model
         self.model = model
         # self.use_cache = self.model.config.use_cache
-        # import pdb;pdb.set_trace()
         self.gptq_related_blocks = trace_gptq_target_blocks(self.model)  # get the transformer block list above
         self.dtype = next(iter(self.model.parameters())).dtype
         log_quantizable_layers_per_transformer(self.gptq_related_blocks)
@@ -621,7 +620,6 @@ class GPTQuantizer(object):
             # Step 2.5: replace output data with quantized weights
             outs = []
             idx = self.cache_key_arguments.pop("i")
-            # import pdb;pdb.set_trace()
             for j in range(len(self.dataloader)):
                 cache_keyword_batch = self.gather_single_batch_from_dict(self.cache_key_arguments, j)
                 cache_positional_batch = self.gather_single_batch_from_list(self.cache_positional_arguments, j)
@@ -639,7 +637,6 @@ class GPTQuantizer(object):
             self.gptq_related_blocks["transformers"][block_idx] = transformer_block.cpu()
             del gptq_for_this_block
             torch.cuda.empty_cache()
-            # import pdb;pdb.set_trace()
             # iteratively replace the input with output, thus layerwise quantization can continue.
             self.update_blockwise_hidden_states(outs)
             logger.info("------------------------------")

--- a/neural_compressor/adaptor/torch_utils/gptq.py
+++ b/neural_compressor/adaptor/torch_utils/gptq.py
@@ -88,7 +88,7 @@ def trace_gptq_target_blocks(module, module_types=[torch.nn.ModuleList, torch.nn
             "transformers": {}, Dict# TODO
         }
     """
-    if type(module).__name__ == 'MixFormerSequentialForCausalLM': # pragma: no cover
+    if type(module).__name__ == "MixFormerSequentialForCausalLM":  # pragma: no cover
         gptq_related_blocks = {
             "embeddings": {},
             "transformers_pre": {},  # todo
@@ -585,7 +585,9 @@ class GPTQuantizer(object):
             for j in range(len(self.dataloader)):
                 cache_keyword_batch = self.gather_single_batch_from_dict(self.cache_key_arguments, j)
                 cache_positional_batch = self.gather_single_batch_from_list(self.cache_positional_arguments, j)
-                if hasattr(self.model.config, "_name_or_path") and "chatglm-6b" in self.model.config._name_or_path: # pragma: no cover
+                if (
+                    hasattr(self.model.config, "_name_or_path") and "chatglm-6b" in self.model.config._name_or_path
+                ):  # pragma: no cover
                     # for chatglm-6b only
                     with torch.autocast("cuda"):
                         out = transformer_block(*cache_positional_batch, **cache_keyword_batch)[0]
@@ -623,7 +625,9 @@ class GPTQuantizer(object):
             for j in range(len(self.dataloader)):
                 cache_keyword_batch = self.gather_single_batch_from_dict(self.cache_key_arguments, j)
                 cache_positional_batch = self.gather_single_batch_from_list(self.cache_positional_arguments, j)
-                if hasattr(self.model.config, "_name_or_path") and "chatglm-6b" in self.model.config._name_or_path: # pragma: no cover
+                if (
+                    hasattr(self.model.config, "_name_or_path") and "chatglm-6b" in self.model.config._name_or_path
+                ):  # pragma: no cover
                     # for chatglm-6b only
                     with torch.autocast("cuda"):
                         out = transformer_block(*cache_positional_batch, **cache_keyword_batch)

--- a/neural_compressor/adaptor/torch_utils/gptq.py
+++ b/neural_compressor/adaptor/torch_utils/gptq.py
@@ -584,14 +584,8 @@ class GPTQuantizer(object):
             for j in range(len(self.dataloader)):
                 cache_keyword_batch = self.gather_single_batch_from_dict(self.cache_key_arguments, j)
                 cache_positional_batch = self.gather_single_batch_from_list(self.cache_positional_arguments, j)
-                if (
-                    hasattr(self.model.config, "_name_or_path") and "chatglm-6b" in self.model.config._name_or_path
-                ):  # pragma: no cover
-                    # for chatglm-6b only
-                    with torch.autocast("cuda"):
-                        out = transformer_block(*cache_positional_batch, **cache_keyword_batch)[0]
-                else:
-                    out = transformer_block(*cache_positional_batch, **cache_keyword_batch)[0]
+                out = transformer_block(*cache_positional_batch, **cache_keyword_batch)
+                out = self.track_hidden_states(out)
             self.cache_key_arguments["i"] = idx
             for h in handles:
                 h.remove()
@@ -623,14 +617,7 @@ class GPTQuantizer(object):
             for j in range(len(self.dataloader)):
                 cache_keyword_batch = self.gather_single_batch_from_dict(self.cache_key_arguments, j)
                 cache_positional_batch = self.gather_single_batch_from_list(self.cache_positional_arguments, j)
-                if (
-                    hasattr(self.model.config, "_name_or_path") and "chatglm-6b" in self.model.config._name_or_path
-                ):  # pragma: no cover
-                    # for chatglm-6b only
-                    with torch.autocast("cuda"):
-                        out = transformer_block(*cache_positional_batch, **cache_keyword_batch)
-                else:
-                    out = transformer_block(*cache_positional_batch, **cache_keyword_batch)
+                out = transformer_block(*cache_positional_batch, **cache_keyword_batch)
                 out = self.track_hidden_states(out)
                 outs.append(out)
             self.cache_key_arguments["i"] = idx


### PR DESCRIPTION
## Type of Change

Enhancement

## Description

- [x] Baichuan-7B

- [x] Baichuan2-7B

- [x] Qwen-7B

- [x] chatglm-6b (inference process should involve "with torch.autocast'cuda'")

- [x] chatglm2-6b

- [x] Mistral

- [x] phi-1

However, Baichuan, chatglm2-6b's evaluation currently not supported. \
Some unique characteristics for chatglm-6b and phi-1: 
- chatglm-6b **requires some specific token id (bos_token_id = 1300xx, etc.)** for successful inference. Thus, direct truncation on tokenized data is not suitable for this model. However, when untruncated sequences are input, the function runs properly.
- phi-1's torch.nn.Sequential object does not only contain the transformer stack but also embedding layers and final heads. Thus, I add a temporary function to trace the proper layers that can be quantized under GPTQ context.