### PR TITLE
Remove Version Check for tf.estimator

### DIFF
--- a/neural_compressor/model/tensorflow_model.py
+++ b/neural_compressor/model/tensorflow_model.py
@@ -81,8 +81,7 @@ def get_model_type(model):
         return "graph"
     elif isinstance(model, tf.compat.v1.GraphDef):
         return "graph_def"
-    # tf.estimator is removed after tf2.14.0
-    elif version1_lt_version2(tf.__version__, "2.14.0") and isinstance(model, tf.compat.v1.estimator.Estimator):
+    elif isinstance(model, tf.compat.v1.estimator.Estimator):
         return "estimator"
     elif isinstance(model, str):
         model = os.path.abspath(os.path.expanduser(model))


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Remove version check for tf.estimator because it has been added back in tf2.14&tf2.15.

## Expected Behavior & Potential Risk

the bug of bert_base_mrpc will be fixed.

## How has this PR been tested?

Extension test, PreCI

## Dependency Change?

No
