### PR TITLE
Fixed inputs error for smoothquant example_inputs

### DIFF
--- a/neural_compressor/adaptor/torch_utils/smooth_quant.py
+++ b/neural_compressor/adaptor/torch_utils/smooth_quant.py
@@ -55,10 +55,11 @@ def move_input_to_device(input, device=torch.device("cpu")):
             tmp_input[k] = move_input_to_device(inp, device)
         input = tmp_input
     elif isinstance(input, list) or isinstance(input, tuple):
+        is_tuple = isinstance(input, tuple)
         tmp_input = []
         for inp in input:
             tmp_input.append(move_input_to_device(inp, device))
-        input = tmp_input
+        input = tuple(tmp_input) if is_tuple else tmp_input
     elif isinstance(input, torch.Tensor):
         input = input.to(device)  # pylint: disable=no-member
     return input


### PR DESCRIPTION
## Type of Change

bug fix  
No API changed

## Description

Fixed inputs error for sq, if inputs is tuple, we need set inputs to specified device and return a tuple, but it will return list type before.

## Expected Behavior & Potential Risk

Quantize T5 model with ipex sq successfully. 

## How has this PR been tested?

Local tested
