### PR TITLE
Support double quant tuning

### DIFF
--- a/neural_compressor/common/base_tuning.py
+++ b/neural_compressor/common/base_tuning.py
@@ -317,12 +317,22 @@ class TuningMonitor:
         # TODO: Support more stop criteria in the next PR, such as `timeout`, and so on.
         # reach max trials
         reach_max_trials = self.trial_cnt >= self.tuning_config.max_trials
+        if reach_max_trials:
+            logger.info(
+                "Current trial count is %d, reached max trials(%s).", self.trial_cnt, self.tuning_config.max_trials
+            )
         # reach accuracy goal
         meet_accuracy_goal = (
             False
             if self.baseline is None
             else self.tuning_history[-1].trial_result >= (self.baseline * (1 - self.tuning_config.tolerable_loss))
         )
+        if meet_accuracy_goal:
+            logger.info(
+                "Current trial result is %s, reached accuracy goal(%s).",
+                self.tuning_history[-1].trial_result,
+                self.baseline * (1 - self.tuning_config.tolerable_loss),
+            )
         # [-1] is the last element representing the latest trail record.
         return reach_max_trials or meet_accuracy_goal
 

--- a/neural_compressor/common/base_tuning.py
+++ b/neural_compressor/common/base_tuning.py
@@ -317,22 +317,12 @@ class TuningMonitor:
         # TODO: Support more stop criteria in the next PR, such as `timeout`, and so on.
         # reach max trials
         reach_max_trials = self.trial_cnt >= self.tuning_config.max_trials
-        if reach_max_trials:
-            logger.info(
-                "Current trial count is %d, reached max trials(%s).", self.trial_cnt, self.tuning_config.max_trials
-            )
         # reach accuracy goal
         meet_accuracy_goal = (
             False
             if self.baseline is None
             else self.tuning_history[-1].trial_result >= (self.baseline * (1 - self.tuning_config.tolerable_loss))
         )
-        if meet_accuracy_goal:
-            logger.info(
-                "Current trial result is %s, reached accuracy goal(%s).",
-                self.tuning_history[-1].trial_result,
-                self.baseline * (1 - self.tuning_config.tolerable_loss),
-            )
         # [-1] is the last element representing the latest trail record.
         return reach_max_trials or meet_accuracy_goal
 

--- a/neural_compressor/torch/quantization/__init__.py
+++ b/neural_compressor/torch/quantization/__init__.py
@@ -26,7 +26,12 @@ from neural_compressor.torch.quantization.config import (
 )
 
 # TODO(Yi): move config to config.py
-from neural_compressor.torch.quantization.autotune import autotune, TuningConfig, get_all_config_set
+from neural_compressor.torch.quantization.autotune import (
+    autotune,
+    TuningConfig,
+    get_all_config_set,
+    get_rtn_double_quant_config_set,
+)
 
 ### Quantization Function Registration ###
 import neural_compressor.torch.quantization.algorithm_entry

--- a/neural_compressor/torch/quantization/autotune.py
+++ b/neural_compressor/torch/quantization/autotune.py
@@ -17,17 +17,25 @@ from typing import Dict, List, Optional, Union
 
 import torch
 
-from neural_compressor.common import Logger
 from neural_compressor.common.base_config import BaseConfig, get_all_config_set_from_config_registry
 from neural_compressor.common.base_tuning import TuningConfig, evaluator, init_tuning
 from neural_compressor.torch.quantization import quantize
-from neural_compressor.torch.quantization.config import FRAMEWORK_NAME
+from neural_compressor.torch.quantization.config import FRAMEWORK_NAME, RTNConfig
 from neural_compressor.torch.utils import logger
+from neural_compressor.torch.utils.constants import DOUBLE_QUANT_CONFIGS
 
 __all__ = [
     "autotune",
     "get_all_config_set",
+    "get_rtn_double_quant_config_set",
 ]
+
+
+def get_rtn_double_quant_config_set() -> List[RTNConfig]:
+    rtn_double_quant_config_set = []
+    for double_quant_type, double_quant_config in DOUBLE_QUANT_CONFIGS.items():
+        rtn_double_quant_config_set.append(RTNConfig.from_dict(double_quant_config))
+    return rtn_double_quant_config_set
 
 
 def get_all_config_set() -> Union[BaseConfig, List[BaseConfig]]:
@@ -52,7 +60,7 @@ def autotune(
     for trial_index, quant_config in enumerate(config_loader):
         tuning_logger.trial_start(trial_index=trial_index)
         tuning_logger.quantization_start()
-        logger.info(f"quant config: {quant_config}")
+        logger.info(quant_config.to_dict())
         # !!! Make sure to use deepcopy only when inplace is set to `True`.
         q_model = quantize(deepcopy(model), quant_config=quant_config, run_fn=run_fn, run_args=run_args, inplace=True)
         tuning_logger.quantization_end()
@@ -62,6 +70,7 @@ def autotune(
         tuning_monitor.add_trial_result(trial_index, eval_result, quant_config)
         tuning_logger.trial_end(trial_index)
         if tuning_monitor.need_stop():
+            logger.info("Stopped tuning.")
             best_quant_config: BaseConfig = tuning_monitor.get_best_quant_config()
             # !!! Make sure to use deepcopy only when inplace is set to `True`.
             quantize(deepcopy(model), quant_config=best_quant_config, run_fn=run_fn, run_args=run_args, inplace=True)

--- a/neural_compressor/torch/quantization/autotune.py
+++ b/neural_compressor/torch/quantization/autotune.py
@@ -21,8 +21,7 @@ from neural_compressor.common.base_config import BaseConfig, get_all_config_set_
 from neural_compressor.common.base_tuning import TuningConfig, evaluator, init_tuning
 from neural_compressor.torch.quantization import quantize
 from neural_compressor.torch.quantization.config import FRAMEWORK_NAME, RTNConfig
-from neural_compressor.torch.utils import logger
-from neural_compressor.torch.utils.constants import DOUBLE_QUANT_CONFIGS
+from neural_compressor.torch.utils import constants, logger
 
 __all__ = [
     "autotune",
@@ -33,7 +32,7 @@ __all__ = [
 
 def get_rtn_double_quant_config_set() -> List[RTNConfig]:
     rtn_double_quant_config_set = []
-    for double_quant_type, double_quant_config in DOUBLE_QUANT_CONFIGS.items():
+    for double_quant_type, double_quant_config in constants.DOUBLE_QUANT_CONFIGS.items():
         rtn_double_quant_config_set.append(RTNConfig.from_dict(double_quant_config))
     return rtn_double_quant_config_set
 

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -55,7 +55,8 @@ def quantize(
         assert isinstance(
             quant_config, BaseConfig
         ), f"Please pass a dict or config instance as the quantization configuration, but got {type(quant_config)}."
-    logger.info(f"Quantize model with config: \n {quant_config.to_json_string()} \n")
+    logger.info("Quantize model with config:")
+    logger.info(quant_config.to_dict())
     # select quantization algo according to config
 
     model_info = quant_config.get_model_info(model=q_model)

--- a/test/3x/torch/test_autotune.py
+++ b/test/3x/torch/test_autotune.py
@@ -239,6 +239,42 @@ class TestAutoTune(unittest.TestCase):
         best_model = autotune(model=build_simple_torch_model(), tune_config=custom_tune_config, eval_fns=eval_acc_fn)
         self.assertIsNone(best_model)
 
+    @reset_tuning_target
+    def test_rtn_double_quant_config_set(self) -> None:
+        from neural_compressor.torch.quantization import TuningConfig, autotune, get_rtn_double_quant_config_set
+        from neural_compressor.torch.utils.constants import DOUBLE_QUANT_CONFIGS
+
+        rtn_double_quant_config_set = get_rtn_double_quant_config_set()
+        self.assertEqual(len(rtn_double_quant_config_set), len(DOUBLE_QUANT_CONFIGS))
+
+        def eval_acc_fn(model) -> float:
+            return 1.0
+
+        custom_tune_config = TuningConfig(config_set=get_rtn_double_quant_config_set(), max_trials=10)
+        best_model = autotune(
+            model=build_simple_torch_model(), tune_config=custom_tune_config, eval_fns=[{"eval_fn": eval_acc_fn}]
+        )
+        self.assertIsNotNone(best_model)
+
+    @reset_tuning_target
+    def test_rtn_double_quant_config_set2(self) -> None:
+        from neural_compressor.torch.quantization import TuningConfig, autotune, get_rtn_double_quant_config_set
+        from neural_compressor.torch.utils.constants import DOUBLE_QUANT_CONFIGS
+
+        rtn_double_quant_config_set = get_rtn_double_quant_config_set()
+        self.assertEqual(len(rtn_double_quant_config_set), len(DOUBLE_QUANT_CONFIGS))
+
+        def eval_acc_fn(model) -> float:
+            return 1.0
+
+        custom_tune_config = TuningConfig(
+            config_set=get_rtn_double_quant_config_set(), max_trials=10, tolerable_loss=-1
+        )
+        best_model = autotune(
+            model=build_simple_torch_model(), tune_config=custom_tune_config, eval_fns=[{"eval_fn": eval_acc_fn}]
+        )
+        self.assertIsNone(best_model)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Type of Change

feature
API changed or not: add API to get the default set

## Description

```python
from neural_compressor.torch.quantization import TuningConfig, autotune, get_rtn_double_quant_config_set
def eval_acc_fn(model) -> float:
    ...

custom_tune_config = TuningConfig(config_set=get_rtn_double_quant_config_set())
q_model = autotune(model=build_simple_torch_model(), tune_config=custom_tune_config, eval_fns=eval_acc_fn)


```


## How has this PR been tested?

Pre-CI

## Dependency Change?
None
