### PR TITLE
set numpy < 2.0 for scikit-learn request

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 deprecated >= 1.2.13
-numpy
+numpy < 2.0
 opencv-python-headless
 pandas
 Pillow


### PR DESCRIPTION
## Type of Change

set "numpy < 2.0" for scikit-learn request "numpy >=1.19.5,<2.0"

## Description

https://pypi.org/project/numpy/2.0.0b1/ just released, pip can't resolve second level deps conflict. 
So if no this version limit, it will be failed when neural-compressor installed by ITREX. 

![image](https://github.com/intel/neural-compressor/assets/51692656/265ac75f-040e-4f0f-bb76-7f47a2044870)
