### PR TITLE
add default for WOQ to support custom Linear

### DIFF
--- a/neural_compressor/adaptor/pytorch_cpu.yaml
+++ b/neural_compressor/adaptor/pytorch_cpu.yaml
@@ -273,6 +273,7 @@
                       'dtype': ['fp32'],
                       },
                   },
+      'default': *cap_weight_only_integer_linear,
   }
 
 


### PR DESCRIPTION
## Type of Change

bug fix
to support falcon, falcon model's linear is named FalconLinear, not Linear.

## Description

add default for WOQ to support custom Linear
