### PR TITLE
Remove unnecessary configs for TF Smooth Quantization

### DIFF
--- a/neural_compressor/adaptor/tensorflow.py
+++ b/neural_compressor/adaptor/tensorflow.py
@@ -1873,17 +1873,10 @@ class TensorFlowAdaptor(Adaptor):
         self.pre_optimized_model = self.pre_optimizer_handle.get_optimized_model(self.itex_mode)
         model.graph_def = self.pre_optimized_model.graph_def
 
-        # Get the nodes list which can't be quantized from tune_cfg
-        tune_cfg = None
-        black_nodes = []
-        if tune_cfg is not None:
-            self._tuning_cfg_to_fw(tune_cfg)
-            black_nodes = [node for node in self.quantize_config if self.quantize_config[node] == "fp32"]
-
         # Run calibration to get max values per channel
         from .tf_utils.smooth_quant_calibration import SmoothQuantCalibration
 
-        calibration = SmoothQuantCalibration(model, dataloader, calib_iter, op_types, percentile, black_nodes)
+        calibration = SmoothQuantCalibration(model, dataloader, calib_iter, op_types, percentile)
         max_vals_per_channel, sq_weight_node_names = calibration()
 
         # Get weight tensors and weight nodes based on the input tensor
@@ -1936,13 +1929,6 @@ class TensorFlowAdaptor(Adaptor):
         self.pre_optimized_model = self.pre_optimizer_handle.get_optimized_model(self.itex_mode)
         model.graph_def = self.pre_optimized_model.graph_def
 
-        # Get the nodes list which can't be quantized from tune_cfg
-        tune_cfg = None
-        black_nodes = []
-        if tune_cfg is not None:
-            self._tuning_cfg_to_fw(tune_cfg)
-            black_nodes = [node for node in self.quantize_config if self.quantize_config[node] == "fp32"]
-
         # only support per-tensor MatMul now
         op_types = ["MatMul"]
         llm_temp_dir = self.work_dir + "/temp_saved_model"
@@ -1955,7 +1941,6 @@ class TensorFlowAdaptor(Adaptor):
             calib_iter,
             op_types,
             percentile,
-            black_nodes,
             llm_temp_dir,
             model.weight_name_mapping,
         )

--- a/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
+++ b/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
@@ -246,9 +246,7 @@ class SmoothQuantCalibrationLLM(SmoothQuantCalibration):
         weight_name_mapping (): A function that convert weight tensor name in autotrackable to node name in graph_def
     """
 
-    def __init__(
-        self, model_path, dataloader, iterations, op_types, percentile, temp_path, weight_name_mapping
-    ):
+    def __init__(self, model_path, dataloader, iterations, op_types, percentile, temp_path, weight_name_mapping):
         """Initializes a SmoothQuantCalibrationLLM object."""
         self.func = None
         self.graph_def = None

--- a/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
+++ b/neural_compressor/adaptor/tf_utils/smooth_quant_calibration.py
@@ -50,10 +50,9 @@ class SmoothQuantCalibration:
         iterations (int): The number of iterations to run the calibration process.
         op_types (List[str]): The types of operations to be quantized.
         percentile (float): The percentile of calibration to remove outliers.
-        black_nodes (List[str]): A list of node names to be ignored during calibration.
     """
 
-    def __init__(self, model, dataloader, iterations, op_types, percentile, black_nodes):
+    def __init__(self, model, dataloader, iterations, op_types, percentile):
         """Initializes a SmoothQuantCalibration object."""
         self.model = model
         self.dataloader = dataloader
@@ -61,7 +60,6 @@ class SmoothQuantCalibration:
         # self.iterations = 3
         self.op_types = op_types
         self.percentile = percentile
-        self.black_nodes = black_nodes
         self._sq_input_node_names = []
         self._sq_output_tensor_dict = {}
         self._sq_weight_node_names = {}  # mapping from its weight node name to the concrete output node name
@@ -171,7 +169,7 @@ class SmoothQuantCalibration:
         )
 
         for node in sorted_graph.node:
-            if node.op not in self.op_types or node.name in self.black_nodes:
+            if node.op not in self.op_types:
                 continue
             # Fix retval already been set issue
             if "while" in node.input[0]:  # pragma: no cover
@@ -243,14 +241,13 @@ class SmoothQuantCalibrationLLM(SmoothQuantCalibration):
         iterations (int): The number of iterations to run the calibration process.
         op_types (List[str]): The types of operations to be quantized.
         percentile (float): The percentile of calibration to remove outliers.
-        black_nodes (List[str]): A list of node names to be ignored during calibration.
         eval_func (function):  The function to inference the model.
         temp_path (str): The temporary path to store median model.
         weight_name_mapping (): A function that convert weight tensor name in autotrackable to node name in graph_def
     """
 
     def __init__(
-        self, model_path, dataloader, iterations, op_types, percentile, black_nodes, temp_path, weight_name_mapping
+        self, model_path, dataloader, iterations, op_types, percentile, temp_path, weight_name_mapping
     ):
         """Initializes a SmoothQuantCalibrationLLM object."""
         self.func = None
@@ -262,7 +259,6 @@ class SmoothQuantCalibrationLLM(SmoothQuantCalibration):
         self.iterations = iterations
         self.op_types = op_types
         self.percentile = percentile
-        self.black_nodes = black_nodes
         self.temp_path = temp_path
         self.weight_name_mapping = weight_name_mapping
         self.print_node_list = []
@@ -465,7 +461,7 @@ class SmoothQuantCalibrationLLM(SmoothQuantCalibration):
         )
 
         for node in sorted_graph.node:
-            if node.op not in self.op_types or node.name in self.black_nodes:
+            if node.op not in self.op_types:
                 continue
             # Fix retval already been set issue
             if "while" in node.input[0]:  # pragma: no cover


### PR DESCRIPTION
## Type of Change

Remove unnecessary configs for TF smooth quantization.

## Description

Remove tune_cfg and black_nodes which are useless in TF smooth quantization.

## How has this PR been tested?

PreCI

## Dependency Change?

No
