### PR TITLE
upgrade lm_eval to 0.4.2 following ITREX

### DIFF
--- a/.azure-pipelines/model-test-3x.yml
+++ b/.azure-pipelines/model-test-3x.yml
@@ -10,6 +10,7 @@ pr:
     include:
       - neural_compressor/common
       - neural_compressor/torch
+      - examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm
       - setup.py
       - requirements_pt.txt
       - .azure-pipelines/scripts/models

--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -64,6 +64,7 @@ subprojects:
     paths:
       - "neural_compressor/common/**"
       - "neural_compressor/torch/**"
+      - "examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/**"
       - "setup.py"
       - "requirements_pt.txt"
       - ".azure-pipelines/scripts/models/**"

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
@@ -8,6 +8,6 @@ pytest
 wandb
 einops
 neural-compressor
-git+https://github.com/intel/intel-extension-for-transformers.git@8f5febc10227231266aa8c55bc5aa2c982afb2f3
+intel-extension-for-transformers
 lm_eval==0.4.2
 peft

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
@@ -8,6 +8,6 @@ pytest
 wandb
 einops
 neural-compressor
-intel-extension-for-transformers
-lm-eval
+git+https://github.com/intel/intel-extension-for-transformers.git@8f5febc10227231266aa8c55bc5aa2c982afb2f3
+lm_eval==0.4.2
 peft

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
@@ -391,20 +391,14 @@ if args.accuracy:
     user_model.eval()
     from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate, LMEvalParser
     eval_args = LMEvalParser(
-        model="hf",
-        model_args='pretrained=' + args.model + ',tokenizer=' + args.model + ',dtype=float32',
+        model="hf", 
         user_model=user_model,
-        tokenizer = tokenizer,
+        tokenizer=tokenizer,
         batch_size=args.batch_size,
         tasks=args.tasks,
         device="cpu",
     )
     results = evaluate(eval_args)
-
-    dumped = json.dumps(results, indent=2)
-    if args.save_accuracy_path:
-        with open(args.save_accuracy_path, "w") as f:
-            f.write(dumped)
     for task_name in args.tasks.split(","):
         if task_name == "wikitext":
             acc = results["results"][task_name]["word_perplexity,none"]
@@ -415,16 +409,14 @@ if args.accuracy:
 
 if args.performance:
     user_model.eval()
-    from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate
+    from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate, LMEvalParser
     import time
 
     samples = args.iters * args.batch_size
-    from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate, LMEvalParser
     eval_args = LMEvalParser(
-        model="hf",
-        model_args='pretrained=' + args.model + ',tokenizer=' + args.model + ',dtype=float32',
+        model="hf", 
         user_model=user_model,
-        tokenizer = tokenizer,
+        tokenizer=tokenizer,
         batch_size=args.batch_size,
         tasks=args.tasks,
         limit=samples,

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
@@ -372,19 +372,22 @@ if args.quantize:
         )
         user_model.save(args.output_dir)
 
-if args.int8 or args.int8_bf16_mixed:
-    print("load int8 model")
 
-    from neural_compressor.torch.algorithms.static_quant import load
+# TODO: we need run_benchmark.sh for loading and remove --accuracy in run_quant.sh, currently run_quant.sh will get fp32 result
+# if args.int8 or args.int8_bf16_mixed:
+#     print("load int8 model")
 
-    if args.ipex:
-        user_model = load(os.path.abspath(os.path.expanduser(args.output_dir)))
-    else:
-        # TODO: WOQ save&load
-        print("Int8 model loading does not support WeightOnlyQuant now.")
-        pass
-else:
-    user_model, _ = get_user_model()
+#     # TODO: from neural_compressor.torch.quantization import load
+#     from neural_compressor.torch.algorithms.static_quant import load
+
+#     if args.ipex:
+#         user_model = load(os.path.abspath(os.path.expanduser(args.output_dir)))
+#     else:
+#         # TODO: WOQ save&load
+#         print("Int8 model loading does not support WeightOnlyQuant now.")
+#         pass
+# else:
+#     user_model, _ = get_user_model()
 
 
 if args.accuracy:

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
@@ -51,7 +51,7 @@ parser.add_argument("--pad_max_length", default=512, type=int,
 parser.add_argument("--calib_iters", default=512, type=int,
                     help="calibration iters.")
 parser.add_argument("--tasks", default="lambada_openai,hellaswag,winogrande,piqa,wikitext",
-                    type=str, help="tasks list for accuracy validation")
+                    type=str, help="tasks for accuracy validation")
 parser.add_argument("--peft_model_id", type=str, default=None, help="model_name_or_path of peft model")
 # ============SmoothQuant configs==============
 parser.add_argument("--sq", action="store_true")

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
 einops
-intel_extension_for_transformers
+git+https://github.com/intel/intel-extension-for-transformers.git@8f5febc10227231266aa8c55bc5aa2c982afb2f3
 optimum
 peft
 sentencepiece
@@ -10,4 +10,4 @@ torch
 tqdm
 tiktoken
 transformers_stream_generator
-git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
+lm_eval==0.4.2

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
 einops
-git+https://github.com/intel/intel-extension-for-transformers.git@8f5febc10227231266aa8c55bc5aa2c982afb2f3
+intel-extension-for-transformers
 optimum
 peft
 sentencepiece

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/run_clm_sparsegpt.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/pruning/eager/run_clm_sparsegpt.py
@@ -271,7 +271,7 @@ def parse_args():
     
     # Evaluation config
     parser.add_argument("--tasks", default="lambada_openai",
-        type=str, help="tasks list for accuracy validation",
+        type=str, help="tasks for accuracy validation",
     )
     parser.add_argument("--use_accelerate", action='store_true',
         help="Usually use to accelerate evaluation for large models"

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
@@ -9,5 +9,5 @@ pytest
 wandb
 einops
 neural-compressor
-intel-extension-for-transformers
-git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
+git+https://github.com/intel/intel-extension-for-transformers.git@8f5febc10227231266aa8c55bc5aa2c982afb2f3
+lm_eval==0.4.2

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/requirements.txt
@@ -9,5 +9,5 @@ pytest
 wandb
 einops
 neural-compressor
-git+https://github.com/intel/intel-extension-for-transformers.git@8f5febc10227231266aa8c55bc5aa2c982afb2f3
+intel-extension-for-transformers
 lm_eval==0.4.2

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
@@ -50,8 +50,7 @@ parser.add_argument("--pad_max_length", default=512, type=int,
                     help="Pad input ids to max length.")
 parser.add_argument("--calib_iters", default=512, type=int,
                     help="calibration iters.")
-parser.add_argument("--tasks", nargs='+', default=["lambada_openai",
-                                                   "hellaswag", "winogrande", "piqa", "wikitext"],
+parser.add_argument("--tasks", default="lambada_openai,hellaswag,winogrande,piqa,wikitext",
                     type=str, help="tasks list for accuracy validation, text-generation and code-generation tasks are different.")
 parser.add_argument("--peft_model_id", type=str, default=None, help="model_name_or_path of peft model")
 # ============SmoothQuant configs==============
@@ -351,9 +350,51 @@ else:
 if args.accuracy:
     user_model.eval()
     if args.code_generation:
-        from intel_extension_for_transformers.llm.evaluation.lm_code_eval import evaluate
+        from intel_extension_for_transformers.transformers.llm.evaluation.bigcode_eval import evaluate
         from transformers import AutoTokenizer
         tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=args.trust_remote_code)
+        results = evaluate(
+            model=user_model,
+            tokenizer=tokenizer,
+            tasks=args.tasks,
+            batch_size=args.batch_size,
+            args=args,
+        )
+        for task_name in args.tasks:
+            if task_name == "truthfulqa_mc":
+                acc = results["results"][task_name]["mc1"]
+            else:
+                acc = results["results"][task_name]["acc"]
+    else:
+        from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate, LMEvalParser
+        eval_args = LMEvalParser(
+            model="hf", 
+            user_model=user_model,
+            tokenizer=tokenizer,
+            batch_size=args.batch_size,
+            tasks=args.tasks,
+            device="cpu",
+        )
+        results = evaluate(eval_args)
+        for task_name in args.tasks.split(","):
+            if task_name == "wikitext":
+                acc = results["results"][task_name]["word_perplexity,none"]
+            else:
+                acc = results["results"][task_name]["acc,none"]
+
+    print("Accuracy: %.5f" % acc)
+    print('Batch size = %d' % args.batch_size)
+
+if args.performance:
+    import time
+    user_model.eval()
+    samples = args.iters * args.batch_size
+
+    if args.code_generation:
+        from intel_extension_for_transformers.transformers.llm.evaluation.bigcode_eval import evaluate
+        from transformers import AutoTokenizer
+        tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=args.trust_remote_code)
+        start = time.time()
         results = evaluate(
             model=user_model,
             tokenizer=tokenizer,
@@ -361,52 +402,30 @@ if args.accuracy:
             batch_size=args.batch_size,
             args=args,
         )
+        end = time.time()
+        for task_name in args.tasks:
+            if task_name == "truthfulqa_mc":
+                acc = results["results"][task_name]["mc1"]
+            else:
+                acc = results["results"][task_name]["acc"]
     else:
-        from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate
-        results = evaluate(
-            model="hf-causal",
-            model_args='pretrained=' + args.model + ',tokenizer=' + args.model + ',dtype=float32',
+        from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate, LMEvalParser
+        eval_args = LMEvalParser(
+            model="hf", 
             user_model=user_model,
+            tokenizer=tokenizer,
             batch_size=args.batch_size,
             tasks=args.tasks,
+            device="cpu",
         )
-
-    dumped = json.dumps(results, indent=2)
-    if args.save_accuracy_path:
-        with open(args.save_accuracy_path, "w") as f:
-            f.write(dumped)
-    for task_name in args.tasks:
-        if task_name == "wikitext":
-            acc = results["results"][task_name]["word_perplexity"]
-        else:
-            acc = results["results"][task_name]["acc"]
-    print("Accuracy: %.5f" % acc)
-    print('Batch size = %d' % args.batch_size)
-
-if args.performance:
-    user_model.eval()
-    from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate
-    import time
-
-    samples = args.iters * args.batch_size
-    start = time.time()
-    results = evaluate(
-        model="hf-causal",
-        model_args='pretrained=' + args.model + ',tokenizer=' + args.model \
-            + ',dtype=float32' + ",trust_remote_code=" + str(args.trust_remote_code),
-        user_model=user_model,
-        batch_size=args.batch_size,
-        tasks=args.tasks,
-        limit=samples,
-    )
-    end = time.time()
-    for task_name in args.tasks:
-        if task_name == "wikitext":
-            acc = results["results"][task_name]["word_perplexity"]
-        elif task_name == "truthfulqa_mc":
-            acc = results["results"][task_name]["mc1"]
-        else:
-            acc = results["results"][task_name]["acc"]
+        start = time.time()
+        results = evaluate(eval_args)
+        end = time.time()
+        for task_name in args.tasks.split(","):
+            if task_name == "wikitext":
+                acc = results["results"][task_name]["word_perplexity,none"]
+            else:
+                acc = results["results"][task_name]["acc,none"]
     print("Accuracy: %.5f" % acc)
     print('Throughput: %.3f samples/sec' % (samples / (end - start)))
     print('Latency: %.3f ms' % ((end - start) * 1000 / samples))

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm/run_clm_no_trainer.py
@@ -51,7 +51,7 @@ parser.add_argument("--pad_max_length", default=512, type=int,
 parser.add_argument("--calib_iters", default=512, type=int,
                     help="calibration iters.")
 parser.add_argument("--tasks", default="lambada_openai,hellaswag,winogrande,piqa,wikitext",
-                    type=str, help="tasks list for accuracy validation, text-generation and code-generation tasks are different.")
+                    type=str, help="tasks for accuracy validation, text-generation and code-generation tasks are different.")
 parser.add_argument("--peft_model_id", type=str, default=None, help="model_name_or_path of peft model")
 # ============SmoothQuant configs==============
 parser.add_argument("--sq", action="store_true")
@@ -398,7 +398,7 @@ if args.performance:
         results = evaluate(
             model=user_model,
             tokenizer=tokenizer,
-            tasks=",".join(args.tasks),
+            tasks=args.tasks,
             batch_size=args.batch_size,
             args=args,
         )


### PR DESCRIPTION
## Type of Change

upgrade following ITREX

## Description

ITREX is upgrading lm_eval version to 0.4.2 and INC examples using ITREX's evaluate need to be updated.
https://github.com/intel/intel-extension-for-transformers/pull/1462

## Expected Behavior & Potential Risk

pre-ci pass

## How has this PR been tested?

local test

## Dependency Change?

lm_eval upgrade
