### PR TITLE
remove pip install for neural coder extension

### DIFF
--- a/neural_coder/extensions/neural_compressor_ext_lab_alibaba/DEVELOP.md
+++ b/neural_coder/extensions/neural_compressor_ext_lab_alibaba/DEVELOP.md
@@ -6,22 +6,6 @@ A JupyterLab extension.
 
 - JupyterLab >= 3.0
 
-## Install
-
-To install the extension, execute:
-
-```bash
-pip install neural_compressor_ext_lab_alibaba
-```
-
-## Uninstall
-
-To remove the extension, execute:
-
-```bash
-pip uninstall neural_compressor_ext_lab_alibaba
-```
-
 ## Contributing
 
 ### Development install


### PR DESCRIPTION
## Type of Change

documentation 

## Description

remove pip install for neural coder extension, remove the invalid description. 
