### PR TITLE
[SmoothQuant] make weight_clipping a default_on option

### DIFF
--- a/neural_compressor/adaptor/onnxrt.py
+++ b/neural_compressor/adaptor/onnxrt.py
@@ -172,6 +172,7 @@ class ONNXRUNTIMEAdaptor(Adaptor):
         op_types=["MatMul", "Gemm", "Conv", "FusedConv"],
         scales_per_op=True,
         record_max_info=False,
+        weight_clip=True,
     ):
         """Get augmented model with smooth quant.
 

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -1761,7 +1761,7 @@ class TemplateAdaptor(Adaptor):
         scales_per_op=None,
         force_re_smooth=False,
         record_max_info=False,
-        weight_clip = True,
+        weight_clip=True,
     ):
         """Convert the model by smooth quant.
 
@@ -1805,7 +1805,9 @@ class TemplateAdaptor(Adaptor):
             kwargs["percentile"] = percentile
         if scales_per_op is not None:
             kwargs["scales_per_op"] = scales_per_op
-        model._model = self.sq.transform(alpha=alpha, folding=folding, calib_iter=calib_iter, weight_clip=weight_clip, **kwargs)
+        model._model = self.sq.transform(
+            alpha=alpha, folding=folding, calib_iter=calib_iter, weight_clip=weight_clip, **kwargs
+        )
         if self.sq.record_max_info:
             model.sq_max_info = self.sq.max_value_info
         return model

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -1761,6 +1761,7 @@ class TemplateAdaptor(Adaptor):
         scales_per_op=None,
         force_re_smooth=False,
         record_max_info=False,
+        weight_clip = True,
     ):
         """Convert the model by smooth quant.
 
@@ -1804,7 +1805,7 @@ class TemplateAdaptor(Adaptor):
             kwargs["percentile"] = percentile
         if scales_per_op is not None:
             kwargs["scales_per_op"] = scales_per_op
-        model._model = self.sq.transform(alpha=alpha, folding=folding, calib_iter=calib_iter, **kwargs)
+        model._model = self.sq.transform(alpha=alpha, folding=folding, calib_iter=calib_iter, weight_clip=weight_clip, **kwargs)
         if self.sq.record_max_info:
             model.sq_max_info = self.sq.max_value_info
         return model
@@ -1833,7 +1834,9 @@ class TemplateAdaptor(Adaptor):
                 absorb_layer = op_name
                 absorbed_layer = info["absorbed_layer"]
                 input_minmax = info["input_minmax"]
-                weight_max = info["weight_max"].clamp(min=1e-5)
+                weight_max = info["weight_max"]
+                if self.sq.weight_clip:
+                    weight_max = weight_max.clamp(min=1e-5)
                 abs_input_max = torch.max(torch.abs(input_minmax[0]), torch.abs(input_minmax[1]))
                 input_power = torch.pow(abs_input_max, alpha)
                 weight_power = torch.pow(weight_max, 1 - alpha)
@@ -1877,7 +1880,9 @@ class TemplateAdaptor(Adaptor):
                 alpha = info["alpha"]
                 absorbed_layer = info["absorbed_layer"]
                 input_minmax = info["input_minmax"]
-                weight_max = info["weight_max"].clamp(min=1e-5)
+                weight_max = info["weight_max"]
+                if self.sq.weight_clip:
+                    weight_max = weight_max.clamp(min=1e-5)
                 abs_input_max = torch.max(torch.abs(input_minmax[0]), torch.abs(input_minmax[1]))
                 input_power = torch.pow(abs_input_max, alpha)
                 weight_power = torch.pow(weight_max, 1 - alpha)
@@ -3279,7 +3284,9 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                 absorbed_layer = info["absorbed_layer"]
                 input_minmax = info["input_minmax"]
                 # for peft model,lora_B weights is 0.
-                weight_max = info["weight_max"].clamp(min=1e-5)
+                weight_max = info["weight_max"]
+                if self.sq.weight_clip:
+                    weight_max = weight_max.clamp(min=1e-5)
                 abs_input_max = torch.max(torch.abs(input_minmax[0]), torch.abs(input_minmax[1]))
                 input_power = torch.pow(abs_input_max, alpha)
                 weight_power = torch.pow(weight_max, 1 - alpha)

--- a/neural_compressor/adaptor/tensorflow.py
+++ b/neural_compressor/adaptor/tensorflow.py
@@ -1822,6 +1822,7 @@ class TensorFlowAdaptor(Adaptor):
         op_types=["MatMul", "Conv2D"],
         scales_per_op=True,
         record_max_info=False,
+        weight_clip=True,
     ):
         """Convert the model by smooth quant.
 

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -578,6 +578,8 @@ class TorchSmoothQuant:
                     weights.append(weight)
 
                 weight_max_per_channel = torch.max(torch.abs(torch.cat(weights, dim=0)), dim=0)[0]
+                if self.weight_clip:
+                    weight_max_per_channel = weight_max_per_channel.clamp(min=1e-5)
                 if self.record_max_info and not tuning:
                     # the input of layers with same absorb layer is the same.
                     input_minmax = [self.input_mins[layer_names[0]], self.input_maxes[layer_names[0]]]

--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -330,6 +330,7 @@ class TorchSmoothQuant:
         self.self_absorb_layers = {}
         self.absorb_to_layer = {}
         self.adjust_alpha_space = False
+        self.weight_clip = True
 
     def _get_device(self):
         """Get the model device
@@ -946,6 +947,7 @@ class TorchSmoothQuant:
         scales_per_op=False,
         calib_iter=100,
         auto_alpha_args={"alpha_min": 0.0, "alpha_max": 1.0, "alpha_step": 0.1, "shared_criterion": "mean"},
+        weight_clip=True,
     ):
         """The main entry of smooth quant
         :param alpha: Alpha value to balance the quantization difficulty of activation and weight, please refer
@@ -971,6 +973,7 @@ class TorchSmoothQuant:
 
             alpha = numpy.clip(alpha, 0.0, 1.0)
 
+        self.weight_clip = weight_clip
         self.recover()
         need_calibration = self._check_need_calibration(alpha, percentile, op_types, scales_per_op, calib_iter)
         with torch.no_grad():

--- a/neural_compressor/algorithm/smooth_quant.py
+++ b/neural_compressor/algorithm/smooth_quant.py
@@ -52,6 +52,7 @@ class SmoothQuant(Algorithm):
         self.op_types = None
         self.scales_per_op = None
         self.tune_cfg = None
+        self.weight_clip = None
 
     def __call__(self, origin_model, q_model, adaptor, dataloader, calib_iter):
         """Return the processed model via SmoothQuant algorithm.
@@ -80,6 +81,7 @@ class SmoothQuant(Algorithm):
             kwargs["scales_per_op"] = self.scales_per_op
         kwargs["folding"] = self.folding
         kwargs["record_max_info"] = True
+        kwargs["weight_clip"] = self.weight_clip
         q_model = adaptor.smooth_quant(
             origin_model,
             dataloader,

--- a/neural_compressor/strategy/strategy.py
+++ b/neural_compressor/strategy/strategy.py
@@ -948,7 +948,9 @@ class TuneStrategy(metaclass=TuneStrategyMeta):
                 if self.framework == "pytorch_ipex":
                     smooth_quant_args["folding"] = None  # will reset it to True if IPEX version < 2.1.
             sq_algo.folding = smooth_quant_args["folding"]
-            sq_algo.weight_clip = smooth_quant_args.get("weight_clip", True) # make weight_clipping a default_on option.
+            sq_algo.weight_clip = smooth_quant_args.get(
+                "weight_clip", True
+            )  # make weight_clipping a default_on option.
             logger.debug(f"Set smooth quant with alpha {sq_algo.alpha} as the pre-tuning algo.")
             algo_scheduler.append_algorithm("pre_quantization", sq_algo)
 

--- a/neural_compressor/strategy/strategy.py
+++ b/neural_compressor/strategy/strategy.py
@@ -948,6 +948,7 @@ class TuneStrategy(metaclass=TuneStrategyMeta):
                 if self.framework == "pytorch_ipex":
                     smooth_quant_args["folding"] = None  # will reset it to True if IPEX version < 2.1.
             sq_algo.folding = smooth_quant_args["folding"]
+            sq_algo.weight_clip = smooth_quant_args.get("weight_clip", True) # make weight_clipping a default_on option.
             logger.debug(f"Set smooth quant with alpha {sq_algo.alpha} as the pre-tuning algo.")
             algo_scheduler.append_algorithm("pre_quantization", sq_algo)
 

--- a/test/algorithm/test_smooth_quant.py
+++ b/test/algorithm/test_smooth_quant.py
@@ -1460,7 +1460,7 @@ class TestInputConfig(unittest.TestCase):
 
         sq = TorchSmoothQuant(model, self.linear_dl, weight_clip=False)
         sq.transform(alpha="auto", calib_iter=1, folding=True)
-        assert sq.weight_clip == False
+        assert sq.weight_clip is False
 
 
 if __name__ == "__main__":

--- a/test/algorithm/test_smooth_quant.py
+++ b/test/algorithm/test_smooth_quant.py
@@ -1427,5 +1427,41 @@ class TestPeftModel(unittest.TestCase):
         out2 = q_model.model(example_input)[0]
 
 
+class TestInputConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        class RandDataloader:
+            def __init__(self):
+                self.batch_size = 1
+
+            def __iter__(self):
+                yield torch.rand((1, 3))
+
+        self.linear_dl = RandDataloader()
+
+    @classmethod
+    def test_sq_weight_clipping(self):
+        class Model(torch.nn.Module):
+            device = torch.device("cpu")
+
+            def __init__(self):
+                super(Model, self).__init__()
+                self.fc1 = torch.nn.Linear(3, 4)
+                self.norm = LlamaRMSNorm(4)
+                self.fc2 = torch.nn.Linear(4, 3)
+
+            def forward(self, x):
+                out = self.fc1(x)
+                out = self.norm(out)
+                out = self.fc2(out)
+                return out
+
+        model = Model()
+
+        sq = TorchSmoothQuant(model, self.linear_dl, weight_clip=False)
+        sq.transform(alpha="auto", calib_iter=1, folding=True)
+        assert sq.weight_clip == False
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/algorithm/test_smooth_quant.py
+++ b/test/algorithm/test_smooth_quant.py
@@ -1458,9 +1458,9 @@ class TestInputConfig(unittest.TestCase):
 
         model = Model()
 
-        sq = TorchSmoothQuant(model, self.linear_dl, weight_clip=False)
-        sq.transform(alpha="auto", calib_iter=1, folding=True)
-        assert sq.weight_clip is False
+        sq = TorchSmoothQuant(model, self.linear_dl)
+        sq.transform(alpha="auto", calib_iter=1, folding=True, weight_clip=False)
+        assert sq.weight_clip == False
 
 
 if __name__ == "__main__":

--- a/test/algorithm/test_smooth_quant.py
+++ b/test/algorithm/test_smooth_quant.py
@@ -1460,7 +1460,7 @@ class TestInputConfig(unittest.TestCase):
 
         sq = TorchSmoothQuant(model, self.linear_dl)
         sq.transform(alpha="auto", calib_iter=1, folding=True, weight_clip=False)
-        assert sq.weight_clip == False
+        assert sq.weight_clip is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Type of Change

code update
API not changed

## Description
make weight_clipping a default_on option when calculating scales for quantization

## Expected Behavior & Potential Risk

no expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

no library dependency introduced or removed
