### PR TITLE
Extend SmoothQuant support (exclude nodes, fuse into layernorm)

### DIFF
--- a/neural_compressor/adaptor/ox_utils/calibration.py
+++ b/neural_compressor/adaptor/ox_utils/calibration.py
@@ -27,6 +27,7 @@ import logging
 import os
 import sys
 from importlib.util import find_spec
+from typing import List, Optional
 
 import numpy as np
 import onnx
@@ -34,8 +35,6 @@ import onnx.numpy_helper as numpy_helper
 import onnxruntime
 from onnx import TensorProto, helper, shape_inference
 from packaging.version import Version
-
-from typing import Optional, List
 
 from neural_compressor.adaptor.ox_utils.calibrator import CALIBRATOR
 from neural_compressor.adaptor.ox_utils.util import (
@@ -661,7 +660,9 @@ class ONNXRTAugment:
                     return True
         return False
 
-    def _get_input_tensor_of_ops(self, op_types=["MatMul", "Gemm", "Conv", "FusedConv"], nodes_to_exclude: Optional[List[str]] = None):
+    def _get_input_tensor_of_ops(
+        self, op_types=["MatMul", "Gemm", "Conv", "FusedConv"], nodes_to_exclude: Optional[List[str]] = None
+    ):
         """Traverse the graph and get all the data tensors flowing into layers of {op_types}.
 
         Group conv is excluded.

--- a/neural_compressor/adaptor/ox_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/ox_utils/smooth_quant.py
@@ -19,6 +19,7 @@
 import copy
 import logging
 import os
+from typing import List, Optional
 
 import numpy as np
 import onnx
@@ -28,8 +29,6 @@ from onnx import onnx_pb as onnx_proto
 from neural_compressor.adaptor.ox_utils.util import _get_qrange_for_qType, is_B_transposed, quantize_data, to_numpy
 from neural_compressor.model.model import BaseModel
 from neural_compressor.model.onnx_model import ONNXModel
-
-from typing import Optional, List
 
 logger = logging.getLogger("neural_compressor")
 
@@ -147,7 +146,7 @@ class ORTSmoothQuant:
         calib_iter=100,
         quantize_config=None,
         auto_alpha_args={"alpha_min": 0.3, "alpha_max": 0.7, "alpha_step": 0.05, "attn_method": "min"},
-        nodes_to_exclude: Optional[List[str]] =None,
+        nodes_to_exclude: Optional[List[str]] = None,
     ):
         """The main entry of smooth quant.
 
@@ -179,7 +178,9 @@ class ORTSmoothQuant:
 
         need_calibration = self._check_need_calibration(alpha, percentile, op_types, scales_per_op, calib_iter)
         if need_calibration:
-            self._dump_op_info(percentile, op_types, calib_iter, quantize_config=quantize_config, nodes_to_exclude=nodes_to_exclude)
+            self._dump_op_info(
+                percentile, op_types, calib_iter, quantize_config=quantize_config, nodes_to_exclude=nodes_to_exclude
+            )
 
         if self.record_max_info:
             return self.model


### PR DESCRIPTION
## Type of Change

As per title.

## Description

This PR includes two new features for SmoothQuant (that I was too lazy to split into two PRs):
* Add the fusion of `MatMul -> Add -> MatMul` into `MatMul -> Add` (that is typically the case for layernorm) as https://github.com/mit-han-lab/smoothquant/blob/78badc0d975506de9fe44b2fe79d9a35d0fd4914/smoothquant/smooth.py#L46
* Add a parameter `nodes_to_exclude` following ORT quantizer & Optimum quantizer fashion, to allow to exclude some nodes from being smoothed. This is following https://github.com/mit-han-lab/smoothquant/issues/15#issuecomment-1353390283 (out_proj & fc2 should not be smoothed out to reproduce the paper results).

## How has this PR been tested?

Locally - I did not test that output from the fusion match but I just reused the code from the `mul` method. Let me know if I should add tests.
