### PR TITLE
Fix smoothquant minmax observer init

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3116,11 +3116,13 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                         if not folding:
                             if self.sq_minmax_init or self.version.release >= Version("2.1.1").release:
                                 from torch.ao.quantization.observer import MinMaxObserver
+
                                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                                     alpha=0.5, act_observer=MinMaxObserver
                                 )
                             elif self.sq_minmax_init or self.version.release >= Version("2.1.0").release:
                                 from torch.ao.quantization.observer import MinMaxObserver
+
                                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                                     alpha=0.5, act_observer=MinMaxObserver()
                                 )
@@ -3310,11 +3312,13 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
         if not hasattr(model._model, "save_qconf_summary") or not hasattr(model._model, "load_qconf_summary"):
             if self.sq_minmax_init or self.version.release >= Version("2.1.1").release:
                 from torch.ao.quantization.observer import MinMaxObserver
+
                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                     alpha=0.5, act_observer=MinMaxObserver
                 )
             elif self.sq_minmax_init or self.version.release >= Version("2.1.0").release:
                 from torch.ao.quantization.observer import MinMaxObserver
+
                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                     alpha=0.5, act_observer=MinMaxObserver()
                 )

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3118,7 +3118,7 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                                 from torch.ao.quantization.observer import MinMaxObserver
 
                                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                                    alpha=0.5, act_observer=MinMaxObserver
+                                    alpha=0.5, act_observer=MinMaxObserver()
                                 )
                             else:
                                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
@@ -3308,7 +3308,7 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                 from torch.ao.quantization.observer import MinMaxObserver
 
                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                    alpha=0.5, act_observer=MinMaxObserver
+                    alpha=0.5, act_observer=MinMaxObserver()
                 )
             else:
                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3114,20 +3114,22 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                         smooth_quant_args = self.recipes.get("smooth_quant_args", {})
                         folding = smooth_quant_args.get("folding", False)
                         if not folding:
-                            if self.sq_minmax_init or self.version.release >= Version("2.1.1").release:
-                                from torch.ao.quantization.observer import MinMaxObserver
+                            from torch.ao.quantization.observer import MinMaxObserver
 
-                                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                                    alpha=0.5, act_observer=MinMaxObserver
-                                )
-                            elif self.sq_minmax_init or self.version.release >= Version("2.1.0").release:
-                                from torch.ao.quantization.observer import MinMaxObserver
-
-                                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                                    alpha=0.5, act_observer=MinMaxObserver()
-                                )
+                            if self.version.release >= Version("2.1.1").release:
+                                if self.sq_minmax_init:
+                                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                                        alpha=0.5, act_observer=MinMaxObserver
+                                    )
+                                else:
+                                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
                             else:
-                                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
+                                if self.sq_minmax_init:
+                                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                                        alpha=0.5, act_observer=MinMaxObserver()
+                                    )
+                                else:
+                                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
                     if self.example_inputs is None:
                         self.example_inputs = get_example_inputs(model, self.q_dataloader)
                     from neural_compressor.adaptor.torch_utils.util import move_input_device
@@ -3310,20 +3312,22 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
         # Check save_qconf_summary part is a workaround for IPEX bug.
         # Sometimes the prepared model from get_op_capablitiy loss this attribute
         if not hasattr(model._model, "save_qconf_summary") or not hasattr(model._model, "load_qconf_summary"):
-            if self.sq_minmax_init or self.version.release >= Version("2.1.1").release:
-                from torch.ao.quantization.observer import MinMaxObserver
+            from torch.ao.quantization.observer import MinMaxObserver
 
-                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                    alpha=0.5, act_observer=MinMaxObserver
-                )
-            elif self.sq_minmax_init or self.version.release >= Version("2.1.0").release:
-                from torch.ao.quantization.observer import MinMaxObserver
-
-                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                    alpha=0.5, act_observer=MinMaxObserver()
-                )
+            if self.version.release >= Version("2.1.1").release:
+                if self.sq_minmax_init:
+                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                        alpha=0.5, act_observer=MinMaxObserver
+                    )
+                else:
+                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
             else:
-                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
+                if self.sq_minmax_init:
+                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                        alpha=0.5, act_observer=MinMaxObserver()
+                    )
+                else:
+                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
             if isinstance(self.example_inputs, dict):
                 model._model = ipex.quantization.prepare(
                     model._model, static_qconfig, example_kwarg_inputs=self.example_inputs, inplace=inplace

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3116,7 +3116,11 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                         if not folding:
                             if self.sq_minmax_init or self.version.release >= Version("2.1.1").release:
                                 from torch.ao.quantization.observer import MinMaxObserver
-
+                                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                                    alpha=0.5, act_observer=MinMaxObserver
+                                )
+                            elif self.sq_minmax_init or self.version.release >= Version("2.1.0").release:
+                                from torch.ao.quantization.observer import MinMaxObserver
                                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                                     alpha=0.5, act_observer=MinMaxObserver()
                                 )
@@ -3306,7 +3310,11 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
         if not hasattr(model._model, "save_qconf_summary") or not hasattr(model._model, "load_qconf_summary"):
             if self.sq_minmax_init or self.version.release >= Version("2.1.1").release:
                 from torch.ao.quantization.observer import MinMaxObserver
-
+                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                    alpha=0.5, act_observer=MinMaxObserver
+                )
+            elif self.sq_minmax_init or self.version.release >= Version("2.1.0").release:
+                from torch.ao.quantization.observer import MinMaxObserver
                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                     alpha=0.5, act_observer=MinMaxObserver()
                 )

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3118,8 +3118,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
 
                             if self.version.release >= Version("2.1.1").release:
                                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                                        alpha=0.5, act_observer=MinMaxObserver
-                                    )
+                                    alpha=0.5, act_observer=MinMaxObserver
+                                )
                             else:
                                 if self.sq_minmax_init:
                                     static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
@@ -3317,8 +3317,8 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
 
             if self.version.release >= Version("2.1.1").release:
                 static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
-                        alpha=0.5, act_observer=MinMaxObserver
-                    )
+                    alpha=0.5, act_observer=MinMaxObserver
+                )
             else:
                 if self.sq_minmax_init:
                     static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3117,16 +3117,17 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                             from torch.ao.quantization.observer import MinMaxObserver
 
                             if self.version.release >= Version("2.1.1").release:
-                                if self.sq_minmax_init:
-                                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                                         alpha=0.5, act_observer=MinMaxObserver
                                     )
-                                else:
-                                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
                             else:
                                 if self.sq_minmax_init:
                                     static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                                         alpha=0.5, act_observer=MinMaxObserver()
+                                    )
+                                    logger.warning(
+                                        "The int8 model accuracy will be close to 0 with MinMaxobserver, "
+                                        + "the suggested IPEX version is higher or equal than 2.1.100."
                                     )
                                 else:
                                     static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
@@ -3315,16 +3316,17 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
             from torch.ao.quantization.observer import MinMaxObserver
 
             if self.version.release >= Version("2.1.1").release:
-                if self.sq_minmax_init:
-                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
+                static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                         alpha=0.5, act_observer=MinMaxObserver
                     )
-                else:
-                    static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)
             else:
                 if self.sq_minmax_init:
                     static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(
                         alpha=0.5, act_observer=MinMaxObserver()
+                    )
+                    logger.warning(
+                        "The int8 model accuracy will be close to 0 with MinMaxobserver, "
+                        + "the suggested IPEX version is higher or equal than 2.1.100+cpu."
                     )
                 else:
                     static_qconfig = ipex.quantization.get_smooth_quant_qconfig_mapping(alpha=0.5)


### PR DESCRIPTION
## Type of Change

ipex 2.1.0 requests observer object, but ipex 2.1.1 requests observer class.
ipex 2.1.0 code
https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-cpu/blob/v2.1.0%2Bcpu-rc4/intel_extension_for_pytorch/quantization/_smooth_quant.py#L85
ipex 2.1.1 code
https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-cpu/blob/v2.1.100%2Bcpu-rc0/intel_extension_for_pytorch/quantization/_smooth_quant.py#L75

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
