### PR TITLE
fix bug in sq torch backend

### DIFF
--- a/neural_compressor/adaptor/torch_utils/model_wrapper.py
+++ b/neural_compressor/adaptor/torch_utils/model_wrapper.py
@@ -43,7 +43,7 @@ PT_VERSION = get_torch_version().release
 
 
 class QDQLinear(torch.nn.Module):
-    def __init__(self, module, scale=1, zero_point=0, dtype=torch.quint8):
+    def __init__(self, module, scale=1.0, zero_point=0, dtype=torch.quint8):
         super().__init__()
         if PT_VERSION < Version("1.13.0").release:
             import torch.nn.quantized as nnq

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -386,6 +386,7 @@ class TorchSmoothQuant:
         :param calibration_method: only support min_max currently
         :param calib_iter: Sample size for calibration
         :return:"""
+        logger.info("Calibrating...")
         if self.q_func:
             self.q_func(self.model)
         else:


### PR DESCRIPTION
## Type of Change

bug fix, related to latest torch modification.

## Description

[NLPTOOLKIU-861](https://jira.devtools.intel.com/browse/NLPTOOLKIU-861)
Fake quantized model for smoothquant on torch backend cannot be reload correctly.
```shell
(Pdb) m = torch.nn.quantized.Quantize(1, 0, dtype=torch.uint8)    
(Pdb) m.scale.dtype                                                    
torch.int64  # cannot load float scale
# change it as below
(Pdb) m = torch.nn.quantized.Quantize(1.0, 0, dtype=torch.uint8)       
(Pdb) m.scale.dtype                 
torch.float32
```

## Expected Behavior & Potential Risk

reload model accuracy recover

## How has this PR been tested?

local tested
