### PR TITLE
Add non-str `op_name` match workaround for IPEX

### DIFF
--- a/neural_compressor/common/base_config.py
+++ b/neural_compressor/common/base_config.py
@@ -414,7 +414,7 @@ class BaseConfig(ABC):
                 for op_name_pattern in op_name_config_dict:
                     if isinstance(op_name, str) and re.match(op_name_pattern, op_name):
                         config_mapping[(op_name, op_type)] = op_name_config_dict[op_name_pattern]
-                    elif op_name_pattern == op_name: # TODO: map ipex opname to stock pt op_name
+                    elif op_name_pattern == op_name:  # TODO: map ipex opname to stock pt op_name
                         config_mapping[(op_name, op_type)] = op_name_config_dict[op_name_pattern]
         return config_mapping
 

--- a/neural_compressor/common/base_config.py
+++ b/neural_compressor/common/base_config.py
@@ -412,7 +412,9 @@ class BaseConfig(ABC):
                 if op_type in op_type_config_dict:
                     config_mapping[(op_name, op_type)] = op_name_config_dict[op_type]
                 for op_name_pattern in op_name_config_dict:
-                    if re.match(op_name_pattern, op_name):
+                    if isinstance(op_name, str) and re.match(op_name_pattern, op_name):
+                        config_mapping[(op_name, op_type)] = op_name_config_dict[op_name_pattern]
+                    elif op_name_pattern == op_name:
                         config_mapping[(op_name, op_type)] = op_name_config_dict[op_name_pattern]
         return config_mapping
 

--- a/neural_compressor/common/base_config.py
+++ b/neural_compressor/common/base_config.py
@@ -414,7 +414,7 @@ class BaseConfig(ABC):
                 for op_name_pattern in op_name_config_dict:
                     if isinstance(op_name, str) and re.match(op_name_pattern, op_name):
                         config_mapping[(op_name, op_type)] = op_name_config_dict[op_name_pattern]
-                    elif op_name_pattern == op_name:
+                    elif op_name_pattern == op_name: # TODO: map ipex opname to stock pt op_name
                         config_mapping[(op_name, op_type)] = op_name_config_dict[op_name_pattern]
         return config_mapping
 


### PR DESCRIPTION
## Type of Change

bug fix

## Description

re.match expected string but got non-str type  when ipex fallback
```
-> if re.match(op_name_pattern, op_name):
(Pdb) op_name_pattern
'add'
(Pdb) op_name
((' ', 'q_op_infos', '0'),)
```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
