### PR TITLE
Fix WOQ example accuracy gap between 2x and 3x

### DIFF
--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
@@ -328,7 +328,7 @@ if args.quantize:
                 )
             quant_config.set_local("lm_head", GPTQConfig(dtype="fp32"))
             user_model = quantize(
-                model=user_model, quant_config=quant_config, run_fn=run_fn_for_gptq, run_args=dataloader_for_calibration
+                model=user_model, quant_config=quant_config, run_fn=run_fn_for_gptq, run_args=(dataloader_for_calibration, )
             )
     else:
         # TODO: smooth quant


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Fixed gptq acc gap.
1. Because run.args must be a tuple.
2. 3x use mse search

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
