### PR TITLE
Add `white_list` to config

### DIFF
--- a/neural_compressor/common/base_config.py
+++ b/neural_compressor/common/base_config.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from neural_compressor.common.logger import Logger
-from neural_compressor.common.utility import BASE_CONFIG, COMPOSABLE_CONFIG, GLOBAL, LOCAL
+from neural_compressor.common.utility import BASE_CONFIG, COMPOSABLE_CONFIG, GLOBAL, LOCAL, OP_NAME_OR_MODULE_TYPE
 
 logger = Logger().get_logger()
 
@@ -60,12 +60,21 @@ class BaseConfig(ABC):
 
     name = BASE_CONFIG
 
-    def __init__(self) -> None:
+    def __init__(self, white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None) -> None:
         self._global_config: Optional[BaseConfig] = None
         # For PyTorch, operator_type is the collective name for module type and functional operation type,
         # for example, `torch.nn.Linear`, and `torch.nn.functional.linear`.
         # local config is the collections of operator_type configs and operator configs
         self._local_config: Dict[str, Optional[BaseConfig]] = {}
+        self._white_list = white_list
+
+    @property
+    def white_list(self):
+        return self._white_list
+
+    @white_list.setter
+    def white_list(self, op_name_or_type_list: Optional[List[OP_NAME_OR_MODULE_TYPE]]):
+        self._white_list = op_name_or_type_list
 
     @property
     def global_config(self):

--- a/neural_compressor/common/base_config.py
+++ b/neural_compressor/common/base_config.py
@@ -23,7 +23,15 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from neural_compressor.common.logger import Logger
-from neural_compressor.common.utility import BASE_CONFIG, COMPOSABLE_CONFIG, GLOBAL, LOCAL, OP_NAME_OR_MODULE_TYPE
+from neural_compressor.common.utility import (
+    BASE_CONFIG,
+    COMPOSABLE_CONFIG,
+    DEFAULT_WHITE_LIST,
+    EMPTY_WHITE_LIST,
+    GLOBAL,
+    LOCAL,
+    OP_NAME_OR_MODULE_TYPE,
+)
 
 logger = Logger().get_logger()
 
@@ -60,13 +68,29 @@ class BaseConfig(ABC):
 
     name = BASE_CONFIG
 
-    def __init__(self, white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None) -> None:
+    def __init__(self, white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = DEFAULT_WHITE_LIST) -> None:
         self._global_config: Optional[BaseConfig] = None
         # For PyTorch, operator_type is the collective name for module type and functional operation type,
         # for example, `torch.nn.Linear`, and `torch.nn.functional.linear`.
         # local config is the collections of operator_type configs and operator configs
         self._local_config: Dict[str, Optional[BaseConfig]] = {}
         self._white_list = white_list
+
+    def _post_init(self):
+        if self.white_list == DEFAULT_WHITE_LIST:
+            global_config = self.get_params_dict()
+            self._global_config = self.__class__(**global_config, white_list=None)
+        elif bool(self.white_list):
+            for op_name_or_type in self.white_list:
+                global_config = self.get_params_dict()
+                tmp_config = self.__class__(**global_config, white_list=None)
+                self.set_local(op_name_or_type, tmp_config)
+        elif self.white_list == EMPTY_WHITE_LIST:
+            return
+        else:
+            raise NotImplementedError(
+                f"The white list should be one of {DEFAULT_WHITE_LIST}, {EMPTY_WHITE_LIST}, a not empty list, but got {self.white_list}"
+            )
 
     @property
     def white_list(self):
@@ -78,8 +102,6 @@ class BaseConfig(ABC):
 
     @property
     def global_config(self):
-        if self._global_config is None:
-            self._global_config = self.__class__(**self.to_dict())
         return self._global_config
 
     @global_config.setter
@@ -97,23 +119,26 @@ class BaseConfig(ABC):
     def set_local(self, operator_name: str, config: BaseConfig) -> BaseConfig:
         if operator_name in self.local_config:
             logger.warning("The configuration for %s has already been set, update it.", operator_name)
-        if self.global_config is None:
-            self.global_config = self.__class__(**self.to_dict())
         self.local_config[operator_name] = config
         return self
 
     def to_dict(self, params_list=[], operator2str=None):
         result = {}
-        global_config = {}
-        for param in params_list:
-            global_config[param] = getattr(self, param)
+        global_config = self.get_params_dict()
         if bool(self.local_config):
             result[LOCAL] = {}
             for op_name, config in self.local_config.items():
                 result[LOCAL][op_name] = config.to_dict()
-            result[GLOBAL] = global_config
+            if self.global_config:
+                result[GLOBAL] = global_config
         else:
             result = global_config
+        return result
+
+    def get_params_dict(self):
+        result = dict()
+        for param in self.params_list:
+            result[param] = getattr(self, param)
         return result
 
     @classmethod
@@ -214,7 +239,8 @@ class BaseConfig(ABC):
             global_config = config.global_config
             op_type_config_dict, op_name_config_dict = config._get_op_name_op_type_config()
             for op_name, op_type in model_info:
-                config_mapping[(op_type, op_name)] = global_config
+                if self.global_config is not None:
+                    config_mapping[(op_type, op_name)] = global_config
                 if op_type in op_type_config_dict:
                     config_mapping[(op_type, op_name)] = op_name_config_dict[op_type]
                 if op_name in op_name_config_dict:

--- a/neural_compressor/common/utility.py
+++ b/neural_compressor/common/utility.py
@@ -21,6 +21,8 @@
 # constants for configs
 GLOBAL = "global"
 LOCAL = "local"
+DEFAULT_WHITE_LIST = "*"
+EMPTY_WHITE_LIST = None
 
 # config name
 BASE_CONFIG = "base_config"

--- a/neural_compressor/common/utility.py
+++ b/neural_compressor/common/utility.py
@@ -29,3 +29,8 @@ RTN_WEIGHT_ONLY_QUANT = "rtn_weight_only_quant"
 STATIC_QUANT = "static_quant"
 GPTQ = "gptq"
 DUMMY_CONFIG = "dummy_config"
+
+
+from typing import Callable, Union
+
+OP_NAME_OR_MODULE_TYPE = Union[str, Callable]

--- a/neural_compressor/tensorflow/quantization/config.py
+++ b/neural_compressor/tensorflow/quantization/config.py
@@ -18,12 +18,12 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Callable, Dict, List, NamedTuple, Union
+from typing import Callable, Dict, List, NamedTuple, Optional, Union
 
 import tensorflow as tf
 
 from neural_compressor.common.base_config import BaseConfig, register_config, registered_configs
-from neural_compressor.common.utility import STATIC_QUANT
+from neural_compressor.common.utility import OP_NAME_OR_MODULE_TYPE, STATIC_QUANT
 
 FRAMEWORK_NAME = "keras"
 
@@ -89,6 +89,7 @@ class StaticQuantConfig(BaseConfig):
         act_dtype: str = "int8",
         act_sym: bool = True,
         act_granularity: str = "per_tensor",
+        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None,
     ):
         """Init static quantization config.
 
@@ -100,7 +101,7 @@ class StaticQuantConfig(BaseConfig):
             act_sym (bool): Indicates whether activations are symmetric, default is True.
             act_granularity (str): Calculate tensor-wise scales or channel-wise scales for activations.
         """
-        super().__init__()
+        super().__init__(white_list=white_list)
         self.weight_dtype = weight_dtype
         self.weight_sym = weight_sym
         self.weight_granularity = weight_granularity

--- a/neural_compressor/tensorflow/quantization/config.py
+++ b/neural_compressor/tensorflow/quantization/config.py
@@ -23,7 +23,7 @@ from typing import Callable, Dict, List, NamedTuple, Optional, Union
 import tensorflow as tf
 
 from neural_compressor.common.base_config import BaseConfig, register_config, registered_configs
-from neural_compressor.common.utility import OP_NAME_OR_MODULE_TYPE, STATIC_QUANT
+from neural_compressor.common.utility import DEFAULT_WHITE_LIST, OP_NAME_OR_MODULE_TYPE, STATIC_QUANT
 
 FRAMEWORK_NAME = "keras"
 
@@ -89,7 +89,7 @@ class StaticQuantConfig(BaseConfig):
         act_dtype: str = "int8",
         act_sym: bool = True,
         act_granularity: str = "per_tensor",
-        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None,
+        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = DEFAULT_WHITE_LIST,
     ):
         """Init static quantization config.
 
@@ -108,6 +108,7 @@ class StaticQuantConfig(BaseConfig):
         self.act_dtype = act_dtype
         self.act_sym = act_sym
         self.act_granularity = act_granularity
+        self._post_init()
 
     def to_dict(self):
         return super().to_dict(params_list=self.params_list, operator2str=operator2str)

--- a/neural_compressor/torch/quantization/config.py
+++ b/neural_compressor/torch/quantization/config.py
@@ -23,7 +23,13 @@ from typing import Callable, Dict, List, NamedTuple, Optional, Union
 import torch
 
 from neural_compressor.common.base_config import BaseConfig, register_config, registered_configs
-from neural_compressor.common.utility import DUMMY_CONFIG, GPTQ, OP_NAME_OR_MODULE_TYPE, RTN_WEIGHT_ONLY_QUANT
+from neural_compressor.common.utility import (
+    DEFAULT_WHITE_LIST,
+    DUMMY_CONFIG,
+    GPTQ,
+    OP_NAME_OR_MODULE_TYPE,
+    RTN_WEIGHT_ONLY_QUANT,
+)
 
 FRAMEWORK_NAME = "torch"
 
@@ -87,7 +93,7 @@ class RTNWeightQuantConfig(BaseConfig):
         double_quant_bits: int = 8,
         double_quant_sym: bool = True,
         double_quant_group_size: int = 256,
-        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None,
+        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = DEFAULT_WHITE_LIST,
     ):
         """Init RTN weight-only quantization config.
 
@@ -120,6 +126,7 @@ class RTNWeightQuantConfig(BaseConfig):
         self.double_quant_dtype = double_quant_dtype
         self.double_quant_sym = double_quant_sym
         self.double_quant_group_size = double_quant_group_size
+        self._post_init()
 
     def to_dict(self):
         return super().to_dict(params_list=self.params_list, operator2str=operator2str)
@@ -221,7 +228,7 @@ class GPTQConfig(BaseConfig):
         double_quant_bits: int = 8,
         double_quant_sym: bool = True,
         double_quant_group_size: int = 256,
-        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None,
+        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = DEFAULT_WHITE_LIST,
     ):
         """Init GPTQ config.
 
@@ -250,6 +257,7 @@ class GPTQConfig(BaseConfig):
         self.double_quant_dtype = double_quant_dtype
         self.double_quant_sym = double_quant_sym
         self.double_quant_group_size = double_quant_group_size
+        self._post_init()
 
     def to_dict(self):
         return super().to_dict(params_list=self.params_list, operator2str=operator2str)

--- a/neural_compressor/torch/quantization/config.py
+++ b/neural_compressor/torch/quantization/config.py
@@ -18,12 +18,12 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Callable, Dict, List, NamedTuple, Union
+from typing import Callable, Dict, List, NamedTuple, Optional, Union
 
 import torch
 
 from neural_compressor.common.base_config import BaseConfig, register_config, registered_configs
-from neural_compressor.common.utility import DUMMY_CONFIG, GPTQ, RTN_WEIGHT_ONLY_QUANT
+from neural_compressor.common.utility import DUMMY_CONFIG, GPTQ, OP_NAME_OR_MODULE_TYPE, RTN_WEIGHT_ONLY_QUANT
 
 FRAMEWORK_NAME = "torch"
 
@@ -87,6 +87,7 @@ class RTNWeightQuantConfig(BaseConfig):
         double_quant_bits: int = 8,
         double_quant_sym: bool = True,
         double_quant_group_size: int = 256,
+        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None,
     ):
         """Init RTN weight-only quantization config.
 
@@ -105,7 +106,7 @@ class RTNWeightQuantConfig(BaseConfig):
             double_quant_sym (bool): Indicates whether double_quant scale are symmetric, default is True.
             double_quant_group_size (int): Size of double_quant groups, default is 32.
         """
-        super().__init__()
+        super().__init__(white_list=white_list)
         self.weight_bits = weight_bits
         self.weight_dtype = weight_dtype
         self.weight_group_size = weight_group_size
@@ -220,12 +221,13 @@ class GPTQConfig(BaseConfig):
         double_quant_bits: int = 8,
         double_quant_sym: bool = True,
         double_quant_group_size: int = 256,
+        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = None,
     ):
         """Init GPTQ config.
 
         Args:
         """
-        super().__init__()
+        super().__init__(white_list=white_list)
         self.weight_dtype = weight_dtype
         self.weight_bits = weight_bits
         self.weight_group_size = weight_group_size

--- a/test/3x/torch/test_config.py
+++ b/test/3x/torch/test_config.py
@@ -169,6 +169,34 @@ class TestQuantizationConfig(unittest.TestCase):
         qmodel = quantize(fp32_model, quant_config)
         self.assertIsNotNone(qmodel)
 
+    def test_config_white_lst(self):
+        from neural_compressor.torch import RTNWeightQuantConfig, quantize
+
+        global_config = RTNWeightQuantConfig(weight_bits=4, weight_dtype="nf4")
+        # set operator instance
+        fc1_config = RTNWeightQuantConfig(weight_bits=4, weight_dtype="int8", white_list=["model.fc1"])
+        # get model and quantize
+        fp32_model = build_simple_torch_model()
+        qmodel = quantize(fp32_model, quant_config=global_config + fc1_config)
+        self.assertIsNotNone(qmodel)
+
+    def test_config_white_lst2(self):
+        from neural_compressor.torch import RTNWeightQuantConfig
+        from neural_compressor.torch.utils import get_model_info
+
+        global_config = RTNWeightQuantConfig(weight_bits=4, weight_dtype="nf4")
+        # set operator instance
+        fc1_config = RTNWeightQuantConfig(weight_bits=6, weight_dtype="int8", white_list=["fc1"])
+        quant_config = global_config + fc1_config
+        # get model and quantize
+        fp32_model = build_simple_torch_model()
+        model_info = get_model_info(fp32_model, white_module_list=[torch.nn.Linear])
+        logger.info(quant_config)
+        configs_mapping = quant_config.to_config_mapping(model_info=model_info)
+        logger.info(configs_mapping)
+        self.assertTrue(configs_mapping[(torch.nn.Linear, "fc1")].weight_bits == 6)
+        self.assertTrue(configs_mapping[(torch.nn.Linear, "fc2")].weight_bits == 4)
+
     def test_config_from_dict(self):
         from neural_compressor.torch import RTNWeightQuantConfig
 


### PR DESCRIPTION
## Type of Change

Add `white_list` to config
API changed: Add `white_list` to config

## Description

`config1` is equal to `config2`

```python
from neural_compressor.torch import RTNWeightQuantConfig

config1 = RTNWeightQuantConfig(weight_bits=4, weight_dtype="nf4")
fc1_config = RTNWeightQuantConfig(weight_bits=6, weight_dtype="int8")
config1.set_local("fc1", fc1_config)

global_config = RTNWeightQuantConfig(weight_bits=4, weight_dtype="nf4")
fc1_config = RTNWeightQuantConfig(weight_bits=6, weight_dtype="int8", white_list=["fc1"])
config2 = global_config + fc1_config


```


## How has this PR been tested?
Pre-CI

## Dependency Change?
None
