### PR TITLE
Support fp16 model to weight-only quantization for PyTorch framework

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -4587,9 +4587,6 @@ class PyTorchWeightOnlyAdaptor(TemplateAdaptor):
                 if recipe_cfgs.get("layer_wise_quant", False):
                     # load weight
                     load_module(model, op_name, model_path, device=self.device)
-                orig_dtype = m.weight.dtype
-                if orig_dtype != torch.float:
-                    m = m.float()
                 m = rtn_quantize(
                     m,
                     num_bits,
@@ -4601,8 +4598,6 @@ class PyTorchWeightOnlyAdaptor(TemplateAdaptor):
                     enable_mse_search=enable_mse_search,
                     group_dim=group_dim,
                 )
-                if orig_dtype != torch.float:
-                    m = m.to(orig_dtype)
                 if recipe_cfgs.get("layer_wise_quant", False):
                     # save and clean weight
                     from .torch_utils.layer_wise_quant.utils import clean_module_weight

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -4587,6 +4587,9 @@ class PyTorchWeightOnlyAdaptor(TemplateAdaptor):
                 if recipe_cfgs.get("layer_wise_quant", False):
                     # load weight
                     load_module(model, op_name, model_path, device=self.device)
+                orig_dtype = m.weight.dtype
+                if orig_dtype != torch.float:
+                    m = m.float()
                 m = rtn_quantize(
                     m,
                     num_bits,
@@ -4598,6 +4601,8 @@ class PyTorchWeightOnlyAdaptor(TemplateAdaptor):
                     enable_mse_search=enable_mse_search,
                     group_dim=group_dim,
                 )
+                if orig_dtype != torch.float:
+                    m = m.to(orig_dtype)
                 if recipe_cfgs.get("layer_wise_quant", False):
                     # save and clean weight
                     from .torch_utils.layer_wise_quant.utils import clean_module_weight

--- a/neural_compressor/adaptor/torch_utils/weight_only.py
+++ b/neural_compressor/adaptor/torch_utils/weight_only.py
@@ -390,6 +390,9 @@ def rtn_quantize(
         model: fake quantized torch module
     """
     assert isinstance(model, torch.nn.Module), "only support torch module"
+    orig_dtype = next(model.parameters()).dtype
+    if orig_dtype != torch.float:
+        model = model.float()
     supported_layers = ["Linear"]
     if return_int:
         compression_dtype = kwargs.get("compression_dtype", torch.int32)
@@ -466,6 +469,8 @@ def rtn_quantize(
             )
             q_weight = q_weight.T if group_dim == 0 else q_weight
             m.weight.data.copy_(q_weight)
+    if orig_dtype != torch.float:
+        model = model.to(orig_dtype)
     return model
 
 

--- a/test/quantization/test_weight_only_quantization.py
+++ b/test/quantization/test_weight_only_quantization.py
@@ -54,6 +54,7 @@ class TestAWQWeightOnlyQuant(unittest.TestCase):
 
     def test_rtn(self):
         fp32_model = copy.deepcopy(self.model)
+        fp16_model = copy.deepcopy(self.model).to(torch.float16)
         model1 = rtn_quantize(fp32_model, num_bits=3, group_size=-1)
         self.assertTrue(isinstance(model1.fc1, torch.nn.Linear))
         weight_config = {
@@ -67,7 +68,7 @@ class TestAWQWeightOnlyQuant(unittest.TestCase):
             },
         }
         model2 = rtn_quantize(fp32_model, weight_config=weight_config)
-        model2 = rtn_quantize(fp32_model, weight_config=weight_config, return_int=True)
+        model2 = rtn_quantize(fp16_model, weight_config=weight_config, return_int=True)
         self.assertTrue(isinstance(model2.fc1, WeightOnlyLinear))
 
     def test_awq(self):


### PR DESCRIPTION
## Type of Change

feature
No API changed

## Description

Support fp16 model to weight-only quantization for PyTorch framework.

## Expected Behavior & Potential Risk

Quantization fp16 model successfully.

## How has this PR been tested?

local tested
