### PR TITLE
rename key to pythonPath

### DIFF
--- a/neural_coder/extensions/neural_compressor_ext_vscode/src/extension.ts
+++ b/neural_coder/extensions/neural_compressor_ext_vscode/src/extension.ts
@@ -34,10 +34,10 @@ async function highLight () {
 
 export async function activate(context: vscode.ExtensionContext) {  
   // init
-  const key = "neuralCoder.pythonPath";
+  const pythonPath = "neuralCoder.pythonPath";
   let config: vscode.WorkspaceConfiguration =
     vscode.workspace.getConfiguration();
-  let currentCondaName = config.get<string>(key);
+  let currentCondaName = config.get<string>(pythonPath);
 
   if (!currentCondaName) {
     vscode.window.showErrorMessage("Please input python Path!");
@@ -46,7 +46,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // conda Env
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(() => {
-      const currentCondaName = vscode.workspace.getConfiguration().get(key);
+      const currentCondaName = vscode.workspace.getConfiguration().get(pythonPath);
       if (!currentCondaName) {
         vscode.window.showErrorMessage("Please input python Path!");
         return;


### PR DESCRIPTION
## Type of Change

security fix: Hardcoded encryption keys can compromise security in a way that is not easy to remedy.
 
API changed or not
no

## Description

rename key to pythonPath

## Expected Behavior & Potential Risk

no security warning

## How has this PR been tested?

no security warning

## Dependency Change?

no
