### PR TITLE
Fix model restore loading

### DIFF
--- a/neural_compressor/utils/pytorch.py
+++ b/neural_compressor/utils/pytorch.py
@@ -497,6 +497,7 @@ def recover_model_from_json(model, json_file_path, example_inputs):
         model = ipex.quantization.prepare(model, qconfig, example_inputs=example_inputs, inplace=True)
     model.load_qconf_summary(qconf_summary=json_file_path)
     model = ipex.quantization.convert(model, inplace=True)
+    model.eval()
     with torch.no_grad():
         try:
             if isinstance(example_inputs, dict):


### PR DESCRIPTION
## Type of Change

[[NLPTOOLKIU-1299] smoothquant qconfig restore error - IT JIRA (Supports IC/ITS Data) (intel.com)](https://jira.devtools.intel.com/browse/NLPTOOLKIU-1299)

bloom 1b7 and mistral 7b due to INC missing model.eval() and model.config.torchscript=True

dolly_v2 and gpt_neox failed by quant with position_ids but restore missing.

the itrex fixed PR: https://github.com/intel/intel-extension-for-transformers/pull/1406
detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
