### PR TITLE
Fix llm model accuracy regression with IPEX 2.1.100

### DIFF
--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3382,7 +3382,7 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                     "The calibration failed when calibrating with ipex, "
                     + "using scale info from SmoothQuant for Linear and "
                     + "one iter calibration for other ops."
-                    )
+                )
         model._model.save_qconf_summary(qconf_summary=self.ipex_config_path)
         self._ipex_post_quant_process(model, q_model, dataloader, inplace=inplace)
 

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3381,7 +3381,7 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
                 "The calibration failed when calibrating with ipex, "
                 + "using scale info from SmoothQuant for Linear and "
                 + "one iter calibration for other ops."
-                )
+            )
         model._model.save_qconf_summary(qconf_summary=self.ipex_config_path)
         if self.version.release > Version("2.1.0").release:
             update_sq_scale(self.ipex_config_path, smoothquant_scale_info)

--- a/neural_compressor/adaptor/pytorch.py
+++ b/neural_compressor/adaptor/pytorch.py
@@ -3365,25 +3365,27 @@ class PyTorch_IPEXAdaptor(TemplateAdaptor):
         self._cfg_to_qconfig(tune_cfg, smooth_quant=True)
         update_sq_scale(self.ipex_config_path, smoothquant_scale_info)
         model._model.load_qconf_summary(qconf_summary=self.ipex_config_path)
-        if self.version.release <= Version("2.1.0").release:
-            # real calibration for other operators
-            try:
-                # IPEX may raise an error on the second iteration.
-                # OverflowError: cannot convert float infinity to integer
-                if q_func is not None:
-                    q_func(model._model)
-                else:
-                    iterations = tune_cfg.get("calib_iteration", 1)
-                    self.model_calibration(
-                        model._model, dataloader, iterations, None, tune_cfg.get("calib_sampling_size", 1)
-                    )
-            except:
-                logger.warning(
-                    "The calibration failed when calibrating with ipex, "
-                    + "using scale info from SmoothQuant for Linear and "
-                    + "one iter calibration for other ops."
+        # real calibration for other operators
+        try:
+            # IPEX may raise an error on the second iteration.
+            # OverflowError: cannot convert float infinity to integer
+            if q_func is not None:
+                q_func(model._model)
+            else:
+                iterations = tune_cfg.get("calib_iteration", 1)
+                self.model_calibration(
+                    model._model, dataloader, iterations, None, tune_cfg.get("calib_sampling_size", 1)
+                )
+        except:
+            logger.warning(
+                "The calibration failed when calibrating with ipex, "
+                + "using scale info from SmoothQuant for Linear and "
+                + "one iter calibration for other ops."
                 )
         model._model.save_qconf_summary(qconf_summary=self.ipex_config_path)
+        if self.version.release > Version("2.1.0").release:
+            update_sq_scale(self.ipex_config_path, smoothquant_scale_info)
+            model._model.load_qconf_summary(qconf_summary=self.ipex_config_path)
         self._ipex_post_quant_process(model, q_model, dataloader, inplace=inplace)
 
         with open(self.ipex_config_path, "r") as f:


### PR DESCRIPTION
## Type of Change

https://jira.devtools.intel.com/browse/IPB-2106?filter=-2, the issue is IPEX linear smoothquant observer doesn't work with  model loaded from json.
due to the above issue fixed by IPEX 2.1.100, we should reset the smoothquant linear scale infos after calibration.

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
