### PR TITLE
remove unnecessary version limitation

### DIFF
--- a/examples/.config/model_params_tensorflow.json
+++ b/examples/.config/model_params_tensorflow.json
@@ -1776,28 +1776,28 @@
     "gpt2_medium_sq": {
       "model_src_dir": "nlp/large_language_models/quantization/ptq/smoothquant",
       "dataset_location": "",
-      "input_model": "/tf_dataset2/models/tensorflow/gpt2-medium",
+      "input_model": "gpt2-medium",
       "main_script": "main.py",
       "batch_size": 16
     },
     "gpt2_medium": {
       "model_src_dir": "nlp/large_language_models/quantization/ptq/smoothquant",
       "dataset_location": "",
-      "input_model": "/tf_dataset2/models/tensorflow/gpt2-medium",
+      "input_model": "gpt2-medium",
       "main_script": "main.py",
       "batch_size": 16
     },
     "opt_125m_sq": {
       "model_src_dir": "nlp/large_language_models/quantization/ptq/smoothquant",
       "dataset_location": "",
-      "input_model": "/tf_dataset2/models/tensorflow/facebook-opt-125m",
+      "input_model": "facebook/opt-125m",
       "main_script": "main.py",
       "batch_size": 16
     },
     "opt_125m": {
       "model_src_dir": "nlp/large_language_models/quantization/ptq/smoothquant",
       "dataset_location": "",
-      "input_model": "/tf_dataset2/models/tensorflow/facebook-opt-125m",
+      "input_model": "facebook/opt-125m",
       "main_script": "main.py",
       "batch_size": 16
     },

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow<=2.12.0
+tensorflow
 datasets
-transformers<=4.29.2
+transformers


### PR DESCRIPTION
## Type of Change

Version fix

## Description

The new release of Transformers  fixes the signature bug, so we do not need to limit the version for gpt-medium

## Expected Behavior & Potential Risk

gpt2-medium quantization SQ passed

## How has this PR been tested?

gpt2-medium SQ test

## Dependency Change?

None