### PR TITLE
Unify the `logger` usage

### DIFF
--- a/.azure-pipelines/scripts/ut/3x/collect_log_3x.sh
+++ b/.azure-pipelines/scripts/ut/3x/collect_log_3x.sh
@@ -1,6 +1,6 @@
 source /neural-compressor/.azure-pipelines/scripts/change_color.sh
 
-set -xe
+set -e
 pip install coverage
 export COVERAGE_RCFILE=/neural-compressor/.azure-pipelines/scripts/ut/3x/coverage.${1}
 coverage_log="/neural-compressor/log_dir/coverage_log"

--- a/neural_compressor/common/__init__.py
+++ b/neural_compressor/common/__init__.py
@@ -14,37 +14,19 @@
 
 from neural_compressor.common.utils import (
     level,
-    log,
-    info,
-    DEBUG,
-    debug,
-    warn,
-    warning,
-    error,
-    fatal,
+    logger,
     set_random_seed,
     set_workspace,
     set_resume_from,
     set_tensorboard,
-    Logger,
-    logger,
 )
 from neural_compressor.common.base_config import options
 
 
 __all__ = [
     "level",
-    "log",
-    "info",
-    "DEBUG",
-    "debug",
-    "warn",
-    "warning",
-    "error",
-    "fatal",
-    "options",
-    "Logger",
     "logger",
+    "options",
     "set_workspace",
     "set_random_seed",
     "set_resume_from",

--- a/neural_compressor/common/__init__.py
+++ b/neural_compressor/common/__init__.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 from neural_compressor.common.utils import (
+    log,
+    info,
+    debug,
+    warning,
+    error,
+    fatal,
     level,
     logger,
     Logger,
@@ -25,8 +31,15 @@ from neural_compressor.common.base_config import options
 
 
 __all__ = [
+    "debug",
+    "error",
+    "fatal",
+    "info",
     "level",
     "logger",
+    "log",
+    "warning",
+    "Logger",
     "options",
     "set_workspace",
     "set_random_seed",

--- a/neural_compressor/common/__init__.py
+++ b/neural_compressor/common/__init__.py
@@ -15,6 +15,7 @@
 from neural_compressor.common.utils import (
     level,
     logger,
+    Logger,
     set_random_seed,
     set_workspace,
     set_resume_from,

--- a/neural_compressor/common/base_config.py
+++ b/neural_compressor/common/base_config.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 from itertools import product
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.utils import (
     BASE_CONFIG,
     COMPOSABLE_CONFIG,
@@ -35,8 +35,6 @@ from neural_compressor.common.utils import (
     LOCAL,
     OP_NAME_OR_MODULE_TYPE,
 )
-
-logger = Logger().get_logger()
 
 __all__ = [
     "ConfigRegistry",

--- a/neural_compressor/common/base_tuning.py
+++ b/neural_compressor/common/base_tuning.py
@@ -18,10 +18,8 @@ import inspect
 import uuid
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig
-
-logger = Logger().get_logger()
 
 __all__ = [
     "Evaluator",

--- a/neural_compressor/common/utils/__init__.py
+++ b/neural_compressor/common/utils/__init__.py
@@ -14,5 +14,4 @@
 
 from neural_compressor.common.utils.constants import *
 from neural_compressor.common.utils.utility import *
-from neural_compressor.common.utils.logger import Logger
-from neural_compressor.common.utils.logger import logger, debug, log, info, warning, error, fatal
+from neural_compressor.common.utils.logger import *

--- a/neural_compressor/common/utils/__init__.py
+++ b/neural_compressor/common/utils/__init__.py
@@ -14,4 +14,5 @@
 
 from neural_compressor.common.utils.constants import *
 from neural_compressor.common.utils.utility import *
-from neural_compressor.common.utils.logger import *
+from neural_compressor.common.utils.logger import Logger
+from neural_compressor.common.utils.logger import logger, debug, log, info, warning, error, fatal

--- a/neural_compressor/common/utils/logger.py
+++ b/neural_compressor/common/utils/logger.py
@@ -19,6 +19,11 @@
 import logging
 import os
 
+__all__ = [
+    "level",
+    "logger",
+]
+
 
 class Logger(object):
     """Logger class."""
@@ -70,65 +75,4 @@ def _pretty_dict(value, indent=0):
 level = Logger().get_logger().level
 DEBUG = logging.DEBUG
 
-
-def log(level, msg, *args, **kwargs):
-    """Output log with the level as a parameter."""
-    if isinstance(msg, dict):
-        for _, line in enumerate(_pretty_dict(msg).split("\n")):
-            Logger().get_logger().log(level, line, *args, **kwargs)
-    else:
-        Logger().get_logger().log(level, msg, *args, **kwargs)
-
-
-def debug(msg, *args, **kwargs):
-    """Output log with the debug level."""
-    if isinstance(msg, dict):
-        for _, line in enumerate(_pretty_dict(msg).split("\n")):
-            Logger().get_logger().debug(line, *args, **kwargs)
-    else:
-        Logger().get_logger().debug(msg, *args, **kwargs)
-
-
-def error(msg, *args, **kwargs):
-    """Output log with the error level."""
-    if isinstance(msg, dict):
-        for _, line in enumerate(_pretty_dict(msg).split("\n")):
-            Logger().get_logger().error(line, *args, **kwargs)
-    else:
-        Logger().get_logger().error(msg, *args, **kwargs)
-
-
-def fatal(msg, *args, **kwargs):
-    """Output log with the fatal level."""
-    if isinstance(msg, dict):
-        for _, line in enumerate(_pretty_dict(msg).split("\n")):
-            Logger().get_logger().fatal(line, *args, **kwargs)
-    else:
-        Logger().get_logger().fatal(msg, *args, **kwargs)
-
-
-def info(msg, *args, **kwargs):
-    """Output log with the info level."""
-    if isinstance(msg, dict):
-        for _, line in enumerate(_pretty_dict(msg).split("\n")):
-            Logger().get_logger().info(line, *args, **kwargs)
-    else:
-        Logger().get_logger().info(msg, *args, **kwargs)
-
-
-def warn(msg, *args, **kwargs):
-    """Output log with the warning level."""
-    if isinstance(msg, dict):
-        for _, line in enumerate(_pretty_dict(msg).split("\n")):
-            Logger().get_logger().warning(line, *args, **kwargs)
-    else:
-        Logger().get_logger().warning(msg, *args, **kwargs)
-
-
-def warning(msg, *args, **kwargs):
-    """Output log with the warning level (Alias of the method warn)."""
-    if isinstance(msg, dict):
-        for _, line in enumerate(_pretty_dict(msg).split("\n")):
-            Logger().get_logger().warning(line, *args, **kwargs)
-    else:
-        Logger().get_logger().warning(msg, *args, **kwargs)
+logger = Logger().get_logger()

--- a/neural_compressor/common/utils/logger.py
+++ b/neural_compressor/common/utils/logger.py
@@ -22,6 +22,16 @@ import os
 __all__ = [
     "level",
     "logger",
+    "debug",
+    "log",
+    "info",
+    "log",
+    "info",
+    "debug",
+    "warning",
+    "error",
+    "fatal",
+    "Logger",
     "Logger",
 ]
 
@@ -73,7 +83,60 @@ def _pretty_dict(value, indent=0):
         return repr(value)
 
 
+def log(level, msg, *args, **kwargs):
+    """Output log with the level as a parameter."""
+    if isinstance(msg, dict):
+        for _, line in enumerate(_pretty_dict(msg).split("\n")):
+            Logger().get_logger().log(level, line, *args, **kwargs, stacklevel=2)
+    else:
+        Logger().get_logger().log(level, msg, *args, **kwargs, stacklevel=2)
+
+
+def debug(msg, *args, **kwargs):
+    """Output log with the debug level."""
+    if isinstance(msg, dict):
+        for _, line in enumerate(_pretty_dict(msg).split("\n")):
+            Logger().get_logger().debug(line, *args, **kwargs, stacklevel=2)
+    else:
+        Logger().get_logger().debug(msg, *args, **kwargs, stacklevel=2)
+
+
+def error(msg, *args, **kwargs):
+    """Output log with the error level."""
+    if isinstance(msg, dict):
+        for _, line in enumerate(_pretty_dict(msg).split("\n")):
+            Logger().get_logger().error(line, *args, **kwargs, stacklevel=2)
+    else:
+        Logger().get_logger().error(msg, *args, **kwargs, stacklevel=2)
+
+
+def fatal(msg, *args, **kwargs):
+    """Output log with the fatal level."""
+    if isinstance(msg, dict):
+        for _, line in enumerate(_pretty_dict(msg).split("\n")):
+            Logger().get_logger().fatal(line, *args, **kwargs, stacklevel=2)
+    else:
+        Logger().get_logger().fatal(msg, *args, **kwargs, stacklevel=2)
+
+
+def info(msg, *args, **kwargs):
+    """Output log with the info level."""
+    if isinstance(msg, dict):
+        for _, line in enumerate(_pretty_dict(msg).split("\n")):
+            Logger().get_logger().info(line, *args, **kwargs, stacklevel=2)
+    else:
+        Logger().get_logger().info(msg, *args, **kwargs, stacklevel=2)
+
+
+def warning(msg, *args, **kwargs):
+    """Output log with the warning level (Alias of the method warn)."""
+    if isinstance(msg, dict):
+        for _, line in enumerate(_pretty_dict(msg).split("\n")):
+            Logger().get_logger().warning(line, *args, **kwargs, stacklevel=2)
+    else:
+        Logger().get_logger().warning(msg, *args, **kwargs, stacklevel=2)
+
+
 level = Logger().get_logger().level
-DEBUG = logging.DEBUG
 
 logger = Logger().get_logger()

--- a/neural_compressor/common/utils/logger.py
+++ b/neural_compressor/common/utils/logger.py
@@ -22,6 +22,7 @@ import os
 __all__ = [
     "level",
     "logger",
+    "Logger",
 ]
 
 

--- a/neural_compressor/common/utils/logger.py
+++ b/neural_compressor/common/utils/logger.py
@@ -20,18 +20,14 @@ import logging
 import os
 
 __all__ = [
-    "level",
-    "logger",
     "debug",
-    "log",
-    "info",
-    "log",
-    "info",
-    "debug",
-    "warning",
     "error",
     "fatal",
-    "Logger",
+    "info",
+    "level",
+    "logger",
+    "log",
+    "warning",
     "Logger",
 ]
 

--- a/neural_compressor/onnxrt/algorithms/weight_only/algo_entry.py
+++ b/neural_compressor/onnxrt/algorithms/weight_only/algo_entry.py
@@ -18,12 +18,10 @@ from typing import Dict, Tuple, Union
 
 import onnx
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.utils import RTN
 from neural_compressor.onnxrt.quantization.config import RTNConfig
 from neural_compressor.onnxrt.utils.utility import register_algo
-
-logger = Logger().get_logger()
 
 
 ###################### RTN Algo Entry ##################################

--- a/neural_compressor/onnxrt/quantization/config.py
+++ b/neural_compressor/onnxrt/quantization/config.py
@@ -23,11 +23,9 @@ from typing import Callable, List, NamedTuple, Optional, Tuple, Union
 
 import onnx
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.base_config import BaseConfig, register_config
 from neural_compressor.common.utils import DEFAULT_WHITE_LIST, OP_NAME_OR_MODULE_TYPE, RTN
-
-logger = Logger().get_logger()
 
 FRAMEWORK_NAME = "onnxrt"
 

--- a/neural_compressor/onnxrt/quantization/quantize.py
+++ b/neural_compressor/onnxrt/quantization/quantize.py
@@ -18,12 +18,10 @@ from typing import Optional, Tuple
 import onnx
 from onnxruntime.quantization import CalibrationDataReader
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig, config_registry
 from neural_compressor.onnxrt.quantization.config import FRAMEWORK_NAME
 from neural_compressor.onnxrt.utils.utility import algos_mapping
-
-logger = Logger().get_logger()
 
 
 def need_apply(quant_config: BaseConfig, algo_name):

--- a/neural_compressor/onnxrt/utils/onnx_model.py
+++ b/neural_compressor/onnxrt/utils/onnx_model.py
@@ -22,10 +22,8 @@ from pathlib import Path
 
 import onnx
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.onnxrt.utils.utility import MAXIMUM_PROTOBUF, find_by_name
-
-logger = Logger().get_logger()
 
 
 class ONNXModel:

--- a/neural_compressor/onnxrt/utils/utility.py
+++ b/neural_compressor/onnxrt/utils/utility.py
@@ -18,9 +18,7 @@ from typing import Callable, Dict, List, Tuple, Union
 import onnx
 from packaging.version import Version
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 ONNXRT116_VERSION = Version("1.16.0")
 ONNXRT1161_VERSION = Version("1.16.1")

--- a/neural_compressor/tensorflow/algorithms/static_quantize/keras.py
+++ b/neural_compressor/tensorflow/algorithms/static_quantize/keras.py
@@ -26,10 +26,8 @@ import numpy as np
 import tensorflow as tf
 import yaml
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.tensorflow.utils import deep_get, dump_elapsed_time
-
-logger = Logger().get_logger()
 
 
 def _add_supported_quantized_objects(custom_objects):

--- a/neural_compressor/tensorflow/quantization/quantize.py
+++ b/neural_compressor/tensorflow/quantization/quantize.py
@@ -16,13 +16,11 @@ from typing import Any, Callable
 
 import tensorflow as tf
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.base_config import BaseConfig
 from neural_compressor.common.utils import STATIC_QUANT
 from neural_compressor.tensorflow.quantization.config import parse_config_from_dict
 from neural_compressor.tensorflow.utils import algos_mapping
-
-logger = Logger().get_logger()
 
 
 def quantize_model(

--- a/neural_compressor/torch/algorithms/weight_only_algos.py
+++ b/neural_compressor/torch/algorithms/weight_only_algos.py
@@ -17,12 +17,10 @@ from typing import Dict, Tuple
 
 import torch
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.utils import GPTQ, RTN
 from neural_compressor.torch.quantization.config import GPTQConfig, RTNConfig
 from neural_compressor.torch.utils.utility import fetch_module, register_algo, set_module
-
-logger = Logger().get_logger()
 
 
 ###################### RTN Algo Entry ##################################

--- a/neural_compressor/torch/quantization/autotune.py
+++ b/neural_compressor/torch/quantization/autotune.py
@@ -17,14 +17,11 @@ from typing import Dict, List, Optional, Union
 
 import torch
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.base_config import BaseConfig, get_all_config_set_from_config_registry
 from neural_compressor.common.base_tuning import TuningConfig, evaluator, init_tuning
 from neural_compressor.torch import quantize
 from neural_compressor.torch.quantization.config import FRAMEWORK_NAME
-
-logger = Logger().get_logger()
-
 
 __all__ = [
     "autotune",

--- a/neural_compressor/torch/quantization/layers.py
+++ b/neural_compressor/torch/quantization/layers.py
@@ -25,7 +25,7 @@ from packaging.version import Version
 from torch.autograd import Function
 from torch.nn import functional as F
 
-from neural_compressor.common import DEBUG, level, logger
+from neural_compressor.common import logger
 from neural_compressor.torch.algorithms.weight_only import quant_tensor
 
 

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -17,12 +17,10 @@ from typing import Any, Callable, Dict, Tuple
 
 import torch
 
-from neural_compressor.common import Logger
+from neural_compressor.common import logger
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig, config_registry
 from neural_compressor.torch.quantization.config import FRAMEWORK_NAME
 from neural_compressor.torch.utils.utility import WHITE_MODULE_LIST, algos_mapping, get_model_info
-
-logger = Logger().get_logger()
 
 
 def need_apply(configs_mapping: Dict[Tuple[str, callable], BaseConfig], algo_name):

--- a/neural_compressor/torch/utils/utility.py
+++ b/neural_compressor/torch/utils/utility.py
@@ -15,9 +15,7 @@
 
 from typing import Callable, Dict, List, Tuple
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 # Dictionary to store a mapping between algorithm names and corresponding algo implementation(function)
 algos_mapping: Dict[str, Callable] = {}

--- a/test/3x/onnxrt/quantization/weight_only/test_rtn.py
+++ b/test/3x/onnxrt/quantization/weight_only/test_rtn.py
@@ -4,9 +4,7 @@ import unittest
 
 from optimum.exporters.onnx import main_export
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 
 def find_onnx_file(folder_path):

--- a/test/3x/onnxrt/test_config.py
+++ b/test/3x/onnxrt/test_config.py
@@ -7,9 +7,7 @@ import numpy as np
 import onnx
 from optimum.exporters.onnx import main_export
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 
 def find_onnx_file(folder_path):

--- a/test/3x/tensorflow/test_config.py
+++ b/test/3x/tensorflow/test_config.py
@@ -25,9 +25,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow import keras
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 
 def build_model():

--- a/test/3x/torch/quantization/weight_only/test_gptq_algo.py
+++ b/test/3x/torch/quantization/weight_only/test_gptq_algo.py
@@ -3,9 +3,7 @@ import unittest
 
 import torch
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 
 def get_gpt_j():

--- a/test/3x/torch/quantization/weight_only/test_rtn.py
+++ b/test/3x/torch/quantization/weight_only/test_rtn.py
@@ -2,9 +2,7 @@ import unittest
 
 import torch
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 
 def get_gpt_j():

--- a/test/3x/torch/test_autotune.py
+++ b/test/3x/torch/test_autotune.py
@@ -1,13 +1,10 @@
 import unittest
-
-import transformers
-
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
 from functools import wraps
 
 import torch
+import transformers
+
+from neural_compressor.common import logger
 
 
 def reset_tuning_target(test_func):

--- a/test/3x/torch/test_config.py
+++ b/test/3x/torch/test_config.py
@@ -1,12 +1,10 @@
 import copy
 import unittest
 
+import torch
 import transformers
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
-import torch
+from neural_compressor.common import logger
 
 
 def build_simple_torch_model():

--- a/test/3x/torch/test_logger.py
+++ b/test/3x/torch/test_logger.py
@@ -1,7 +1,9 @@
 """Tests for logging utilities."""
 import unittest
 
-from neural_compressor.common import logger
+from neural_compressor.common import Logger, logger
+
+inc_logger = Logger().get_logger()  # `inc_logger` is the same as `logger`
 
 
 class TestLogger(unittest.TestCase):
@@ -16,8 +18,6 @@ class TestLogger(unittest.TestCase):
         logger.fatal({"msg": "call logger fatal function"})
         logger.info("call logger info function")
         logger.info({"msg": "call logger info function."})
-        logger.warn("call logger warn function")
-        logger.warn({"msg": "call logger warn function"})
         logger.warning("call logger warning function")
         logger.warning({"msg": "call logger warning function"})
         logger.warning(["call logger warning function", "done"])
@@ -28,6 +28,12 @@ class TestLogger(unittest.TestCase):
         logger.warning([{"msg": "call logger warning function"}, {"msg2": "done"}])
         logger.warning(({"msg": "call logger warning function"}, {"msg2": "done"}))
         logger.warning(({"msg": [{"sub_msg": "call logger"}, {"sub_msg2": "call warning function"}]}, {"msg2": "done"}))
+
+    def test_in_logger(self):
+        inc_logger.log(0, "call logger log function.")
+        inc_logger.log(1, {"msg": "call logger log function."})
+        inc_logger.debug("call logger debug function.")
+        inc_logger.debug({"msg": "call logger debug function."})
 
 
 if __name__ == "__main__":

--- a/test/3x/torch/test_logger.py
+++ b/test/3x/torch/test_logger.py
@@ -9,9 +9,11 @@ msg_lst = [
     "call logger log function.",
     {"msg": "call logger warning function"},
     ["call logger warning function", "done"],
+    ({"msg": "call logger warning function"}, {"msg2": "done"}),
     {"msg": {("bert", "embedding"): {"weight": {"dtype": ["unint8", "int8"]}}}},
     {"msg": [{"sub_msg": "call logger"}, {"sub_msg2": "call warning function"}]},
     {"msg2": "done"},
+    {("bert", "embedding"): {"op": ("a", "b")}},
 ]
 
 

--- a/test/3x/torch/test_logger.py
+++ b/test/3x/torch/test_logger.py
@@ -45,12 +45,15 @@ class TestLogger(unittest.TestCase):
         inc_logger.debug({"msg": "call logger debug function."})
 
     def test_logger_func(self):
-        from neural_compressor.common.utils import debug, info, log
+        from neural_compressor.common import debug, error, fatal, info, level, log, warning
 
         for msg in msg_lst:
-            debug(msg)
             log(level=1, msg=msg)
-            info(msg)
+            info(msg=msg)
+            debug(msg=msg)
+            warning(msg=msg)
+            error(msg=msg)
+            fatal(msg=msg)
 
 
 if __name__ == "__main__":

--- a/test/3x/torch/test_logger.py
+++ b/test/3x/torch/test_logger.py
@@ -5,6 +5,15 @@ from neural_compressor.common import Logger, logger
 
 inc_logger = Logger().get_logger()  # `inc_logger` is the same as `logger`
 
+msg_lst = [
+    "call logger log function.",
+    {"msg": "call logger warning function"},
+    ["call logger warning function", "done"],
+    {"msg": {("bert", "embedding"): {"weight": {"dtype": ["unint8", "int8"]}}}},
+    {"msg": [{"sub_msg": "call logger"}, {"sub_msg2": "call warning function"}]},
+    {"msg2": "done"},
+]
+
 
 class TestLogger(unittest.TestCase):
     def test_logger(self):
@@ -34,6 +43,14 @@ class TestLogger(unittest.TestCase):
         inc_logger.log(1, {"msg": "call logger log function."})
         inc_logger.debug("call logger debug function.")
         inc_logger.debug({"msg": "call logger debug function."})
+
+    def test_logger_func(self):
+        from neural_compressor.common.utils import debug, info, log
+
+        for msg in msg_lst:
+            debug(msg)
+            log(level=1, msg=msg)
+            info(msg)
 
 
 if __name__ == "__main__":

--- a/test/3x/torch/test_utils.py
+++ b/test/3x/torch/test_utils.py
@@ -2,9 +2,7 @@ import unittest
 
 import torch
 
-from neural_compressor.common import Logger
-
-logger = Logger().get_logger()
+from neural_compressor.common import logger
 
 
 def get_gpt_j():


### PR DESCRIPTION
## Type of Change

API changed or not:  None

## Description

```python
# Recommend usage
from neural_compressor.common import logger
logger.info("Log info: %s", log_str)

from neural_compressor.common import Logger
from neural_compressor.common.utils import Logger
logger = Logger().get_logger()
logger.info("Log info: %s", log_str)
```

## How has this PR been tested?
Pre-CI

## Dependency Change?
None
