### PR TITLE
Support Quantization of Big Saved Model for TF Backend

### DIFF
--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/README.md
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/README.md
@@ -1,0 +1,52 @@
+Step-by-Step
+============
+
+This document is used to list steps of reproducing TensorFlow Intel® Neural Compressor quantization and smooth quantization of language models such as OPT and GPT2.
+
+## Prerequisite
+
+```shell
+# Install Intel® Neural Compressor
+pip install neural-compressor
+pip install -r requirements
+```
+## Run
+
+
+### Basic quantization
+
+```
+python main.py --model_name_or_path <MODEL_NAME>
+```
+
+`<MODEL_NAME>` can be following:
+
+- gpt2-medium
+- facebook/opt-125m
+
+### Smooth quant
+
+```shell
+bash run_quant.sh --input_model=<MODEL_NAME>
+```
+
+Or you can use
+
+```
+python main.py --model_name_or_path <MODEL_NAME> --sq
+```
+
+## Benchmark
+
+### Get the FP32 performance
+
+```shell
+bash run_benchmark.sh --input_model=<MODEL_NAME>
+```
+
+### Get the INT8 performance
+
+```shell
+bash run_benchmark.sh --input_model=<MODEL_NAME> --int8=true
+```
+

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/main.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/main.py
@@ -257,7 +257,7 @@ def evaluate(model, tf_eval_dataset=mydata):
             break
     latency = np.array(latency_list[warmup:]).mean() / 1
     acc = correct/(iteration+1)
-    return latency, acc
+    return acc
 
 def weight_name_mapping(name):
     """The function that maps name from AutoTrackable variables to graph nodes"""
@@ -282,6 +282,7 @@ def main():
                                         excluded_precisions=["bf16"],##use basic tuning
                                         recipes=recipes,
                                         op_type_dict=op_type_dict, 
+                                        calibration_sampling_size=[1],
                                         accuracy_criterion=AccuracyCriterion()
                                         )
         model = Model('./gpt-j-6B', modelType='llm_saved_model')

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/main.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/main.py
@@ -1,0 +1,235 @@
+#
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import time
+import math
+import numpy as np
+import logging
+import datasets
+import tensorflow as tf
+from typing import Optional
+from itertools import chain
+from datasets import load_dataset
+from collections import defaultdict
+from dataclasses import dataclass, field
+from sklearn.model_selection import train_test_split
+
+import transformers
+from transformers import (
+    TF_MODEL_FOR_CAUSAL_LM_MAPPING,
+    AutoConfig,
+    AutoTokenizer,
+    HfArgumentParser,
+    TFAutoModelForCausalLM,
+    TFTrainingArguments,
+    set_seed,
+)
+from transformers.utils.versions import require_version
+
+
+logger = logging.getLogger(__name__)
+require_version("datasets>=1.8.0", "To fix: pip install -r benchmarks/language_modeling/tensorflow/gpt_j/requirements.txt")
+MODEL_CONFIG_CLASSES = list(TF_MODEL_FOR_CAUSAL_LM_MAPPING.keys())
+MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
+
+@dataclass
+class ModelArguments:
+    """
+    Arguments pertaining to which model/config/tokenizer we are going to use.
+    """
+
+    model_name_or_path: Optional[str] = field(
+        default="EleutherAI/gpt-j-6B",
+        metadata={
+            "help": (
+                "The model checkpoint for GPT-J weights."
+            )
+        },
+    )
+    config_overrides: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Override some existing default config settings when a model is trained from scratch. Example: "
+                "n_embd=10,resid_pdrop=0.2,scale_attn_weights=false,summary_type=cls_index"
+            )
+        },
+    )
+    checkpoint: Optional[str] = field(
+        default=None,
+        metadata={"help": "Where do you want to store the pretrained models downloaded from huggingface.co"},
+    )
+    use_fast_tokenizer: bool = field(
+        default=True,
+        metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
+    )
+    precision: Optional[str] = field(
+        default="fp32",
+        metadata={"help": "The precision that we want to run with."},
+    )
+
+
+
+@dataclass
+class DataTrainingArguments:
+    """
+    Arguments pertaining to what data we are going to input our model for evaluation.
+    """
+
+    dataset_name: Optional[str] = field(
+        default="EleutherAI/lambada_openai", metadata={"help": "The name of the dataset to use (via the datasets library)."}
+    )
+    dataset_config_name: Optional[str] = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
+    block_size: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional input sequence length after tokenization. "
+                "The training dataset will be truncated in block of this size for training. "
+                "Default to the model max input length for single sentence inputs (take into account special tokens)."
+            )
+        },
+    )
+    preprocessing_num_workers: Optional[int] = field(
+        default=None,
+        metadata={"help": "The number of processes to use for the preprocessing."},
+    )
+
+parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TFTrainingArguments))
+model_args, data_args, run_args = parser.parse_args_into_dataclasses()
+
+logger.setLevel(logging.INFO)
+datasets.utils.logging.set_verbosity_warning()
+transformers.utils.logging.set_verbosity_info()
+
+if run_args.seed is not None:
+    set_seed(run_args.seed)
+
+raw_datasets = load_dataset(
+        data_args.dataset_name,
+        data_args.dataset_config_name,
+        cache_dir=model_args.checkpoint,
+        use_auth_token=None,
+    )
+    
+config = AutoConfig.from_pretrained(model_args.model_name_or_path)
+tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
+column_names = raw_datasets["test"].column_names
+text_column_name = "text" if "text" in column_names else column_names[0]
+
+mydata = tokenizer(raw_datasets["test"][text_column_name], return_tensors="np").input_ids
+
+marg = {}
+stacked = np.concatenate(mydata)
+unique, counts = np.unique(stacked, return_counts=True)
+counts = counts / np.sum(counts)
+
+marg = dict(zip(unique, counts))
+marg = defaultdict(lambda: 0, marg)
+
+def prepare_attention_mask_for_generation(
+    inputs: tf.Tensor,
+    pad_token_id=50256,
+    eos_token_id=50256,
+) -> tf.Tensor:
+
+    is_input_ids = len(inputs.shape) == 2 and inputs.dtype in (tf.int32, tf.int64)
+    is_pad_token_in_inputs = (pad_token_id is not None) and tf.math.reduce_any(inputs == pad_token_id)
+    is_pad_token_not_equal_to_eos_token_id = (eos_token_id is None) or (pad_token_id != eos_token_id)
+
+    # Check if input is input_ids and padded -> only then is attention_mask defined
+    if is_input_ids and is_pad_token_in_inputs and is_pad_token_not_equal_to_eos_token_id:
+        return tf.cast(tf.math.not_equal(inputs, pad_token_id), dtype=tf.int32)
+    else:
+        return tf.ones(inputs.shape[:2], dtype=tf.int32)
+
+def evaluate(model, tf_eval_dataset=mydata):
+    """Evaluate function that inference the model to apply calibration or benchmarking.
+
+    Args:
+        model (tf.python.training.tracking.tracking.AutoTrackable): The model to be evaluated.
+            The object is usually gotten by using tf.saved_model.load(model_dir) API.
+
+    Returns:
+        accuracy (float): The accuracy result.
+    """
+    warmup = 5
+    batch_size = 1
+    pad_token_id = 50256
+    iteration = 10
+    correct = 0
+    latency_list = []
+    infer = model.signatures["serving_default"]
+    for idx, data in enumerate(tf_eval_dataset):
+        print('Running Iteration: ', idx)
+        input_ids = tf.convert_to_tensor([data[:-1]], dtype=tf.int32)
+        cur_len = len(data)-1
+        input_ids_padding = tf.ones((batch_size, 1), dtype=tf.int32) * (pad_token_id or 0)
+        generated = tf.concat([input_ids, input_ids_padding], axis=-1)
+        input_ids = generated[:, :cur_len]
+        attention_mask = prepare_attention_mask_for_generation(input_ids)
+        inputs = {'input_ids': input_ids, 'attention_mask': attention_mask}
+
+        start = time.time()
+        predictions = infer(**inputs)
+        end = time.time()
+
+        dur = end-start
+        print('Time taken: ', dur)
+        latency_list.append(dur)
+        if idx >= iteration:
+            break
+    latency = np.array(latency_list[warmup:]).mean() / 1
+    acc = correct/(iteration+1)
+    return latency, acc
+
+def weight_name_mapping(name):
+    name = name.replace('tfgptj_for_causal_lm', 'StatefulPartitionedCall')
+    name = name.replace('kernel:0', 'Tensordot/ReadVariableOp')
+    return name
+
+def main():    
+    with run_args.strategy.scope():
+        options = tf.data.Options()
+        options.experimental_distribute.auto_shard_policy = tf.data.experimental.AutoShardPolicy.OFF
+        from neural_compressor import PostTrainingQuantConfig
+        from neural_compressor.config import AccuracyCriterion
+
+        from neural_compressor import quantization, Model
+
+        recipes = {"smooth_quant": True, "smooth_quant_args": {'alpha': 0.491}}
+        op_type_dict = {}
+        conf = PostTrainingQuantConfig(quant_level=1, excluded_precisions=["bf16"],##use basic tuning
+                                        recipes=recipes,
+                                        op_type_dict=op_type_dict, accuracy_criterion=AccuracyCriterion(
+        tolerable_loss=0.011,      # TODO remove for debug
+        ))
+
+        model = Model('./gpt-j-6B', model_type='llm_saved_model')
+        model.weight_name_mapping = weight_name_mapping
+        q_model = quantization.fit( model,
+                                    conf,
+                                    calib_func=evaluate,
+                                    eval_func=evaluate)
+        save_model_name ='gpt-j-6B'
+        q_model.save(f"{save_model_name}_int8")
+
+if __name__ == "__main__":
+    main()

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/main.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/main.py
@@ -183,7 +183,7 @@ class MyDataloader:
     
     def __iter__(self):
         labels = None
-        for idx, data in enumerate(self.dataset):
+        for _, data in enumerate(self.dataset):
             cur_input = self.generate_data(data)
             yield (cur_input, labels)
 
@@ -232,7 +232,6 @@ def evaluate(model, tf_eval_dataset=mydata):
     iteration = 200
     correct = 0
     latency_list = []
-    model=tf.saved_model.load(model)
     infer = model.signatures["serving_default"]
     for idx, data in enumerate(tf_eval_dataset):
         print('Running Iteration: ', idx)

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/prepare_model.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/prepare_model.py
@@ -1,0 +1,5 @@
+from transformers import AutoTokenizer, TFAutoModelForCausalLM
+
+tokenizer = AutoTokenizer.from_pretrained("EleutherAI/gpt-j-6B")
+model = TFAutoModelForCausalLM.from_pretrained("EleutherAI/gpt-j-6B")
+model.save_pretrained('./gpt-j-6B', saved_model=True)

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/requirements.txt
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/requirements.txt
@@ -1,3 +1,4 @@
-tensorflow<=2.12.0
+tensorflow==2.11
+transformers==4.25.0
 datasets
-transformers<=4.29.2
+numpy==1.23.5

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/requirements.txt
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/requirements.txt
@@ -1,0 +1,3 @@
+tensorflow<=2.12.0
+datasets
+transformers<=4.29.2

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/run_benchmark.sh
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/run_benchmark.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -x
+
+function main {
+
+  init_params "$@"
+  run_benchmark
+
+}
+
+# init params
+function init_params {
+  int8=false
+  batch_size=16
+  for var in "$@"
+  do
+    case $var in
+      --input_model=*)
+          input_model=$(echo $var |cut -f2 -d=)
+      ;;
+      --int8=*)
+          int8=$(echo $var |cut -f2 -d=)
+      ;;
+      --batch_size=*)
+          batch_size=$(echo $var |cut -f2 -d=)
+      ;;
+    esac
+  done
+
+}
+
+# run_tuning
+function run_benchmark {
+  if [[ "${int8}" == "true" ]]; then
+     python benchmark.py \
+        --model_name_or_path ${input_model} \
+        --batch_size ${batch_size} \
+        --int8
+  else
+     python benchmark.py \
+        --model_name_or_path ${input_model} \
+        --batch_size ${batch_size}
+  fi
+
+}
+
+main "$@"

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/run_quant.sh
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/gpt-j/run_quant.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -x
+
+function main {
+
+  init_params "$@"
+  run_tuning
+
+}
+
+# init params
+function init_params {
+  for var in "$@"
+  do
+    case $var in
+      --input_model=*)
+          input_model=$(echo $var |cut -f2 -d=)
+      ;;
+      --sq=*)
+          sq=$(echo ${var} |cut -f2 -d=)
+      ;;
+    esac
+  done
+
+}
+
+# run_tuning
+function run_tuning {
+
+    ext_cmd=""
+    if [[ ${sq} == "True" ]]; then
+        ext_cmd="--sq"
+    fi
+    python main.py \
+        --model_name_or_path ${input_model} \
+        ${ext_cmd}
+}
+
+main "$@"

--- a/neural_compressor/adaptor/tensorflow.py
+++ b/neural_compressor/adaptor/tensorflow.py
@@ -16,17 +16,17 @@
 # limitations under the License.
 """Tensorflow Adaptor Classes."""
 
+import os
 import copy
 import math
-import os
+import yaml
+import numpy as np
 from collections import OrderedDict, UserDict
 
-import numpy as np
-import yaml
-
+from ..utils import logger
 from ..conf.dotdict import deep_get
 from ..data.dataloaders.base_dataloader import BaseDataLoader
-from ..utils import logger
+from ..model.tensorflow_model import TensorflowLLMSavedModelModel
 from ..utils.utility import (
     GLOBAL_STATE,
     MODE,
@@ -648,6 +648,7 @@ class TensorFlowAdaptor(Adaptor):
                     fp32_ops=self.fp32_ops,
                     bf16_ops=self.bf16_ops,
                     data_loader=data_loader,
+                    calib_func=q_func,
                     qdq_enabled=self.qdq_enabled,
                     new_api=self.new_api,
                     performance_only=self.performance_only,
@@ -670,6 +671,7 @@ class TensorFlowAdaptor(Adaptor):
                     fp32_ops=self.fp32_ops,
                     bf16_ops=self.bf16_ops,
                     data_loader=data_loader,
+                    calib_func=q_func,
                     qdq_enabled=self.qdq_enabled,
                     new_api=self.new_api,
                     performance_only=self.performance_only,
@@ -693,6 +695,7 @@ class TensorFlowAdaptor(Adaptor):
                 fp32_ops=self.fp32_ops,
                 bf16_ops=self.bf16_ops,
                 data_loader=data_loader,
+                calib_func=q_func,
                 qdq_enabled=self.qdq_enabled,
                 new_api=self.new_api,
                 performance_only=self.performance_only,
@@ -1845,6 +1848,10 @@ class TensorFlowAdaptor(Adaptor):
         if self.smooth_quant_model is not None:
             return self.smooth_quant_model
 
+        if isinstance(model, TensorflowLLMSavedModelModel):
+            return self.smooth_quant_LLM(model, calib_iter, tune_cfg, alpha, folding,
+                     percentile, op_types, scales_per_op)
+
         # Do a pre-optimization before smooth quant
         from .tf_utils.graph_rewriter.generic.pre_optimize import PreOptimization
 
@@ -1876,6 +1883,56 @@ class TensorFlowAdaptor(Adaptor):
         model, mul_list = scaler.transform(
             max_vals_per_channel, sq_weight_tensors, sq_weights_nodes, sq_weight_node_names
         )
+        self.smooth_quant_mul_ops.extend(mul_list)
+        self.smooth_quant_model = model
+        return self.smooth_quant_model
+
+    def smooth_quant_LLM(self, model, calib_iter=1, tune_cfg=None, alpha=0.5, folding=False,
+                     percentile=99.999, op_types=['MatMul', 'Conv2D'], scales_per_op=True):
+        """Convert the model by smooth quant.
+
+        Args:
+            model: original model of TensorflowLLMSavedModelModel object.
+            calib_iter: how many steps of iterations on the dataloader to move forward.
+            tune_cfg: quantization config.
+            alpha: smooth alpha in SmoothQuant, 1.0 will fallback to SPIQ.
+            folding: whether insert mul(False) or just allow foldable layers(True) for SmoothQuant.
+            percentile: percentile of calibration to remove outliers.
+            op_types: The op types whose input tensor will be dumped.
+            scales_per_op: True, each op will have an individual scale, mainly for accuracy.
+                           False, ops with the same input will share a scale, mainly for performance.
+
+        Returns:
+            model: A smoothed Tensorflow model.
+        """
+        # Do a pre-optimization before smooth quant
+        from .tf_utils.graph_rewriter.generic.pre_optimize import PreOptimization
+
+        self.pre_optimizer_handle = PreOptimization(model, self.new_api, self.device)
+        self.pre_optimized_model = self.pre_optimizer_handle.get_optimized_model(self.itex_mode)
+        model.graph_def = self.pre_optimized_model.graph_def
+
+        # Get the nodes list which can't be quantized from tune_cfg
+        black_nodes = []
+        if tune_cfg is not None:
+            self._tuning_cfg_to_fw(tune_cfg)
+            black_nodes = [node for node in self.quantize_config if self.quantize_config[node] == "fp32"]
+
+        llm_temp_dir = self.work_dir+'/temp_saved_model'
+        # Run calibration to get max values per channel
+        from .tf_utils.smooth_quant_calibration import SmoothQuantCalibrationLLM
+        calibration = SmoothQuantCalibrationLLM(model._model, calib_iter, op_types, percentile, black_nodes,\
+                                                        self.evaluate, llm_temp_dir, model.weight_name_mapping)
+        max_vals_per_channel, sq_target_node_names, sq_weight_tensor_dict, sq_graph_def = calibration()
+
+        # Calculate the smooth quant scaler and insert Mul op into the graph
+        from .tf_utils.smooth_quant_scaler import SmoothQuantScalerLLM
+        scaler = SmoothQuantScalerLLM(sq_graph_def, alpha, scales_per_op, op_types)
+        sq_graph_def, sq_weight_scale_dict, mul_list = scaler.transform(max_vals_per_channel,
+                                                            sq_weight_tensor_dict, sq_target_node_names)
+        model.graph_def = sq_graph_def
+        model.model_path = llm_temp_dir
+        model.sq_weight_scale_dict = sq_weight_scale_dict
         self.smooth_quant_mul_ops.extend(mul_list)
         self.smooth_quant_model = model
         return self.smooth_quant_model
@@ -1938,6 +1995,7 @@ class Tensorflow_ITEXAdaptor(TensorFlowAdaptor):
                     fp32_ops=self.fp32_ops,
                     bf16_ops=self.bf16_ops,
                     data_loader=data_loader,
+                    calib_func=q_func,
                     itex_mode=self.itex_mode,
                     qdq_enabled=self.qdq_enabled,
                     new_api=self.new_api,
@@ -1985,6 +2043,7 @@ class Tensorflow_ITEXAdaptor(TensorFlowAdaptor):
                 fp32_ops=self.fp32_ops,
                 bf16_ops=self.bf16_ops,
                 data_loader=data_loader,
+                calib_func=q_func,
                 itex_mode=self.itex_mode,
                 qdq_enabled=self.qdq_enabled,
                 new_api=self.new_api,

--- a/neural_compressor/adaptor/tf_utils/graph_converter.py
+++ b/neural_compressor/adaptor/tf_utils/graph_converter.py
@@ -200,7 +200,7 @@ class GraphConverter:
         if self.calib_func:
             self.calib_func(model.model)
             return
-            
+
         if model.model_type == 'llm_saved_model':
             self._inference_llm(model)
             return
@@ -297,7 +297,7 @@ class GraphConverter:
         input_tensor_names = model.input_tensor_names
         auto_trackable = model.model
         infer = auto_trackable.signatures["serving_default"]
-        for idx, (inputs, _) in enumerate(self.dataloader):
+        for idx, (inputs, _) in enumerate(self.data_loader):
             assert len(input_tensor_names) == len(inputs), "inputs len must equal with input_tensor"
             feed_dict = {}
             for i, input_tensor_name in enumerate(input_tensor_names):

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_matmul_redundant_dequantize.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/int8/fuse_matmul_redundant_dequantize.py
@@ -94,7 +94,11 @@ class FuseMatMulRedundantDequantizeTransformer(GraphRewriterBase):
             if "U" in quantized_node.attr:
                 new_node.attr["U"].CopyFrom(quantized_node.attr["U"])
             if "is_weight_const" in quantized_node.attr:
-                new_node.attr["is_weight_const"].CopyFrom(quantized_node.attr["is_weight_const"])
+                if self.graph_info[quantized_node.input[1]].node.op == 'QuantizeV2' and \
+                self.graph_info[self.graph_info[quantized_node.input[1]].node.input[0]].node.op == 'ReadVariableOp':
+                    Helper.set_attr_bool(new_node, "is_weight_const", False)
+                else:
+                    new_node.attr["is_weight_const"].CopyFrom(quantized_node.attr["is_weight_const"])
             if "is_bias_const" in quantized_node.attr:
                 new_node.attr["is_bias_const"].CopyFrom(quantized_node.attr["is_bias_const"])
             if "transpose_a" in quantized_node.attr:

--- a/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
+++ b/neural_compressor/adaptor/tf_utils/graph_rewriter/qdq/insert_qdq_pattern.py
@@ -46,6 +46,7 @@ class GenerateGraphWithQDQPattern(GraphRewriterBase):
         device,
         performance_only,
         itex_mode,
+        llm_weight_minmax,
     ):
         """Initialization."""
         super().__init__(model)
@@ -58,6 +59,7 @@ class GenerateGraphWithQDQPattern(GraphRewriterBase):
         self.device = device
         self.performance_only = performance_only
         self.itex_mode = itex_mode
+        self.llm_weight_minmax = llm_weight_minmax
         self.node_details = namedtuple("node_details", ["node", "output"])
         self.node_name_mapping = {}
         self.check_op_list = {
@@ -548,6 +550,24 @@ class GenerateGraphWithQDQPattern(GraphRewriterBase):
                 # qint8_tensor = np.clip(qint8_tensor, -127, 127).astype(np.int8)
                 min_value = -range_value
                 max_value = range_value
+        elif weight_node.op == 'ReadVariableOp':
+            min_value = self.llm_weight_minmax[weight_node.name][0]
+            max_value = self.llm_weight_minmax[weight_node.name][1]
+            min_value *= range_coefficent
+            max_value *= range_coefficent
+            min_value = min(min_value, 0.0)
+            if min_value == max_value:
+                if abs(min_value) < 0.000001:
+                    max_value = min_value + 1.0
+                elif min_value > 0:
+                    max_value = 2 * min_value
+                else:
+                    max_value = min_value / 2.0
+            range_value = np.max(np.abs([min_value, max_value]))
+            # qint8_tensor = (np.around(float_tensor * 127.0 / range_value)).astype(np.int8)
+            # qint8_tensor = np.clip(qint8_tensor, -127, 127).astype(np.int8)
+            min_value = -range_value
+            max_value = range_value
         elif host_op_type == "DepthwiseConv2dNative":
             float_tensor = tensor_util.MakeNdarray(weight_node.attr["value"].tensor)
             # get the max values based on dim 0 and 1 for depthwise conv

--- a/neural_compressor/adaptor/tf_utils/smooth_quant_scaler.py
+++ b/neural_compressor/adaptor/tf_utils/smooth_quant_scaler.py
@@ -153,3 +153,114 @@ class SmoothQuantScaler:
         sq_graph_def.library.CopyFrom(self.model.graph_def.library)
         self.model.graph_def = sq_graph_def
         return self.model, self.mul_list
+
+class SmoothQuantScalerLLM(SmoothQuantScaler):
+    """A class for scaling model weights for TF LLM models using Smooth Quantization method.
+
+    Args:
+        graph_def: graph_def of the model to be scaled
+        alpha: float, the scaling factor
+        scales_per_op: bool, each op will have an individual scale or
+                       ops with the same input will share a scale
+        op_types: 
+    """
+    def __init__(self, graph_def, alpha, scales_per_op, op_types):
+        """Initialization."""
+        self.graph_def = graph_def
+        self.alpha = alpha
+        self.scales_per_op = scales_per_op
+        self.op_types = op_types
+
+        self.graph_info = None
+        self.mul_list = []
+        self.sq_weight_scale_dict = {}
+
+    def _parse_weight_dict(self, max_vals_per_channel, sq_weight_tensor_dict):
+        """Parse weight related dictionaries to two required dictionaries.
+
+        Args:
+            max_vals_per_channel (dict): A dictionary containing the maximum values per channel.
+            sq_weight_tensor_dict (dict): A dictionary containing tensor of weights.
+
+        Returns:
+            sq_weight_tensors: A dictionary whose structure is like {input_node_name: weight_tensor}}.
+            sq_weights_node_names: A dictionary whose structure is like {input_node_name: weight_node_name}}.
+        """
+        sq_weight_tensors = {}
+        sq_weight_node_names = {}
+        for input_node_name in max_vals_per_channel:
+            curr_weight_tensors = []
+            curr_weights_node_names = []
+            next_node_names = self.graph_info[input_node_name].outputs
+            for node_name in next_node_names:
+                curr_node = self.graph_info[node_name].node
+                if curr_node.op not in self.op_types:
+                    continue
+                if len(curr_node.input) >= 2:
+                    weight_name = curr_node.input[1]
+                    weight_tensor = sq_weight_tensor_dict[weight_name]
+                    curr_weight_tensors.append(weight_tensor)
+                    curr_weights_node_names.append(weight_name)
+            sq_weight_tensors[input_node_name] = curr_weight_tensors
+            sq_weight_node_names[input_node_name] = curr_weights_node_names
+        return sq_weight_tensors, sq_weight_node_names
+
+    def transform(self, max_vals_per_channel, sq_weight_tensor_dict, sq_target_node_names):
+        """Apply scaling to weights and activations based on the maximum values per channel.
+
+        Args:
+            max_vals_per_channel (dict): A dictionary containing the maximum values per channel for each input node.
+            sq_weight_tensor_dict (dict): A dictionary whose structure is like {input_node_name: weight_tensor}.
+            sq_target_node_names (dict): A dictionary whose structure is like {weight_node_name: target_node_name}.
+        """
+        self.g_analyzer = GraphAnalyzer()
+        self.g_analyzer.graph = self.graph_def
+        self.graph_info = self.g_analyzer.parse_graph()
+        sq_weight_tensors, sq_weight_node_names = self._parse_weight_dict(max_vals_per_channel, 
+                                                            sq_weight_tensor_dict)
+        logger.info("Start scaling on model graph for Smooth Quantization.")
+        if self.scales_per_op:
+            # 1. obtain the smooth scale per op
+            # 2. adjust weight
+            # 3. adjust activation
+            for _, input_node_name in enumerate(max_vals_per_channel):
+                activation_max_per_in_channel = max_vals_per_channel[input_node_name]
+                W_lst = sq_weight_tensors[input_node_name]  # VQK weight value
+                # Use the const nodes before to get weight values, VQK ReadVariable
+                W_node_name_lst = sq_weight_node_names[input_node_name]
+                # Get the concrete weight node as the output of Mul insertion, QKV ReadVariable
+                for w_i, W in enumerate(W_lst):
+                    if len(W.shape) == 4:
+                        # https://www.tensorflow.org/api_docs/python/tf/nn/conv2d
+                        # weight: [filter_height, filter_width, in_channels, out_channels]
+                        # activation: NHWC, also batch_shape + [in_height, in_width, in_channels]
+                        tensor = np.abs(np.transpose(W, [0, 1, 3, 2]))
+                        # reduce weight max to (in_channel, ), aligned with activation max
+                        W_max_per_in_channel = np.max(np.reshape(tensor, (-1, tensor.shape[-1])), axis=0)
+                    elif len(W.shape) == 2: # matmul
+                        # reduce weight max to (in_channel, ), aligned with activation max
+                        tensor = np.abs(W)
+                        W_max_per_in_channel = np.max(tensor, axis=1)
+                    else: # pragma: no cover
+                        assert False, "not supported"
+                    cur_weight_node_name = W_node_name_lst[w_i]
+                    try:
+                        scale = np.power(activation_max_per_in_channel, self.alpha) /  \
+                                np.power(W_max_per_in_channel, (1-self.alpha))
+                    except ValueError as e: # pragma: no cover
+                        logger.info(e)
+                        logger.info("Skip smoothing the node: {}".format(cur_weight_node_name))
+                        continue
+                    # clip the scales that are too small
+                    scale = np.clip(scale, a_min=1e-5, a_max=1e8)
+                    # skip smoothing the op where scale has elements that less than 1
+                    # if np.any(scale < 1):
+                    #     logger.info("skip smooth quant: {}".format(input_node_name))
+                    #     continue
+                    self.sq_weight_scale_dict[cur_weight_node_name] = scale
+                    self._adjust_activation(1 / scale, input_node_name, sq_target_node_names[cur_weight_node_name], w_i)
+        else:
+            pass
+        sq_graph_def = self.g_analyzer.dump_graph()
+        sq_graph_def.library.CopyFrom(self.graph_def.library)
+        return sq_graph_def, self.sq_weight_scale_dict, self.mul_list

--- a/neural_compressor/adaptor/tf_utils/util.py
+++ b/neural_compressor/adaptor/tf_utils/util.py
@@ -17,19 +17,25 @@
 #
 """Tensorflow Utils Helper functions."""
 
-import os
-from collections import OrderedDict, UserDict
-
 import numpy as np
 import tensorflow as tf
-from google.protobuf import text_format
 from pkg_resources import parse_version
-from tensorflow.core.framework import attr_value_pb2, graph_pb2, node_def_pb2
+from google.protobuf import text_format
+from collections import OrderedDict, UserDict
+
+from tensorflow.python.util import nest
+from tensorflow.python.training import saver
 from tensorflow.python.platform import gfile
+from tensorflow.python.grappler import tf_optimizer
+from tensorflow.python.eager import context, wrap_function
+from tensorflow.core.protobuf import config_pb2, meta_graph_pb2
+from tensorflow.core.framework import graph_pb2, variable_pb2, node_def_pb2, attr_value_pb2
+from tensorflow.python.saved_model import save, load, tag_constants, signature_constants
 
 from neural_compressor.utils import logger
+from .graph_util import GraphAnalyzer
+from .graph_util import GraphRewriterHelper
 
-from .graph_util import GraphAnalyzer, GraphRewriterHelper
 
 TF_SPR_BASE_VERSIONS = ("2.11.0202242", "2.11.0202250", "2.11.0202317", "2.11.0202323")
 
@@ -659,3 +665,156 @@ def get_weight_from_input_tensor(model, input_tensor_names, op_types):
         sq_weight_tensors[name] = curr_weight_tensors
         sq_weights_nodes[name] = curr_weights_nodes
     return sq_weight_tensors, sq_weights_nodes
+
+def apply_inlining(func):
+    """Apply an inlining optimization to the function's graph definition.
+    Args:
+        func: A concrete function get from saved_model.
+
+    Returns:
+        new_graph_def: The optimized graph in graph_def format.
+    """
+    graph_def = func.graph.as_graph_def()
+
+    # In some cases, a secondary implementation of the function (e.g. for GPU) is
+    # written to the "api_implements" attribute. (e.g. `tf.keras.layers.LSTM` in
+    # TF2 produces a CuDNN-based RNN for GPU).
+    # This function suppose to inline all functions calls, but "api_implements"
+    # prevents this from happening. Removing the attribute solves the problem.
+    # To learn more about "api_implements", see:
+    #   tensorflow/core/grappler/optimizers/implementation_selector.h
+    for function in graph_def.library.function:
+        if "api_implements" in function.attr:
+            del function.attr["api_implements"]
+
+    meta_graph = saver.export_meta_graph(graph_def=graph_def, graph=func.graph)
+
+    # Clear the initializer_name for the variables collections, since they are not
+    # needed after saved to saved_model.
+    for name in [
+        "variables", "model_variables", "trainable_variables", "local_variables"
+    ]:
+        raw_list = []
+        for raw in meta_graph.collection_def["variables"].bytes_list.value:
+            variable = variable_pb2.VariableDef()
+            variable.ParseFromString(raw)
+            variable.ClearField("initializer_name")
+            raw_list.append(variable.SerializeToString())
+        meta_graph.collection_def[name].bytes_list.value[:] = raw_list
+
+    # Add a collection 'train_op' so that Grappler knows the outputs.
+    fetch_collection = meta_graph_pb2.CollectionDef()
+    for array in func.inputs + func.outputs:
+        fetch_collection.node_list.value.append(array.name)
+    meta_graph.collection_def["train_op"].CopyFrom(fetch_collection)
+
+    # Initialize RewriterConfig with everything disabled except function inlining.
+    config = config_pb2.ConfigProto()
+    rewrite_options = config.graph_options.rewrite_options
+    rewrite_options.min_graph_nodes = -1  # do not skip small graphs
+    rewrite_options.optimizers.append("function")
+
+    new_graph_def = tf_optimizer.OptimizeGraph(config, meta_graph)
+
+    return new_graph_def
+
+def construct_function_from_graph_def(func, graph_def, frozen_func=None):
+    """Rebuild function from graph_def.
+    Args:
+        func: The original concrete function get from saved_model.
+        graph_def: The optimized graph after applying inlining optimization.
+
+    Returns:
+        new_func: The reconstructed function.
+    """
+    if frozen_func is None:
+        frozen_func = func
+
+    # If a function is converted, then the TF context contains the original
+    # function while the converted_graph_def contains the converted function.
+    # Remove the original function from the TF context in this case.
+    for f in graph_def.library.function:
+        while context.context().has_function(f.signature.name):
+            context.context().remove_function(f.signature.name)
+
+    captures = {
+        c[1].name.split(":")[0]: c[0]
+        for c in frozen_func.graph.captures
+    }
+    new_func = wrap_function.function_from_graph_def(
+        graph_def, [tensor.name for tensor in frozen_func.inputs],
+        [tensor.name for tensor in frozen_func.outputs], captures)
+    new_func.graph.structured_outputs = nest.pack_sequence_as(
+        func.graph.structured_outputs, new_func.graph.structured_outputs)
+    # new_func._function_type = func.function_type  # pylint: disable=protected-access
+
+    # Copy structured input signature from original function (used during
+    # serialization)
+    new_func.graph.structured_input_signature = (func.structured_input_signature)
+
+    return new_func
+
+def parse_saved_model(model, freeze=False, input_tensor_names=[], output_tensor_names=[]):
+    """Parse a input saved_model.
+    Args:
+        model(string or AutoTrackable object): The input saved_model.
+
+    Returns:
+        graph_def: The graph_def parsed from saved_model.
+        _saved_model: TF AutoTrackable object loaded from saved_model.
+        func: The concrete function get from saved_model.
+        frozen_func: The reconstructed function from inlining optimized graph.
+    """
+    config = tf.compat.v1.ConfigProto()
+    config.use_per_session_threads = 1
+    config.inter_op_parallelism_threads = 1
+
+    if isinstance(model, str):
+        _saved_model = load.load(model, [tag_constants.SERVING])
+    else:
+        _saved_model = model
+        
+    func = _saved_model.signatures[signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
+
+    if freeze:
+        frozen_func = convert_to_constants.convert_variables_to_constants_v2(func)
+    else:
+        inlined_graph_def = apply_inlining(func)
+        frozen_func = construct_function_from_graph_def(func, inlined_graph_def)
+
+    if len(input_tensor_names) == 0:
+        input_tensor_names = [i.name.split(":")[0] for i in frozen_func.inputs]
+    if len(output_tensor_names) == 0:
+        output_tensor_names = [i.name.split(":")[0] for i in frozen_func.outputs]
+
+    frozen_graph_def = frozen_func.graph.as_graph_def()
+    grappler_meta_graph_def = saver.export_meta_graph(
+        graph_def=frozen_graph_def, graph=frozen_func.graph)
+
+    # Add a collection 'train_op' so that Grappler knows the outputs.
+    fetch_collection = meta_graph_pb2.CollectionDef()
+    for array in frozen_func.inputs + frozen_func.outputs:
+        fetch_collection.node_list.value.append(array.name)
+        grappler_meta_graph_def.collection_def["train_op"].CopyFrom(
+            fetch_collection)
+
+    grappler_session_config = config_pb2.ConfigProto()
+    rewrite_options = grappler_session_config.graph_options.rewrite_options
+    rewrite_options.min_graph_nodes = -1
+    graph_def = tf_optimizer.OptimizeGraph(grappler_session_config,
+                                        grappler_meta_graph_def, graph_id=b"tf_graph")
+    return graph_def, _saved_model, func, frozen_func, input_tensor_names, output_tensor_names
+
+def reconstruct_saved_model(graph_def, func, frozen_func, trackable, path):
+    """Reconstruct a saved_model.
+    Args:
+        graph_def: The input graph_def.
+        func: The concrete function get from the original saved_model.
+        frozen_func: The reconstructed function from inlining optimized graph.
+        trackable: TF AutoTrackable object loaded from the original saved_model.
+        path: The destination path to save the reconstructed saved_model.
+
+    """
+    converted_func = construct_function_from_graph_def(func, graph_def, frozen_func)
+    signatures = {signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY: converted_func}
+    save.save(trackable, path, signatures, options=None)

--- a/neural_compressor/adaptor/tf_utils/util.py
+++ b/neural_compressor/adaptor/tf_utils/util.py
@@ -783,7 +783,7 @@ def parse_saved_model(model, freeze=False, input_tensor_names=[], output_tensor_
         frozen_func = construct_function_from_graph_def(func, inlined_graph_def)
 
     if len(input_tensor_names) == 0:
-        input_tensor_names = [i.name.split(":")[0] for i in frozen_func.inputs]
+        input_tensor_names = [i.name.split(":")[0] for i in frozen_func.inputs if 'unknown' not in i.name]
     if len(output_tensor_names) == 0:
         output_tensor_names = [i.name.split(":")[0] for i in frozen_func.outputs]
 

--- a/neural_compressor/adaptor/tf_utils/util.py
+++ b/neural_compressor/adaptor/tf_utils/util.py
@@ -17,6 +17,7 @@
 #
 """Tensorflow Utils Helper functions."""
 
+import os
 import numpy as np
 import tensorflow as tf
 from pkg_resources import parse_version
@@ -28,6 +29,7 @@ from tensorflow.python.training import saver
 from tensorflow.python.platform import gfile
 from tensorflow.python.grappler import tf_optimizer
 from tensorflow.python.eager import context, wrap_function
+from tensorflow.python.framework import convert_to_constants
 from tensorflow.core.protobuf import config_pb2, meta_graph_pb2
 from tensorflow.core.framework import graph_pb2, variable_pb2, node_def_pb2, attr_value_pb2
 from tensorflow.python.saved_model import save, load, tag_constants, signature_constants
@@ -517,8 +519,6 @@ def int8_node_name_reverse(node):
 
 def tf_diagnosis_helper(fp32_model, quan_model, tune_cfg, save_path):
     """Tensorflow diagnosis helper function."""
-    import tensorflow as tf
-
     from ...utils.utility import dump_data_to_local
 
     fp32_node_mapping = {}

--- a/neural_compressor/model/model.py
+++ b/neural_compressor/model/model.py
@@ -31,6 +31,7 @@ from neural_compressor.model.tensorflow_model import (
     TensorflowModel,
     TensorflowQATModel,
     get_model_type,
+    TensorflowLLMSavedModelModel,
 )
 from neural_compressor.utils import logger
 from neural_compressor.utils.utility import LazyImport
@@ -235,6 +236,8 @@ class Model(object):
                             model_type = kwargs["modelType"]
                         else:
                             model_type = get_model_type(root)
+                        if model_type == 'llm_saved_model':
+                            return TensorflowLLMSavedModelModel(root, **kwargs)
                         if hasattr(conf, "backend") and conf.backend == "itex":
                             if model_type == "keras":
                                 conf.framework = "keras"

--- a/neural_compressor/model/tensorflow_model.py
+++ b/neural_compressor/model/tensorflow_model.py
@@ -308,11 +308,17 @@ def load_saved_model(model, saved_model_tags, input_tensor_names, output_tensor_
 
 
 def _get_graph_from_saved_model_v2(saved_model_dir, input_tensor_names, output_tensor_names):
+    from .adaptor.tf_utils.util import parse_saved_model
     from tensorflow.python.saved_model import signature_constants, tag_constants
-
     saved_model_exported_names = [signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
     saved_model_tags = set([tag_constants.SERVING])
-    return load_saved_model(saved_model_dir, saved_model_tags, input_tensor_names, output_tensor_names)
+    try: 
+        graph_def, _saved_model, func, frozen_func, input_names, output_names = parse_saved_model(saved_model_dir, \
+                                                                        True, input_tensor_names, output_tensor_names)
+    except:
+        graph_def, input_names, output_names = load_saved_model(saved_model_dir, saved_model_tags, 
+                                                                input_tensor_names, output_tensor_names)
+    return graph_def, input_names, output_names
 
 
 def _get_graph_from_original_keras_v2(model, output_dir):


### PR DESCRIPTION
## Description

This PR includes the code of support big saved_model and GPT-J-6B as an example. 
- [x] Optimize parsing code for TF saved_model
- [x] Support the PTQ of big saved_model
- [x] Landing zone model GPT-J-6B as an example
- [x] Support Smooth Quant

Other TODOs by follow-up PRs.

- [ ] Support Config combination (`RTNWeightOnlyConfig` + `GPTQWeightOnlyConfig`)
- [ ] Validate the user config
- [ ] Port a LLM using RTN
- [ ] Dcos
- [ ] Other `TODO`s marked in the code

## 3.0 API Usage

Users can pass the model kwargs by a `modelType='llm_saved_model'` to create a INC inner class for TF big saved_model .
A function that maps name from AutoTrackable variables to graph nodes is also requred.

### Create Instace
```python
from neural_compressor import Model
model = Model('./gpt-j-6B', modelType='llm_saved_model')
```

### Mapping function

```python
def weight_name_mapping(name):
    """The function that maps name from AutoTrackable variables to graph nodes"""
    name = name.replace('tfgptj_for_causal_lm', 'StatefulPartitionedCall')
    name = name.replace('kernel:0', 'Tensordot/ReadVariableOp')
    return name
model.weight_name_mapping = weight_name_mapping
```

## How has this PR been tested?

Pre-CI, Extension Test

## Dependency Change?

No
