### PR TITLE
Support auto device for TEQ and AWQ  

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/awq.py
+++ b/neural_compressor/torch/algorithms/weight_only/awq.py
@@ -33,6 +33,8 @@ from .utility import (
     set_module,
 )
 
+__all__ = ["awq_quantize"]
+
 
 def _get_absorb_per_block(model, example_inputs, folding=False, weight_config={}):
     """Get absorbed layer per block.

--- a/neural_compressor/torch/algorithms/weight_only/teq.py
+++ b/neural_compressor/torch/algorithms/weight_only/teq.py
@@ -24,6 +24,8 @@ from neural_compressor.torch.utils import get_device, logger
 from .modules import MulLinear, TEQLinearFakeQuant
 from .utility import get_module, quant_tensor, set_module
 
+__all__ = ["teq_quantize", "TEQuantizer"]
+
 
 class TEQuantizer:
     """Weight-only quantization, Trainable Equivalent Transformation (TEQ): linear wrapper to apply scale to input."""

--- a/neural_compressor/torch/utils/auto_accelerator.py
+++ b/neural_compressor/torch/utils/auto_accelerator.py
@@ -19,7 +19,6 @@
 
 # NOTICE: The design adapted from:
 # https://github.com/microsoft/DeepSpeed/blob/master/accelerator/abstract_accelerator.py.
-# TODO: move it into torch/utils
 
 
 # To keep it simply, only add the APIs we need.
@@ -204,9 +203,12 @@ class CUDA_Accelerator(Auto_Accelerator):
 
 
 def auto_detect_accelerator(device_name="auto") -> Auto_Accelerator:
+    # Force use the cpu on node has both cpu and gpu: `FORCE_DEVICE=cpu` python main.py ...
     # The environment variable `FORCE_DEVICE` has higher priority than the `device_name`.
     # TODO: refine the docs and logic later
     FORCE_DEVICE = os.environ.get("FORCE_DEVICE", None)
+    if FORCE_DEVICE:
+        FORCE_DEVICE = FORCE_DEVICE.lower()
     if FORCE_DEVICE and accelerator_registry.get_accelerator_cls_by_name(FORCE_DEVICE) is not None:
         logger.warning("Force use %s accelerator.", FORCE_DEVICE)
         return accelerator_registry.get_accelerator_cls_by_name(FORCE_DEVICE)()

--- a/neural_compressor/torch/utils/auto_accelerator.py
+++ b/neural_compressor/torch/utils/auto_accelerator.py
@@ -204,14 +204,18 @@ class CUDA_Accelerator(Auto_Accelerator):
 
 def auto_detect_accelerator(device_name="auto") -> Auto_Accelerator:
     # Force use the cpu on node has both cpu and gpu: `FORCE_DEVICE=cpu` python main.py ...
+    # The `FORCE_DEVICE` is case insensitive.
     # The environment variable `FORCE_DEVICE` has higher priority than the `device_name`.
     # TODO: refine the docs and logic later
+    # 1. Get the device setting from environment variable `FORCE_DEVICE`.
     FORCE_DEVICE = os.environ.get("FORCE_DEVICE", None)
     if FORCE_DEVICE:
         FORCE_DEVICE = FORCE_DEVICE.lower()
+    # 2. If the `FORCE_DEVICE` is set and the accelerator is available, use it.
     if FORCE_DEVICE and accelerator_registry.get_accelerator_cls_by_name(FORCE_DEVICE) is not None:
         logger.warning("Force use %s accelerator.", FORCE_DEVICE)
         return accelerator_registry.get_accelerator_cls_by_name(FORCE_DEVICE)()
+    # 3. If the `device_name` is set and the accelerator is available, use it.
     if device_name != "auto":
         if accelerator_registry.get_accelerator_cls_by_name(device_name) is not None:
             accelerator_cls = accelerator_registry.get_accelerator_cls_by_name(device_name)
@@ -219,6 +223,7 @@ def auto_detect_accelerator(device_name="auto") -> Auto_Accelerator:
             return accelerator_cls()
         else:
             logger.warning("The device name %s is not supported, use auto detect instead.", device_name)
+    # 4. Select the accelerator by priority.
     for accelerator_cls in accelerator_registry.get_sorted_accelerators():
         if accelerator_cls.is_available():
             logger.warning("Auto detect accelerator: %s.", accelerator_cls.__name__)
@@ -228,5 +233,7 @@ def auto_detect_accelerator(device_name="auto") -> Auto_Accelerator:
 
 # Force use cpu accelerator even if cuda is available.
 # FORCE_DEVICE = "cpu" python ...
+# or
+# FORCE_DEVICE = "CPU" python ...
 # or
 # CUDA_VISIBLE_DEVICES="" python ...


### PR DESCRIPTION
## Type of Change

feature: Support auto device for TEQ and AWQ  
API changed or not: None

## Description

Follow-up to https://github.com/intel/neural-compressor/pull/1622.

```bash
pytest test_woq_on_cuda.py -k test_awq
pytest test_woq_on_cuda.py -k test_teq
```
## How has this PR been tested?

Pre-CI

## Dependency Change?
None