### PR TITLE
remove the ipex adaptor invalid print

### DIFF
--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -475,8 +475,6 @@ def update_sq_scale(ipex_config_path, smoothquant_scale_info):
     with open(ipex_config_path, "w") as f1:
         json.dump(ipex_config, f1, indent=4)
         f1.close()
-    print(ipex_config_path)
-    # exit(0)
 
 
 def auto_copy(module):  # pragma: no cover


### PR DESCRIPTION
## Type of Change

remove the invalid print

## Description

detail description
```
2023-11-15 19:40:40 [INFO] []
2023-11-15 19:40:40 [INFO] Pass query framework capability elapsed time: 19496.57 ms
2023-11-15 19:40:40 [INFO] Do not evaluate the baseline and quantize the model with default configuration.
2023-11-15 19:40:40 [INFO] Quantize the model with default config.
/home/changwa1/itrex/examples/huggingface/pytorch/text-generation/quantization/nc_workspace/2023-11-15_19-29-59/ipex_config_tmp.json

/home/changwa1/anaconda3/envs/rc4/lib/python3.9/site-packages/intel_extension_for_pytorch/quantization/_quantization_state_utils.py:454: TracerWarning: Converting a tensor to a Python number might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  args, scale.item(), zp.item(), dtype
```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
