### PR TITLE
Fix case where pad_max_length set to None

### DIFF
--- a/neural_compressor/adaptor/torch_utils/gptq.py
+++ b/neural_compressor/adaptor/torch_utils/gptq.py
@@ -248,7 +248,7 @@ class GPTQuantizer(object):
 
         # dataloader
         self.use_max_length = use_max_length
-        self.pad_max_length = pad_max_length
+        self.pad_max_length = pad_max_length or 2048
         self.dataloader_original = dataloader
         self.dataloader = []
         self.nsamples = nsamples


### PR DESCRIPTION
Set default value for the `pad_max_length` attribute to avoid the case where it's set to `None` as done here https://github.com/intel/neural-compressor/blob/ba479850d3365fa8fae145b1376f104211af8b66/neural_compressor/adaptor/pytorch.py#L4531 by default as it'll results in issue when comparing its value during quantization like done here https://github.com/intel/neural-compressor/blob/v2.5/neural_compressor/adaptor/torch_utils/gptq.py#L307


An other solution could be to modify `framework_specific_info["recipes"]`
