### PR TITLE
add quantization support on MacOS

### DIFF
--- a/neural_compressor/benchmark.py
+++ b/neural_compressor/benchmark.py
@@ -510,11 +510,10 @@ def fit(model, conf, b_dataloader=None, b_func=None):
 
     if b_dataloader is not None:
         check_dataloader(b_dataloader)
-
-    assert sys.platform in ["linux", "win32"], "only support platform windows and linux..."
+    assert sys.platform in ["linux", "win32", "darwin"], "platform not supported..."
     # disable multi-instance for running benchmark on GPU device
     set_all_env_var(conf)
-    if conf.device == "gpu":
+    if conf.device == "gpu" or sys.platform == "darwin":
         set_env_var("NC_ENV_CONF", True, overwrite_existing=True)
 
     if conf.diagnosis and os.environ.get("NC_ENV_CONF", None) in [None, "False"]:

--- a/neural_compressor/utils/utility.py
+++ b/neural_compressor/utils/utility.py
@@ -249,7 +249,10 @@ class CpuInfo(object):
                     b"\xB8\x07\x00\x00\x00" b"\x0f\xa2" b"\xC3",  # mov eax, 7  # cpuid  # ret
                 )
                 self._bf16 = bool(eax & (1 << 5))
-        self._sockets = self.get_number_of_sockets()
+        if "arch" in info and "ARM" in info["arch"]: # pragma: no cover
+            self._sockets = 1
+        else:
+            self._sockets = self.get_number_of_sockets()
         self._cores = psutil.cpu_count(logical=False)
         self._cores_per_socket = int(self._cores / self._sockets)
 

--- a/neural_compressor/utils/utility.py
+++ b/neural_compressor/utils/utility.py
@@ -249,7 +249,7 @@ class CpuInfo(object):
                     b"\xB8\x07\x00\x00\x00" b"\x0f\xa2" b"\xC3",  # mov eax, 7  # cpuid  # ret
                 )
                 self._bf16 = bool(eax & (1 << 5))
-        if "arch" in info and "ARM" in info["arch"]: # pragma: no cover
+        if "arch" in info and "ARM" in info["arch"]:  # pragma: no cover
             self._sockets = 1
         else:
             self._sockets = self.get_number_of_sockets()


### PR DESCRIPTION
## Type of Change

Enhancement

## Description

add quantization support on MacOS, which will fix

https://github.com/intel/neural-compressor/issues/1278 and https://github.com/intel/neural-compressor/issues/1275

## Expected Behavior & Potential Risk

add quantization support on MacOS

## How has this PR been tested?

Run the example neural-compressor/examples/onnxrt/nlp/bert/quantization/ptq_static

on a Apple M2 Pro

## Dependency Change?

None