### PR TITLE
Fix export compressed model OOM

### DIFF
--- a/neural_compressor/adaptor/torch_utils/weight_only.py
+++ b/neural_compressor/adaptor/torch_utils/weight_only.py
@@ -128,7 +128,7 @@ def qdq_weight_asym(weight, num_bits=4, quantile=1.0, return_int=False):
     weight.add_(zp)
     weight.clamp_(0, maxq)
     if return_int:
-        return weight.type(torch.uint8), scale.type(torch.float), zp.type(torch.uint8)
+        return weight, scale.type(torch.float), zp.type(torch.uint8)
     weight.sub_(zp)
     return weight.mul_(scale)
 
@@ -176,7 +176,7 @@ def qdq_weight_sym(weight, num_bits=4, quantile=1.0, return_int=False, full_rang
     weight.round_()
     weight.clamp_(minq, maxq)
     if return_int:
-        return weight.type(torch.int8), scale.type(torch.float), None
+        return weight, scale.type(torch.float), None
     return weight.mul_(scale)
 
 

--- a/neural_compressor/adaptor/torch_utils/weight_only.py
+++ b/neural_compressor/adaptor/torch_utils/weight_only.py
@@ -93,7 +93,7 @@ def quantize_4bit(tensor, quantile=1.0, data_type="nf4", return_int=False):
             q_tensor += torch.where((mid_data[i - 1] < tensor) & (tensor <= mid_data[i]), data, 0)
     tensor.copy_(q_tensor)
     if return_int:
-        return tensor.type(torch.int8), scale.type(torch.float), None
+        return tensor, scale.type(torch.float), None
     return tensor.mul_(scale)
 
 

--- a/neural_compressor/adaptor/torch_utils/weight_only.py
+++ b/neural_compressor/adaptor/torch_utils/weight_only.py
@@ -93,7 +93,7 @@ def quantize_4bit(tensor, quantile=1.0, data_type="nf4", return_int=False):
             q_tensor += torch.where((mid_data[i - 1] < tensor) & (tensor <= mid_data[i]), data, 0)
     tensor.copy_(q_tensor)
     if return_int:
-        return tensor, scale.type(torch.float), None
+        return tensor, scale, None
     return tensor.mul_(scale)
 
 
@@ -128,7 +128,7 @@ def qdq_weight_asym(weight, num_bits=4, quantile=1.0, return_int=False):
     weight.add_(zp)
     weight.clamp_(0, maxq)
     if return_int:
-        return weight, scale.type(torch.float), zp.type(torch.uint8)
+        return weight, scale, zp
     weight.sub_(zp)
     return weight.mul_(scale)
 


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Fix OOM when export compressed model.
root cause: a) quantized weight `type` is not  an in-place operation. b)WeightOnlyLinear objects also occupy memory.
solution: a) return origin type


## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
