### PR TITLE
Fix wrong socket number retrieval for non-english system

### DIFF
--- a/neural_compressor/utils/utility.py
+++ b/neural_compressor/utils/utility.py
@@ -273,7 +273,7 @@ class CpuInfo(object):
 
     def get_number_of_sockets(self) -> int:
         """Get number of sockets in platform."""
-        cmd = "lscpu | grep 'Socket(s)' | cut -d ':' -f 2"
+        cmd = "cat /proc/cpuinfo | grep 'physical id' | sort -u | wc -l"
         if psutil.WINDOWS:
             cmd = r'wmic cpu get DeviceID | C:\Windows\System32\find.exe /C "CPU"'
 
@@ -915,7 +915,7 @@ def dump_table_to_csv(
 
 def get_number_of_sockets() -> int:
     """Get number of sockets in platform."""
-    cmd = "lscpu | grep 'Socket(s)' | cut -d ':' -f 2"
+    cmd = "cat /proc/cpuinfo | grep 'physical id' | sort -u | wc -l"
     if sys.platform == "win32":
         cmd = 'wmic cpu get DeviceID | find /c "CPU"'
 


### PR DESCRIPTION
## Type of Change

Fix https://github.com/intel/intel-extension-for-transformers/issues/762

## Description

`lscpu | grep 'Socket(s)' | cut -d ':' -f 2` may not fetch correct Socket number on non-english system, because `Socket(s)` may be translated to different language, as shown in `https://github.com/intel/intel-extension-for-transformers/issues/762#issuecomment-1873773702`.

What we can do is an alternative `cat /proc/cpuinfo | grep 'physical id' | sort -u | wc -l`, which should be in pure English to fetch.

## Expected Behavior & Potential Risk

As above.

## How has this PR been tested?

Original UT will be enough.

## Dependency Change?

None