### PR TITLE
support hardware scale for gaudi2

### DIFF
--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/habana_fp8/run_llm.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/habana_fp8/run_llm.py
@@ -1,7 +1,8 @@
 import os
 os.environ["EXPERIMENTAL_WEIGHT_SHARING"] = "False"
 os.environ["USE_GAUDI2_SCALE"] = "True"
-os.environ.pop("USE_GAUDI2_SCALE")  # gaudi scale work
+# USE_GAUDI2_SCALE requires PT_USE_FP8_AMAX for torch.mm/bmm, or got failure
+os.environ["PT_USE_FP8_AMAX"] = "True"  
 # os.environ["GRAPH_VISUALIZATION"] = "True"
 # import shutil
 # shutil.rmtree(".graph_dumps", ignore_errors=True)
@@ -173,7 +174,7 @@ else:
         args.model,
         trust_remote_code=args.trust_remote_code
     )
-
+tokenizer.pad_token = tokenizer.eos_token
 
 user_model.eval()
 
@@ -219,6 +220,7 @@ if args.approach in ["dynamic", "static"] and not args.load:
 
         user_model = quantize(user_model, qconfig, calib_func, inplace=True)
         # saving
+        print(user_model)
         if args.save and local_rank in [-1, 0]:
             user_model.save("saved_results")
 

--- a/neural_compressor/torch/algorithms/habana_fp8/modules.py
+++ b/neural_compressor/torch/algorithms/habana_fp8/modules.py
@@ -55,7 +55,7 @@ class Autocast(nn.Module):
 
 ##################### FP8 modules #######################
 def _map_guadi2_scale(scale):
-    USE_GAUDI2_SCALE = os.environ.get("USE_GAUDI2_SCALE")
+    USE_GAUDI2_SCALE = bool(os.getenv("USE_GAUDI2_SCALE", False))
     if USE_GAUDI2_SCALE:
         scale_list = torch.tensor([16, 1, 1 / 16, 1 / 256])
         for i in scale_list:
@@ -135,6 +135,7 @@ class FP8DynamicLinear(torch.nn.Module):
         if inp.dtype not in [torch.float8_e4m3fn, torch.float8_e5m2]:
             if self.use_amax:
                 input_scale = self.dtype_amax / inp.abs().max()
+                input_scale = _map_guadi2_scale(input_scale)
                 input_scale_inv = torch.reciprocal(input_scale)
             else:
                 input_scale, input_scale_inv = None, None
@@ -183,6 +184,7 @@ class FP8DynamicMatmul(torch.nn.Module):
             self.out_dtype = input1.dtype
             if self.use_amax:
                 input1_scale = self.dtype_amax / input1.data.abs().max()
+                input1_scale = _map_guadi2_scale(input1_scale)
                 input1_scale_inv = torch.reciprocal(input1_scale)
             else:
                 input1_scale, input1_scale_inv = None, None
@@ -195,6 +197,7 @@ class FP8DynamicMatmul(torch.nn.Module):
             self.out_dtype = input2.dtype
             if self.use_amax:
                 input2_scale = self.dtype_amax / input2.data.abs().max()
+                input2_scale = _map_guadi2_scale(input2_scale)
                 input2_scale_inv = torch.reciprocal(input2_scale)
             else:
                 input2_scale, input2_scale_inv = None, None


### PR DESCRIPTION
## Type of Change

[feature] support hardware scale for gaudi2

## Description

I found the cause of hardware scale failure before, it's because that I'm using scale=None for torch.matmul/bmm. 
It seems that all scales should be set when using hardware scales.

## Expected Behavior & Potential Risk

UT pass

