### PR TITLE
[bug fix] update quantizable add ops detection on IPEX backend

### DIFF
--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -458,15 +458,13 @@ def get_quantizable_ops_from_cfgs(ops_name, op_infos_from_cfgs, input_tensor_ids
             op_info = op_infos_from_cfgs[name]
             output_tensors = op_info["output_tensor_infos"]
             input_tensors = op_info["input_tensor_infos"]
-            for input_tensor in input_tensors:
-                if "inf_dtype" not in input_tensor.keys():
-                    continue
-                if input_tensor["inf_dtype"] == "torch.float32":
-                    pre_op_names = input_tensor_ids_op_name[input_tensor["id"]]
-                    for pre_op_name in pre_op_names:
-                        if pre_op_name[1] in ["q_op_infos"]:
-                            start = False
-                            break
+            start = any(
+                [
+                    input_tensor["inf_dtype"] != "torch.float32"
+                    for input_tensor in input_tensors
+                    if "inf_dtype" in input_tensor.keys()
+                ]
+            )
             if not start:
                 continue
             # add quantizable ops, include op and fuse ops.

--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -461,12 +461,13 @@ def get_quantizable_ops_from_cfgs(ops_name, op_infos_from_cfgs, input_tensor_ids
             for input_tensor in input_tensors:
                 if "inf_dtype" not in input_tensor.keys():
                     continue
-                if input_tensor["inf_dtype"] == torch.float32:
-                    pre_op_name = input_tensor_ids_op_name[input_tensor["id"]]
-                    if pre_op_name[1] in ["q_op_infos"]:
-                        print(pre_op_name, "is not the fuse ops first op.")
-                        start = False
-                        continue
+                if input_tensor["inf_dtype"] == "torch.float32":
+                    pre_op_names = input_tensor_ids_op_name[input_tensor["id"]]
+                    for pre_op_name in pre_op_names:
+                        if pre_op_name[1] in ["q_op_infos"]:
+                            logger.info(pre_op_name, "is not the fuse ops first op.")
+                            start = False
+                            break
             if not start:
                 continue
             # add quantizable ops, include op and fuse ops.

--- a/neural_compressor/adaptor/torch_utils/util.py
+++ b/neural_compressor/adaptor/torch_utils/util.py
@@ -465,7 +465,6 @@ def get_quantizable_ops_from_cfgs(ops_name, op_infos_from_cfgs, input_tensor_ids
                     pre_op_names = input_tensor_ids_op_name[input_tensor["id"]]
                     for pre_op_name in pre_op_names:
                         if pre_op_name[1] in ["q_op_infos"]:
-                            logger.info(pre_op_name, "is not the fuse ops first op.")
                             start = False
                             break
             if not start:

--- a/test/ipex/test_adaptor_ipex.py
+++ b/test/ipex/test_adaptor_ipex.py
@@ -316,62 +316,6 @@ class TestPytorchIPEX_1_12_Adaptor(unittest.TestCase):
         )
         self.assertTrue(isinstance(q_model._model, torch.jit.ScriptModule))
 
-    def test_tune_add(self):
-        class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv = torch.nn.Conv2d(3, 1, 1)
-                self.linear = torch.nn.Linear(224 * 224, 5)
-
-            def forward(self, a):
-                x = self.conv(a)
-                x = x.view(1, -1)
-                x += x
-                x = self.linear(x)
-                return x
-
-        model = M()
-        from neural_compressor import PostTrainingQuantConfig, quantization
-
-        acc_lst = [1, 0.8, 1.1, 1.2]
-
-        def fake_eval(model):
-            res = acc_lst.pop(0)
-            return res
-
-        conf = PostTrainingQuantConfig(backend="ipex", quant_level=0)
-        calib_dataloader = Dataloader()
-        q_model = quantization.fit(model, conf, calib_dataloader=calib_dataloader, eval_func=fake_eval)
-        self.assertTrue(isinstance(q_model._model, torch.jit.ScriptModule))
-
-    def test_tune_add_with_recipe(self):
-        class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(224 * 224 * 3, 5)
-
-            def forward(self, x):
-                x += x
-                x = x.view(1, -1)
-                x = self.linear(x)
-                return x
-
-        model = M()
-        from neural_compressor import PostTrainingQuantConfig, quantization
-
-        acc_lst = [1, 0.8, 1.1, 1.2]
-
-        def fake_eval(model):
-            res = acc_lst.pop(0)
-            return res
-
-        conf = PostTrainingQuantConfig(
-            backend="ipex", quant_level=0, recipes={"smooth_quant": True, "smooth_quant_args": {"alpha": 0.5}}
-        )
-        calib_dataloader = Dataloader()
-        q_model = quantization.fit(model, conf, calib_dataloader=calib_dataloader, eval_func=fake_eval)
-        self.assertTrue(isinstance(q_model._model, torch.jit.ScriptModule))
-
     def test_tune_minmax_obs(self):
         class M(torch.nn.Module):
             def __init__(self):
@@ -525,67 +469,6 @@ class TestPytorchIPEX_XPU_1_12_Adaptor(unittest.TestCase):
             conf,
             calib_dataloader=calib_dataloader,
         )
-        self.assertTrue(isinstance(q_model._model, torch.jit.ScriptModule))
-
-    def test_tune_add(self):
-        class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv = torch.nn.Conv2d(3, 1, 1)
-                self.linear = torch.nn.Linear(224 * 224, 5)
-
-            def forward(self, a):
-                x = self.conv(a)
-                x = x.view(1, -1)
-                x += x
-                x = self.linear(x)
-                return x
-
-        model = M().to("xpu")
-        from neural_compressor import PostTrainingQuantConfig, quantization
-
-        acc_lst = [1, 0.8, 1.1, 1.2]
-
-        def fake_eval(model):
-            res = acc_lst.pop(0)
-            return res
-
-        conf = PostTrainingQuantConfig(backend="ipex", device="xpu", quant_level=0)
-        calib_dataloader = Dataloader(device="xpu")
-        q_model = quantization.fit(model, conf, calib_dataloader=calib_dataloader, eval_func=fake_eval)
-        self.assertTrue(isinstance(q_model._model, torch.jit.ScriptModule))
-
-    def test_tune_add_with_recipe(self):
-        class M(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.conv = torch.nn.Conv2d(3, 1, 1)
-                self.linear = torch.nn.Linear(224 * 224, 5)
-
-            def forward(self, a):
-                x = self.conv(a)
-                x = x.view(1, -1)
-                x += x
-                x = self.linear(x)
-                return x
-
-        model = M().to("xpu")
-        from neural_compressor import PostTrainingQuantConfig, quantization
-
-        acc_lst = [1, 0.8, 1.1, 1.2]
-
-        def fake_eval(model):
-            res = acc_lst.pop(0)
-            return res
-
-        conf = PostTrainingQuantConfig(
-            backend="ipex",
-            device="xpu",
-            quant_level=0,
-            recipes={"smooth_quant": True, "smooth_quant_args": {"alpha": 0.5}},
-        )
-        calib_dataloader = Dataloader(device="xpu")
-        q_model = quantization.fit(model, conf, calib_dataloader=calib_dataloader, eval_func=fake_eval)
         self.assertTrue(isinstance(q_model._model, torch.jit.ScriptModule))
 
 


### PR DESCRIPTION
## Type of Change

bug fix

## Description

IPEX backend got wrong number of quantizable add ops when detecting. 
Quantizable add ops should be detected in gptj but not in opt model.

## Expected Behavior & Potential Risk

 # add ops can only be detected if both input inf_dtypes are not float32.
```
        "q_op_infos": {
            "0": {
                "op_type": "<method 'add' of 'torch._C._TensorBase' objects>",
                "op_type_is_module": false,
                "fqn": "",
                "input_tensor_infos": [
                    {
                        "id": 0,
                        "orig_dtype": "torch.float32",
                        "inf_dtype": "torch.float32",
                        "force_dtype": "torch.float32",
                        "scale": [
                            0.007949741557240486
                        ],
                        "zero_point": [
                            219
                        ]
                    },
                    {
                        "id": 0,
                        "orig_dtype": "torch.float32",
                        "inf_dtype": "torch.float32",
                        "force_dtype": "torch.float32",
                        "scale": [
                            0.007949741557240486
                        ],
                        "zero_point": [
                            219
                        ]
                    }
                ],
```
## How has this PR been tested?

local test on models

## Dependency Change?

N/A
