### PR TITLE
Fix comparison of module_type and MulLinear 

### DIFF
--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -220,7 +220,7 @@ def load_weight_only(checkpoint_dir, model, layer_wise=False):
     for op_name, config in weight_only_config.items():
         if config["dtype"] == "fp32":
             continue
-        if config["module_type"] == MulLinear.__module__:
+        if config["module_type"] == MulLinear.__module__ + "." + MulLinear.__name__:
             # op should be repleced by MulLinear
             module = util.fetch_module(model, op_name)
             new_module = MulLinear(module)

--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -210,7 +210,6 @@ def load_weight_only(checkpoint_dir, model, layer_wise=False):
     Returns:
         (object): quantized model
     """
-    import neural_compressor  # for eval(config['module_type'])
     from neural_compressor.adaptor.torch_utils.model_wrapper import MulLinear
 
     weights_file = os.path.join(os.path.abspath(os.path.expanduser(checkpoint_dir)), "best_model.pt")
@@ -221,7 +220,7 @@ def load_weight_only(checkpoint_dir, model, layer_wise=False):
     for op_name, config in weight_only_config.items():
         if config["dtype"] == "fp32":
             continue
-        if eval(config["module_type"]) == MulLinear:
+        if config["module_type"] == MulLinear.__module__:
             # op should be repleced by MulLinear
             module = util.fetch_module(model, op_name)
             new_module = MulLinear(module)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

falcon_7b_woq_gptq_int4 
```
if eval(config["module_type"]) == MulLinear:
File "<string>", line 1
transformers_modules.tiiuae.falcon-7b-instruct.cf4b3c42ce2fdfe24f753f0f0d179202fea59c99.modeling_falcon.FalconLinear
^
SyntaxError: invalid decimal literal
```
## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
