### PR TITLE
Avoid screen output pollution due to large input tensors by letting user know 'Not printed here due to large size tensors...

### DIFF
--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -211,14 +211,16 @@ def fit(
             conf_dict = {}
             dump_class_attrs(conf, conf_dict)
             import copy
+
             def update(d):
                 o = copy.copy(d)
                 for k, v in o.items():
-                    if k == 'example_inputs':
-                        o[k] = 'Not printed here due to large size tensors...'
+                    if k == "example_inputs":
+                        o[k] = "Not printed here due to large size tensors..."
                     elif isinstance(v, dict):
                         o[k] = update(v)
                 return o
+
             logger.info(update(conf_dict))
             if conf.diagnosis:
                 ni_workload_id = register_neural_insights_workload(

--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -215,7 +215,7 @@ def fit(
                 o = copy.copy(d)
                 for k, v in o.items():
                     if k == 'example_inputs':
-                        o[k] = 'Not printed here due to large size tensor...'
+                        o[k] = 'Not printed here due to large size tensors...'
                     elif isinstance(v, dict):
                         o[k] = update(v)
                 return o

--- a/neural_compressor/quantization.py
+++ b/neural_compressor/quantization.py
@@ -210,7 +210,16 @@ def fit(
             logger.debug("Dump user configuration:")
             conf_dict = {}
             dump_class_attrs(conf, conf_dict)
-            logger.info(conf_dict)
+            import copy
+            def update(d):
+                o = copy.copy(d)
+                for k, v in o.items():
+                    if k == 'example_inputs':
+                        o[k] = 'Not printed here due to large size tensor...'
+                    elif isinstance(v, dict):
+                        o[k] = update(v)
+                return o
+            logger.info(update(conf_dict))
             if conf.diagnosis:
                 ni_workload_id = register_neural_insights_workload(
                     workload_location=os.path.abspath(options.workspace),


### PR DESCRIPTION
## Type of Change

No API change. Fixed screen pollution issue due to large input tensors from llm. 

## Description

Don't print sample inputs by replacing it with notice for users "Not printed here due to large size tensors..."

## Expected Behavior & Potential Risk
No risk. 

## How has this PR been tested?


## Dependency Change?

No dependency change
