### PR TITLE
Fix  RTN supported layer checking condition

### DIFF
--- a/neural_compressor/adaptor/torch_utils/weight_only.py
+++ b/neural_compressor/adaptor/torch_utils/weight_only.py
@@ -398,7 +398,7 @@ def rtn_quantize(
         model: fake quantized torch module
     """
     assert isinstance(model, torch.nn.Module), "only support torch module"
-    supported_layers = [torch.nn.Linear]
+    supported_layers = (torch.nn.Linear, )
     if return_int:
         compression_dtype = kwargs.get("compression_dtype", torch.int32)
         compression_dim = kwargs.get("compression_dim", 1)
@@ -407,7 +407,7 @@ def rtn_quantize(
         use_optimum_format = kwargs.get("use_optimum_format", True)
     with torch.no_grad():
         for name, m in model.named_modules():
-            if not any(isinstance(m, layer) for layer in supported_layers):
+            if not isinstance(m, supported_layers):
                 continue
             orig_dtype = next(m.parameters()).dtype
             if orig_dtype != torch.float:

--- a/neural_compressor/adaptor/torch_utils/weight_only.py
+++ b/neural_compressor/adaptor/torch_utils/weight_only.py
@@ -398,7 +398,7 @@ def rtn_quantize(
         model: fake quantized torch module
     """
     assert isinstance(model, torch.nn.Module), "only support torch module"
-    supported_layers = ["Linear"]
+    supported_layers = [torch.nn.Linear]
     if return_int:
         compression_dtype = kwargs.get("compression_dtype", torch.int32)
         compression_dim = kwargs.get("compression_dim", 1)
@@ -407,7 +407,7 @@ def rtn_quantize(
         use_optimum_format = kwargs.get("use_optimum_format", True)
     with torch.no_grad():
         for name, m in model.named_modules():
-            if m.__class__.__name__ not in supported_layers:
+            if not any(isinstance(m, layer) for layer in supported_layers):
                 continue
             orig_dtype = next(m.parameters()).dtype
             if orig_dtype != torch.float:

--- a/neural_compressor/adaptor/torch_utils/weight_only.py
+++ b/neural_compressor/adaptor/torch_utils/weight_only.py
@@ -398,7 +398,7 @@ def rtn_quantize(
         model: fake quantized torch module
     """
     assert isinstance(model, torch.nn.Module), "only support torch module"
-    supported_layers = (torch.nn.Linear, )
+    supported_layers = (torch.nn.Linear,)
     if return_int:
         compression_dtype = kwargs.get("compression_dtype", torch.int32)
         compression_dim = kwargs.get("compression_dim", 1)


### PR DESCRIPTION
## Type of Change

bug fix

## Description
Issue: `FalconLinear` is not quantized.
root cause: falcon model 's linear is built-in by itself, not used torch.nn.linear, the issue depends on INC return model
solution: change supported layers name string to isinstance checking.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
