### PR TITLE
Refactor PT 3.x  API: static_quant & rtn

### DIFF
--- a/neural_compressor/torch/algorithms/__init__.py
+++ b/neural_compressor/torch/algorithms/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base_algorithm import Quantizer, TwoStepQuantizer, algo_quantizer_register, algo_quantizers
+from .base_algorithm import Quantizer, algo_quantizer_register, algo_quantizers

--- a/neural_compressor/torch/algorithms/__init__.py
+++ b/neural_compressor/torch/algorithms/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base_algorithm import Quantizer, algo_quantizer_register, algo_quantizers
+from .base_algorithm import Quantizer

--- a/neural_compressor/torch/algorithms/__init__.py
+++ b/neural_compressor/torch/algorithms/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .base_algorithm import Quantizer, TwoStepQuantizer, algo_quantizer_register, algo_quantizers

--- a/neural_compressor/torch/algorithms/base_algorithm.py
+++ b/neural_compressor/torch/algorithms/base_algorithm.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+from typing import Any
+
+import torch
+
+algo_quantizers = {}
+
+
+def algo_quantizer_register(name):
+    def decorator(algo_quantizer):
+        algo_quantizers[name] = algo_quantizer
+        return algo_quantizer
+
+    return decorator
+
+
+class Quantizer(ABC):
+    """The base quantizer for one step algorithm quantizers."""
+
+    def __init__(self, config: OrderedDict = {}):
+        self.config = config
+
+    @abstractmethod
+    def quantize(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
+        raise NotImplementedError
+
+
+class TwoStepQuantizer(ABC):
+    """The base quantizer for two steps algorithm quantizers."""
+
+    def __init__(self, config: OrderedDict = {}):
+        self.config = config
+
+    @abstractmethod
+    def prepare(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
+        raise NotImplementedError
+
+    @abstractmethod
+    def convert(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
+        raise NotImplementedError

--- a/neural_compressor/torch/algorithms/base_algorithm.py
+++ b/neural_compressor/torch/algorithms/base_algorithm.py
@@ -17,17 +17,7 @@ from collections import OrderedDict
 from typing import Any
 
 import torch
-
-algo_quantizers = {}
-
-
-def algo_quantizer_register(name):
-    def decorator(algo_quantizer):
-        algo_quantizers[name] = algo_quantizer
-        return algo_quantizer
-
-    return decorator
-
+from neural_compressor.torch.utils import Mode
 
 class Quantizer(ABC):
     """The base quantizer for one step algorithm quantizers."""
@@ -37,31 +27,26 @@ class Quantizer(ABC):
 
     @abstractmethod
     def quantize(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError("{} doesn't implement `quantize` function.".format(self.__class__.__name__))
+        raise NotImplementedError("{} doesn't implement `quantize` function.".format(
+            self.__class__.__name__))
 
     def prepare(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError(
-            "{} doesn't implement `prepare` function. "
+        raise NotImplementedError("{} doesn't implement `prepare` function. "
             "Please implement `prepare` function or "
             "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
-                self.__class__.__name__
-            )
-        )
+            self.__class__.__name__))
 
     def convert(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError(
-            "{} doesn't implement `convert` function. "
+        raise NotImplementedError("{} doesn't implement `convert` function. "
             "Please implement `convert` function or "
             "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
-                self.__class__.__name__
-            )
-        )
+            self.__class__.__name__))
 
     def execute(self, model, mode, *args: Any, **kwargs: Any):
-        if mode == "prepare":
+        if mode == Mode.PREPARE:
             model = self.prepare(model, *args, **kwargs)
-        elif mode == "convert":
+        elif mode == Mode.CONVERT:
             model = self.convert(model, *args, **kwargs)
-        elif mode == "quantize":
+        elif mode == Mode.QUANTIZE:
             model = self.quantize(model, *args, **kwargs)
         return model

--- a/neural_compressor/torch/algorithms/base_algorithm.py
+++ b/neural_compressor/torch/algorithms/base_algorithm.py
@@ -37,20 +37,25 @@ class Quantizer(ABC):
 
     @abstractmethod
     def quantize(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError("{} doesn't implement `quantize` function.".format(
-            self.__class__.__name__))
+        raise NotImplementedError("{} doesn't implement `quantize` function.".format(self.__class__.__name__))
 
     def prepare(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError("{} doesn't implement `prepare` function. "
+        raise NotImplementedError(
+            "{} doesn't implement `prepare` function. "
             "Please implement `prepare` function or "
             "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
-            self.__class__.__name__))
+                self.__class__.__name__
+            )
+        )
 
     def convert(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError("{} doesn't implement `convert` function. "
+        raise NotImplementedError(
+            "{} doesn't implement `convert` function. "
             "Please implement `convert` function or "
             "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
-            self.__class__.__name__))
+                self.__class__.__name__
+            )
+        )
 
     def execute(self, model, mode, *args: Any, **kwargs: Any):
         if mode == "prepare":

--- a/neural_compressor/torch/algorithms/base_algorithm.py
+++ b/neural_compressor/torch/algorithms/base_algorithm.py
@@ -90,7 +90,7 @@ class Quantizer(ABC):
             )
         )
 
-    def execute(self, model: torch.nn.Module, mode, *args: Any, **kwargs: Any): # pragma: no cover
+    def execute(self, model: torch.nn.Module, mode, *args: Any, **kwargs: Any):  # pragma: no cover
         """Execute according to mode.
 
         Args:

--- a/neural_compressor/torch/algorithms/base_algorithm.py
+++ b/neural_compressor/torch/algorithms/base_algorithm.py
@@ -32,24 +32,31 @@ def algo_quantizer_register(name):
 class Quantizer(ABC):
     """The base quantizer for one step algorithm quantizers."""
 
-    def __init__(self, config: OrderedDict = {}):
-        self.config = config
+    def __init__(self, tune_cfg: OrderedDict = {}):
+        self.tune_cfg = tune_cfg
 
     @abstractmethod
     def quantize(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError
+        raise NotImplementedError("{} doesn't implement `quantize` function.".format(
+            self.__class__.__name__))
 
-
-class TwoStepQuantizer(ABC):
-    """The base quantizer for two steps algorithm quantizers."""
-
-    def __init__(self, config: OrderedDict = {}):
-        self.config = config
-
-    @abstractmethod
     def prepare(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError
+        raise NotImplementedError("{} doesn't implement `prepare` function. "
+            "Please implement `prepare` function or "
+            "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
+            self.__class__.__name__))
 
-    @abstractmethod
     def convert(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError
+        raise NotImplementedError("{} doesn't implement `convert` function. "
+            "Please implement `convert` function or "
+            "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
+            self.__class__.__name__))
+
+    def execute(self, model, mode, *args: Any, **kwargs: Any):
+        if mode == "prepare":
+            model = self.prepare(model, *args, **kwargs)
+        elif mode == "convert":
+            model = self.convert(model, *args, **kwargs)
+        elif mode == "quantize":
+            model = self.quantize(model, *args, **kwargs)
+        return model

--- a/neural_compressor/torch/algorithms/base_algorithm.py
+++ b/neural_compressor/torch/algorithms/base_algorithm.py
@@ -17,7 +17,9 @@ from collections import OrderedDict
 from typing import Any
 
 import torch
+
 from neural_compressor.torch.utils import Mode
+
 
 class Quantizer(ABC):
     """The base quantizer for one step algorithm quantizers."""
@@ -27,20 +29,25 @@ class Quantizer(ABC):
 
     @abstractmethod
     def quantize(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError("{} doesn't implement `quantize` function.".format(
-            self.__class__.__name__))
+        raise NotImplementedError("{} doesn't implement `quantize` function.".format(self.__class__.__name__))
 
     def prepare(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError("{} doesn't implement `prepare` function. "
+        raise NotImplementedError(
+            "{} doesn't implement `prepare` function. "
             "Please implement `prepare` function or "
             "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
-            self.__class__.__name__))
+                self.__class__.__name__
+            )
+        )
 
     def convert(self, model: torch.nn.Module, *args: Any, **kwargs: Any) -> torch.nn.Module:
-        raise NotImplementedError("{} doesn't implement `convert` function. "
+        raise NotImplementedError(
+            "{} doesn't implement `convert` function. "
             "Please implement `convert` function or "
             "switch to call `from neural_compressor.torch.quantization import quantize` to do quantization.".format(
-            self.__class__.__name__))
+                self.__class__.__name__
+            )
+        )
 
     def execute(self, model, mode, *args: Any, **kwargs: Any):
         if mode == Mode.PREPARE:

--- a/neural_compressor/torch/algorithms/base_algorithm.py
+++ b/neural_compressor/torch/algorithms/base_algorithm.py
@@ -90,13 +90,14 @@ class Quantizer(ABC):
             )
         )
 
-    def execute(self, model: torch.nn.Module, mode, *args: Any, **kwargs: Any):
+    def execute(self, model: torch.nn.Module, mode, *args: Any, **kwargs: Any): # pragma: no cover
         """Execute according to mode.
 
         Args:
             model (torch.nn.Module): The model to be executed.
             mode (Mode): The mode of current phase, including 'prepare', 'convert' and 'quantize'.
         """
+        # TODO: remove '# pragma: no cover' once CI test can cover this function
         if mode == Mode.PREPARE:
             model = self.prepare(model, *args, **kwargs)
         elif mode == Mode.CONVERT:

--- a/neural_compressor/torch/algorithms/static_quant/__init__.py
+++ b/neural_compressor/torch/algorithms/static_quant/__init__.py
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 from .utility import *
-from .static_quant import static_quantize
+from .static_quant import StaticQuantQuantizer
 from .save_load import save, load

--- a/neural_compressor/torch/algorithms/static_quant/static_quant.py
+++ b/neural_compressor/torch/algorithms/static_quant/static_quant.py
@@ -47,9 +47,24 @@ ipex_ver = get_ipex_version()
 
 class StaticQuantQuantizer(Quantizer):
     def __init__(self, tune_cfg: OrderedDict = {}):
+        """Init a StaticQuantQuantizer object.
+
+        Args:
+            tune_cfg (OrderedDict, optional): quantization config for ops. Defaults to {}.
+        """
         super().__init__(tune_cfg)
 
     def prepare(self, model, example_inputs, inplace=True, *args, **kwargs):
+        """Prepares a given model for quantization.
+
+        Args:
+            model: A float model to be quantized.
+            example_inputs: Used to trace torch model.
+            inplace: Whether to carry out model transformations in-place. Defaults to True.
+
+        Returns:
+            A prepared model.
+        """
         assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
         _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(
@@ -83,6 +98,16 @@ class StaticQuantQuantizer(Quantizer):
         return model
 
     def convert(self, model, example_inputs, inplace=True, *args, **kwargs):
+        """Converts a prepared model to a quantized model.
+
+        Args:
+            model: The prepared model to be converted.
+            example_inputs: Used to trace torch model.
+            inplace: Whether to carry out model transformations in-place. Defaults to True.
+
+        Returns:
+            A quantized model.
+        """
         from neural_compressor.torch.algorithms.static_quant import save
 
         user_cfg = getattr(model, "user_cfg", OrderedDict())
@@ -102,6 +127,17 @@ class StaticQuantQuantizer(Quantizer):
         return model
 
     def quantize(self, model, example_inputs, run_fn, inplace=True, *args, **kwargs):
+        """Quantizes a given torch model.
+
+        Args:
+            model: A float model to be quantized.
+            example_inputs: Used to trace torch model.
+            run_fn: a calibration function for calibrating the model.
+            inplace: Whether to carry out model transformations in-place. Defaults to True.
+
+        Returns:
+            A quantized model.
+        """
         model = self.prepare(model, example_inputs=example_inputs, inplace=inplace)
         run_fn(model)
         model = self.convert(model, example_inputs=example_inputs, inplace=inplace)

--- a/neural_compressor/torch/algorithms/static_quant/static_quant.py
+++ b/neural_compressor/torch/algorithms/static_quant/static_quant.py
@@ -30,8 +30,7 @@ from collections import OrderedDict
 
 from packaging.version import Version
 
-from neural_compressor.common.utils import STATIC_QUANT
-from neural_compressor.torch.algorithms import Quantizer, algo_quantizer_register
+from neural_compressor.torch.algorithms import Quantizer
 from neural_compressor.torch.utils import logger
 
 from .utility import (
@@ -46,7 +45,6 @@ from .utility import (
 ipex_ver = get_ipex_version()
 
 
-@algo_quantizer_register(name=STATIC_QUANT)
 class StaticQuantQuantizer(Quantizer):
     def __init__(self, tune_cfg: OrderedDict = {}):
         super().__init__(tune_cfg)
@@ -54,9 +52,7 @@ class StaticQuantQuantizer(Quantizer):
     def prepare(self, model, example_inputs, inplace=True, *args, **kwargs):
         assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
-        _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(
-            model, example_inputs
-        )
+        _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(model, example_inputs)
         # update json file in ipex_config_path; map ipex op_name to pt op_name
         user_cfg = cfg_to_qconfig(self.tune_cfg, cfgs, op_infos_from_cfgs, output_tensor_id_op_name)
         model.eval()

--- a/neural_compressor/torch/algorithms/static_quant/static_quant.py
+++ b/neural_compressor/torch/algorithms/static_quant/static_quant.py
@@ -54,7 +54,9 @@ class StaticQuantQuantizer(Quantizer):
     def prepare(self, model, example_inputs, inplace=True, *args, **kwargs):
         assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
-        _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(model, example_inputs)
+        _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(
+            model, example_inputs
+        )
         # update json file in ipex_config_path; map ipex op_name to pt op_name
         user_cfg = cfg_to_qconfig(self.tune_cfg, cfgs, op_infos_from_cfgs, output_tensor_id_op_name)
         model.eval()

--- a/neural_compressor/torch/algorithms/static_quant/static_quant.py
+++ b/neural_compressor/torch/algorithms/static_quant/static_quant.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 
 import json
+from copy import deepcopy
+from types import MethodType
 
 import torch
 
@@ -24,7 +26,13 @@ try:
 except:
     assert False, "Please install IPEX for static quantization."
 
+from collections import OrderedDict
+
 from packaging.version import Version
+
+from neural_compressor.common.utils import STATIC_QUANT
+from neural_compressor.torch.algorithms import TwoStepQuantizer, algo_quantizer_register
+from neural_compressor.torch.utils import logger
 
 from .utility import (
     cfg_to_qconfig,
@@ -38,53 +46,88 @@ from .utility import (
 ipex_ver = get_ipex_version()
 
 
-def static_quantize(model, tune_cfg, run_fn, example_inputs, inplace=True):
-    """Execute the quantize process on the specified model.
+@algo_quantizer_register(name=STATIC_QUANT)
+class StaticQuantQuantizer(TwoStepQuantizer):
+    def __init__(self, config: OrderedDict = {}):
+        super().__init__(config)
+        self._preprocess_config()
 
-    Args:
-        model: a float model to be quantized.
-        tune_cfg: quantization config for ops.
-        run_fn: a calibration function for calibrating the model.
-        example_inputs: used to trace torch model.
-        inplace: whether to carry out model transformations in-place.
+    def prepare(self, model, example_inputs, inplace=True):
+        assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
-    Returns:
-        A quantized model.
-    """
-    _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(model, example_inputs)
-    # update json file in ipex_config_path; map ipex op_name to pt op_name
-    user_cfg = cfg_to_qconfig(tune_cfg, cfgs, op_infos_from_cfgs, output_tensor_id_op_name)
-    model.eval()
+        _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(model, example_inputs)
+        # update json file in ipex_config_path; map ipex op_name to pt op_name
+        user_cfg = cfg_to_qconfig(self.config, cfgs, op_infos_from_cfgs, output_tensor_id_op_name)
+        print('user_cfg 1',user_cfg)
+        setattr(model, "user_cfg", user_cfg)
+        model.eval()
 
-    # Check save_qconf_summary part is a workaround for IPEX bug.
-    # Sometimes the prepared model from get_op_capablitiy loss this attribute
-    if not hasattr(model, "save_qconf_summary") or not hasattr(model, "load_qconf_summary"):
-        from torch.ao.quantization import MinMaxObserver, PerChannelMinMaxObserver, QConfig
+        # Check save_qconf_summary part is a workaround for IPEX bug.
+        # Sometimes the prepared model from get_op_capablitiy loss this attribute
+        if not hasattr(model, "save_qconf_summary") or not hasattr(model, "load_qconf_summary"):
+            from torch.ao.quantization import MinMaxObserver, PerChannelMinMaxObserver, QConfig
 
-        if ipex_ver.release >= Version("2.1").release:
-            static_qconfig = ipex.quantization.default_static_qconfig_mapping
-        else:
-            static_qconfig = QConfig(
-                activation=MinMaxObserver.with_args(qscheme=torch.per_tensor_affine, dtype=torch.quint8),
-                weight=PerChannelMinMaxObserver.with_args(dtype=torch.qint8, qscheme=torch.per_channel_symmetric),
-            )
-        if isinstance(example_inputs, dict):
-            model = ipex.quantization.prepare(
-                model, static_qconfig, example_kwarg_inputs=example_inputs, inplace=inplace
-            )
-        else:
-            model = ipex.quantization.prepare(model, static_qconfig, example_inputs=example_inputs, inplace=inplace)
+            if ipex_ver.release >= Version("2.1").release:
+                static_qconfig = ipex.quantization.default_static_qconfig_mapping
+            else:
+                static_qconfig = QConfig(
+                    activation=MinMaxObserver.with_args(qscheme=torch.per_tensor_affine, dtype=torch.quint8),
+                    weight=PerChannelMinMaxObserver.with_args(dtype=torch.qint8, qscheme=torch.per_channel_symmetric),
+                )
+            if isinstance(example_inputs, dict):
+                model = ipex.quantization.prepare(
+                    model, static_qconfig, example_kwarg_inputs=example_inputs, inplace=inplace
+                )
+            else:
+                model = ipex.quantization.prepare(model, static_qconfig, example_inputs=example_inputs, inplace=inplace)
 
-    model.load_qconf_summary(qconf_summary=ipex_config_path)
-    run_fn(model)
-    model.save_qconf_summary(qconf_summary=ipex_config_path)
-    model = _ipex_post_quant_process(model, example_inputs, inplace=inplace)
+        model.load_qconf_summary(qconf_summary=ipex_config_path)
+        return model
 
-    with open(ipex_config_path, "r") as f:
-        model.tune_cfg = json.load(f)
-    model.ipex_config_path = ipex_config_path
-    dump_model_op_stats(user_cfg)
-    return model
+    def convert(self, model, example_inputs, inplace=True):
+        from neural_compressor.torch.algorithms.static_quant import save
+
+        model.save_qconf_summary(qconf_summary=ipex_config_path)
+        model = _ipex_post_quant_process(model, example_inputs, inplace=inplace)
+
+        with open(ipex_config_path, "r") as f:
+            model.tune_cfg = json.load(f)
+        model.ipex_config_path = ipex_config_path
+
+        user_cfg = getattr(model, "user_cfg", OrderedDict())
+        print('user_cfg 2',user_cfg)
+        dump_model_op_stats(user_cfg)
+
+        logger.info("Static quantization done.")
+        model.ori_save = model.save
+        model.save = MethodType(save, model)
+        return model
+
+    def _preprocess_config(self):
+        logger.info("Quantize model with the static quant algorithm.")
+
+        # convert the user config into internal format
+        quant_config_mapping = {}
+        cfgs = deepcopy(self.config)
+        quant_config_mapping["op"] = cfgs
+        for (op_name, op_type), cfg in cfgs.items():
+            if cfg.name != STATIC_QUANT:
+                continue
+            quant_config_mapping["op"][(op_name, op_type)] = {
+                "weight": {
+                    "dtype": cfg.w_dtype,
+                    "scheme": "sym",
+                    "granularity": cfg.w_granularity,
+                    "algorithm": cfg.w_algo,
+                },
+                "activation": {
+                    "dtype": cfg.act_dtype,
+                    "scheme": "sym" if cfg.act_sym else "asym",
+                    "granularity": cfg.act_granularity,
+                    "algorithm": cfg.act_algo,
+                },
+            }
+        self.config = quant_config_mapping
 
 
 def _ipex_post_quant_process(model, example_inputs, inplace=False):

--- a/neural_compressor/torch/algorithms/static_quant/static_quant.py
+++ b/neural_compressor/torch/algorithms/static_quant/static_quant.py
@@ -52,7 +52,9 @@ class StaticQuantQuantizer(Quantizer):
     def prepare(self, model, example_inputs, inplace=True, *args, **kwargs):
         assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
-        _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(model, example_inputs)
+        _, cfgs, op_infos_from_cfgs, output_tensor_id_op_name, _ = get_quantizable_ops_recursively(
+            model, example_inputs
+        )
         # update json file in ipex_config_path; map ipex op_name to pt op_name
         user_cfg = cfg_to_qconfig(self.tune_cfg, cfgs, op_infos_from_cfgs, output_tensor_id_op_name)
         model.eval()

--- a/neural_compressor/torch/algorithms/weight_only/awq.py
+++ b/neural_compressor/torch/algorithms/weight_only/awq.py
@@ -431,8 +431,7 @@ class ActAwareWeightQuant:
         logger.info("Quantizing the AWQ optimized fp32 model")
         from .rtn import RTNQuantizer
 
-        rtn_quantizer = RTNQuantizer()
-        rtn_quantizer.config = self.weight_config
+        rtn_quantizer = RTNQuantizer(tune_cfg=self.weight_config)
         rtn_quantizer.quantize(
             self.model,
             bits=self.bits,

--- a/neural_compressor/torch/algorithms/weight_only/awq.py
+++ b/neural_compressor/torch/algorithms/weight_only/awq.py
@@ -429,14 +429,15 @@ class ActAwareWeightQuant:
         """
         # apply quantization and clip
         logger.info("Quantizing the AWQ optimized fp32 model")
-        from .rtn import rtn_quantize
+        from .rtn import RTNQuantizer
 
-        self.model = rtn_quantize(
+        rtn_quantizer = RTNQuantizer()
+        rtn_quantizer.config = self.weight_config
+        rtn_quantizer.quantize(
             self.model,
-            num_bits=self.bits,
+            bits=self.bits,
             group_size=self.group_size,
             scheme=self.scheme,
-            weight_config=self.weight_config,
             return_int=return_int,
             use_full_range=self.use_full_range,
         )

--- a/neural_compressor/torch/algorithms/weight_only/rtn.py
+++ b/neural_compressor/torch/algorithms/weight_only/rtn.py
@@ -57,17 +57,6 @@ class RTNQuantizer(Quantizer):
             scheme (str, optional): sym or asym. Defaults to "sym".
             quantile (float, optional): percentile of clip. Defaults to 1.0.
             dtype (str, optional): select from int, nf4, fp4. Defaults to int.
-            weight_config (dict, optional): specific layer wise configurations. Defaults to {}.
-                For example,
-                    weight_config={
-                        'fc2':
-                            {
-                                'dtype': 'int',
-                                'bits': 4,
-                                'group_size': 32,
-                                'scheme': 'sym'
-                            }
-                    }
             export_compressed_model (bool, optional): Choose return fp32 or int32 model.
                                         Defaults to False.
             use_full_range (bool, optional): Choose sym range whether use -2**(bits-1).

--- a/neural_compressor/torch/algorithms/weight_only/rtn.py
+++ b/neural_compressor/torch/algorithms/weight_only/rtn.py
@@ -28,6 +28,7 @@ from neural_compressor.torch.utils import get_device, logger, set_module
 
 from .utility import quant_tensor, search_clip
 
+
 class RTNQuantizer(Quantizer):
     def __init__(self, tune_cfg: OrderedDict = {}):
         super().__init__(tune_cfg)

--- a/neural_compressor/torch/algorithms/weight_only/rtn.py
+++ b/neural_compressor/torch/algorithms/weight_only/rtn.py
@@ -19,174 +19,209 @@
 # limitations under the License.
 
 
+from collections import OrderedDict
+
 import torch
 
+from neural_compressor.common.utils import RTN
+from neural_compressor.torch.algorithms import Quantizer, algo_quantizer_register
 from neural_compressor.torch.utils import get_device, logger, set_module
-from neural_compressor.torch.utils.auto_accelerator import auto_detect_accelerator
 
 from .utility import quant_tensor, search_clip
 
 
-@torch.no_grad()
-def rtn_quantize(
-    model,
-    dtype="int",
-    bits=4,
-    scheme="sym",
-    group_size=32,
-    group_dim=1,
-    quantile=1.0,
-    weight_config={},
-    export_compressed_model=False,
-    use_full_range=False,
-    use_mse_search=False,
-    **kwargs,
-):
-    """Quant the model with round to nearest method and inplace is True.
+@algo_quantizer_register(name=RTN)
+class RTNQuantizer(Quantizer):
+    def __init__(self, config: OrderedDict = {}):
+        super().__init__(config)
+        self._preprocess_config()
 
-    Args:
-        model: torch module
-        bits: num bits. Defaults to 4.
-        group_size (int, optional): how many elements share one scale/zp. Defaults to 32.
-        scheme (str, optional): sym or asym. Defaults to "sym".
-        quantile (float, optional): percentile of clip. Defaults to 1.0.
-        dtype (str, optional): select from int, nf4, fp4. Defaults to int.
-        weight_config (dict, optional): specific layer wise configurations. Defaults to {}.
-            For example,
-                weight_config={
-                    'fc2':
-                        {
-                            'dtype': 'int',
-                            'bits': 4,
-                            'group_size': 32,
-                            'scheme': 'sym'
-                        }
+    @torch.no_grad()
+    def quantize(
+        self,
+        model,
+        dtype="int",
+        bits=4,
+        scheme="sym",
+        group_size=32,
+        group_dim=1,
+        quantile=1.0,
+        export_compressed_model=False,
+        use_full_range=False,
+        use_mse_search=False,
+        **kwargs,
+    ):
+        """Quant the model with round to nearest method and inplace is True.
+
+        Args:
+            model: torch module
+            bits: num bits. Defaults to 4.
+            group_size (int, optional): how many elements share one scale/zp. Defaults to 32.
+            scheme (str, optional): sym or asym. Defaults to "sym".
+            quantile (float, optional): percentile of clip. Defaults to 1.0.
+            dtype (str, optional): select from int, nf4, fp4. Defaults to int.
+            weight_config (dict, optional): specific layer wise configurations. Defaults to {}.
+                For example,
+                    weight_config={
+                        'fc2':
+                            {
+                                'dtype': 'int',
+                                'bits': 4,
+                                'group_size': 32,
+                                'scheme': 'sym'
+                            }
+                    }
+            export_compressed_model (bool, optional): Choose return fp32 or int32 model.
+                                        Defaults to False.
+            use_full_range (bool, optional): Choose sym range whether use -2**(bits-1).
+                                        Defaults to False.
+            use_mse_search (bool, optional):  Whether search clip range.
+                                        Defaults to True.
+            group_dim (int, optional):   0 means splitting output channel,
+                                        1 means splitting input channel. Defaults to 1.
+
+        Returns:
+            model: fake quantized torch module
+        """
+        device = get_device(kwargs.pop("device", "auto"))
+        weight_config = self.config
+
+        # Put model on device explicitly
+        # TODO: refine it later, Put module on device one by one instead of the whole model
+        model.to(device)
+
+        assert isinstance(model, torch.nn.Module), "only support torch module"
+        supported_layers = (torch.nn.Linear,)
+        # initialize global configuration
+        double_quant_config = {
+            "double_quant": kwargs.get("use_double_quant", False),
+            "double_quant_dtype": kwargs.get("double_quant_dtype", "int"),
+            "double_quant_bits": kwargs.get("double_quant_bits", 8),
+            "double_quant_scheme": kwargs.get("double_quant_scheme", "sym"),
+            "double_quant_group_size": kwargs.get("double_quant_group_size", 256),
+        }
+        if export_compressed_model:
+            use_optimum_format = kwargs.get("use_optimum_format", True)
+        for name, m in model.named_modules():
+            if not isinstance(m, supported_layers):
+                continue
+            if name in weight_config:  # pragma: no cover
+                # initialize op configuration
+                dtype = weight_config[name].get("dtype", "int")
+                if dtype == "fp32":
+                    continue
+                logger.debug("Apply RTN on module %s.", name)
+                bits = weight_config[name].get("bits", 4)
+                group_size = weight_config[name]["group_size"]
+                scheme = weight_config[name]["scheme"]
+                quantile = weight_config[name].get("quantile", 1.0)
+                group_dim = weight_config[name]["group_dim"]
+                use_full_range = weight_config[name]["use_full_range"]
+                use_mse_search = weight_config[name]["use_mse_search"]
+                use_layer_wise = weight_config[name]["use_layer_wise"]
+                export_compressed_model = weight_config[name]["export_compressed_model"]
+                if export_compressed_model:
+                    use_optimum_format = kwargs.get("use_optimum_format", True)
+                # double quant config
+                double_quant_config = {
+                    "double_quant": weight_config[name]["use_double_quant"],
+                    "double_quant_dtype": weight_config[name]["double_quant_dtype"],
+                    "double_quant_bits": weight_config[name]["double_quant_bits"],
+                    "double_quant_scheme": weight_config[name]["double_quant_scheme"],
+                    "double_quant_group_size": weight_config[name]["double_quant_group_size"],
                 }
-        export_compressed_model (bool, optional): Choose return fp32 or int32 model.
-                                     Defaults to False.
-        use_full_range (bool, optional): Choose sym range whether use -2**(bits-1).
-                                     Defaults to False.
-        use_mse_search (bool, optional):  Whether search clip range.
-                                     Defaults to True.
-        group_dim (int, optional):   0 means splitting output channel,
-                                     1 means splitting input channel. Defaults to 1.
-
-    Returns:
-        model: fake quantized torch module
-    """
-    device = get_device(kwargs.pop("device", "auto"))
-
-    # Put model on device explicitly
-    # TODO: refine it later, Put module on device one by one instead of the whole model
-    model.to(device)
-
-    assert isinstance(model, torch.nn.Module), "only support torch module"
-    supported_layers = (torch.nn.Linear,)
-    # initialize global configuration
-    double_quant_config = {
-        "double_quant": kwargs.get("use_double_quant", False),
-        "double_quant_dtype": kwargs.get("double_quant_dtype", "int"),
-        "double_quant_bits": kwargs.get("double_quant_bits", 8),
-        "double_quant_scheme": kwargs.get("double_quant_scheme", "sym"),
-        "double_quant_group_size": kwargs.get("double_quant_group_size", 256),
-    }
-    if export_compressed_model:
-        use_optimum_format = kwargs.get("use_optimum_format", True)
-    for name, m in model.named_modules():
-        if not isinstance(m, supported_layers):
-            continue
-        if name in weight_config:  # pragma: no cover
-            # initialize op configuration
-            dtype = weight_config[name].get("dtype", "int")
+                if dtype != "int" and "int" in dtype:
+                    bits = int(dtype.lstrip("int"))
+                    dtype = "int"
+            log_msg = (
+                f"RTN quantization config: bits={bits}, group_size={group_size}, "
+                + f"scheme={scheme}, quantile={quantile}"
+            )
+            if dtype != "int":
+                log_msg += f", dtype={dtype}"
+            elif scheme == "sym":  # nf4/fp4 is always [-7,7]
+                log_msg += f", use_full_range={use_full_range}"
             if dtype == "fp32":
                 continue
-            logger.debug("Apply RTN on module %s.", name)
-            bits = weight_config[name].get("bits", 4)
-            group_size = weight_config[name]["group_size"]
-            scheme = weight_config[name]["scheme"]
-            quantile = weight_config[name].get("quantile", 1.0)
-            group_dim = weight_config[name]["group_dim"]
-            use_full_range = weight_config[name]["use_full_range"]
-            use_mse_search = weight_config[name]["use_mse_search"]
-            use_layer_wise = weight_config[name]["use_layer_wise"]
-            export_compressed_model = weight_config[name]["export_compressed_model"]
-            if export_compressed_model:
-                use_optimum_format = kwargs.get("use_optimum_format", True)
-            # double quant config
-            double_quant_config = {
-                "double_quant": weight_config[name]["use_double_quant"],
-                "double_quant_dtype": weight_config[name]["double_quant_dtype"],
-                "double_quant_bits": weight_config[name]["double_quant_bits"],
-                "double_quant_scheme": weight_config[name]["double_quant_scheme"],
-                "double_quant_group_size": weight_config[name]["double_quant_group_size"],
-            }
-            if dtype != "int" and "int" in dtype:
-                bits = int(dtype.lstrip("int"))
-                dtype = "int"
-        log_msg = (
-            f"RTN quantization config: bits={bits}, group_size={group_size}, " + f"scheme={scheme}, quantile={quantile}"
-        )
-        if dtype != "int":
-            log_msg += f", dtype={dtype}"
-        elif scheme == "sym":  # nf4/fp4 is always [-7,7]
-            log_msg += f", use_full_range={use_full_range}"
-        if dtype == "fp32":
-            continue
-        logger.debug(f"RTN quantized module:{name, m}")
-        logger.debug(log_msg)
-        if group_dim == 0:
-            weight = m.weight.t_().contiguous()
-        else:
-            weight = m.weight
-        if use_mse_search:
-            quantile = search_clip(m, bits, group_size, scheme, dtype, use_full_range)
-        if export_compressed_model:
-            int_weight, scale, zp = quant_tensor(
-                weight,
-                dtype=dtype,
-                bits=bits,
-                group_size=group_size,
-                scheme=scheme,
-                quantile=quantile,
-                return_int=True,
-                full_range=use_full_range,
-                **double_quant_config,
-            )
-            int_weight = int_weight.t_().contiguous() if group_dim == 0 else int_weight
-            scale = scale.t_().contiguous() if group_dim == 0 else scale
-            zp = zp.t_().contiguous() if group_dim == 0 and zp is not None else zp
-            from .modules import WeightOnlyLinear
-
-            new_module = WeightOnlyLinear(
-                m.in_features,
-                m.out_features,
-                dtype=dtype,
-                bits=bits,
-                group_size=group_size,
-                zp=zp is not None,
-                bias=m.bias is not None,
-                use_optimum_format=use_optimum_format,
-                device=device,
-            )
-            new_module.pack(int_weight, scale, zp, m.bias)
-            if name == "":
-                return new_module
-            else:
-                set_module(model, name, new_module)
-        else:
-            weight = quant_tensor(
-                weight,
-                dtype=dtype,
-                bits=bits,
-                group_size=group_size,
-                scheme=scheme,
-                quantile=quantile,
-                full_range=use_full_range,
-                **double_quant_config,
-            )
+            logger.debug(f"RTN quantized module:{name, m}")
+            logger.debug(log_msg)
             if group_dim == 0:
-                # for group_dim is 0, we need to transpose the quantized tensor and module's weight back
-                weight = weight.t_().contiguous()
-                m.weight.t_().contiguous()
-            m.weight.data.copy_(weight)
-    return model
+                weight = m.weight.t_().contiguous()
+            else:
+                weight = m.weight
+            if use_mse_search:
+                quantile = search_clip(m, bits, group_size, scheme, dtype, use_full_range)
+            if export_compressed_model:
+                int_weight, scale, zp = quant_tensor(
+                    weight,
+                    dtype=dtype,
+                    bits=bits,
+                    group_size=group_size,
+                    scheme=scheme,
+                    quantile=quantile,
+                    return_int=True,
+                    full_range=use_full_range,
+                    **double_quant_config,
+                )
+                int_weight = int_weight.t_().contiguous() if group_dim == 0 else int_weight
+                scale = scale.t_().contiguous() if group_dim == 0 else scale
+                zp = zp.t_().contiguous() if group_dim == 0 and zp is not None else zp
+                from .modules import WeightOnlyLinear
+
+                new_module = WeightOnlyLinear(
+                    m.in_features,
+                    m.out_features,
+                    dtype=dtype,
+                    bits=bits,
+                    group_size=group_size,
+                    zp=zp is not None,
+                    bias=m.bias is not None,
+                    use_optimum_format=use_optimum_format,
+                    device=device,
+                )
+                new_module.pack(int_weight, scale, zp, m.bias)
+                if name == "":
+                    return new_module
+                else:
+                    set_module(model, name, new_module)
+            else:
+                weight = quant_tensor(
+                    weight,
+                    dtype=dtype,
+                    bits=bits,
+                    group_size=group_size,
+                    scheme=scheme,
+                    quantile=quantile,
+                    full_range=use_full_range,
+                    **double_quant_config,
+                )
+                if group_dim == 0:
+                    # for group_dim is 0, we need to transpose the quantized tensor and module's weight back
+                    weight = weight.t_().contiguous()
+                    m.weight.t_().contiguous()
+                m.weight.data.copy_(weight)
+        return model
+
+    def _preprocess_config(self):
+        # rebuild weight_config for rtn_quantize function
+        weight_config = {}
+        for (op_name, op_type), quant_config in self.config.items():
+            if quant_config.name != RTN:
+                continue
+            weight_config[op_name] = {
+                "dtype": quant_config.dtype,
+                "bits": quant_config.bits,
+                "scheme": "sym" if quant_config.use_sym else "asym",
+                "group_size": quant_config.group_size,
+                "group_dim": quant_config.group_dim,
+                "use_full_range": quant_config.use_full_range,
+                "use_mse_search": quant_config.use_mse_search,
+                "use_layer_wise": quant_config.use_layer_wise,
+                "export_compressed_model": quant_config.export_compressed_model,
+                "use_double_quant": quant_config.use_double_quant,
+                "double_quant_dtype": quant_config.double_quant_dtype,
+                "double_quant_bits": quant_config.double_quant_bits,
+                "double_quant_scheme": "sym" if quant_config.double_quant_use_sym else "asym",
+                "double_quant_group_size": quant_config.double_quant_group_size,
+            }
+        self.config = weight_config

--- a/neural_compressor/torch/algorithms/weight_only/rtn.py
+++ b/neural_compressor/torch/algorithms/weight_only/rtn.py
@@ -23,14 +23,11 @@ from collections import OrderedDict
 
 import torch
 
-from neural_compressor.common.utils import RTN
-from neural_compressor.torch.algorithms import Quantizer, algo_quantizer_register
+from neural_compressor.torch.algorithms import Quantizer
 from neural_compressor.torch.utils import get_device, logger, set_module
 
 from .utility import quant_tensor, search_clip
 
-
-@algo_quantizer_register(name=RTN)
 class RTNQuantizer(Quantizer):
     def __init__(self, tune_cfg: OrderedDict = {}):
         super().__init__(tune_cfg)

--- a/neural_compressor/torch/quantization/__init__.py
+++ b/neural_compressor/torch/quantization/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from neural_compressor.torch.quantization.quantize import quantize
+from neural_compressor.torch.quantization.quantize import quantize, prepare, convert
 from neural_compressor.torch.quantization.config import (
     RTNConfig,
     get_default_rtn_config,

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -109,6 +109,7 @@ def gptq_entry(
         }
     )
     kwargs.pop("example_inputs")
+    kwargs.pop("mode") # TODO: will be removed after GPTQ refactoring
 
     logger.warning("lm_head in transformer model is skipped by GPTQ")
     model, quantization_perm = gptq_quantize(model=model, weight_config=weight_config, *args, **kwargs)
@@ -155,7 +156,12 @@ def static_quant_entry(
     assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
     quantizer = StaticQuantQuantizer(tune_cfg=quant_config_mapping)
-    model = quantizer.execute(model, mode=mode, run_fn=run_fn, example_inputs=example_inputs, inplace=inplace)
+    model = quantizer.execute(
+        model,
+        mode=mode,
+        run_fn=run_fn,
+        example_inputs=example_inputs,
+        inplace=inplace)
     return model
 
 

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -30,7 +30,7 @@ from neural_compressor.torch.quantization import (
     StaticQuantConfig,
     TEQConfig,
 )
-from neural_compressor.torch.utils import logger, register_algo, Mode
+from neural_compressor.torch.utils import Mode, logger, register_algo
 
 
 ###################### RTN Algo Entry ##################################

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -30,14 +30,18 @@ from neural_compressor.torch.quantization import (
     StaticQuantConfig,
     TEQConfig,
 )
-from neural_compressor.torch.utils import logger, register_algo
+from neural_compressor.torch.utils import logger, register_algo, Mode
 
 
 ###################### RTN Algo Entry ##################################
 @register_algo(RTN)
 @torch.no_grad()
 def rtn_entry(
-    model: torch.nn.Module, configs_mapping: Dict[Tuple[str, callable], RTNConfig], *args, **kwargs
+    model: torch.nn.Module,
+    configs_mapping: Dict[Tuple[str, callable], RTNConfig],
+    mode: Mode = Mode.QUANTIZE,
+    *args,
+    **kwargs
 ) -> torch.nn.Module:
     """The main entry to apply rtn quantization."""
     from neural_compressor.torch.algorithms.weight_only.rtn import RTNQuantizer
@@ -63,8 +67,6 @@ def rtn_entry(
             "double_quant_scheme": "sym" if quant_config.double_quant_use_sym else "asym",
             "double_quant_group_size": quant_config.double_quant_group_size,
         }
-
-    mode = kwargs.get("mode", "quantize")
 
     quantizer = RTNQuantizer(tune_cfg=weight_config)
     model = quantizer.execute(model, mode=mode)
@@ -122,7 +124,11 @@ def gptq_entry(
 @register_algo(name=STATIC_QUANT)
 @torch.no_grad()
 def static_quant_entry(
-    model: torch.nn.Module, configs_mapping: Dict[Tuple[str, callable], StaticQuantConfig], *args, **kwargs
+    model: torch.nn.Module,
+    configs_mapping: Dict[Tuple[str, callable], StaticQuantConfig],
+    mode: Mode = Mode.QUANTIZE,
+    *args,
+    **kwargs
 ) -> torch.nn.Module:
     logger.info("Quantize model with the static quant algorithm.")
     from neural_compressor.torch.algorithms.static_quant import StaticQuantQuantizer
@@ -152,7 +158,6 @@ def static_quant_entry(
     run_fn = kwargs.get("run_fn", None)
     example_inputs = kwargs.get("example_inputs", None)
     inplace = kwargs.get("inplace", True)
-    mode = kwargs.get("mode", "quantize")
     assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
     quantizer = StaticQuantQuantizer(tune_cfg=quant_config_mapping)

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -109,7 +109,7 @@ def gptq_entry(
         }
     )
     kwargs.pop("example_inputs")
-    kwargs.pop("mode") # TODO: will be removed after GPTQ refactoring
+    kwargs.pop("mode")  # TODO: will be removed after GPTQ refactoring
 
     logger.warning("lm_head in transformer model is skipped by GPTQ")
     model, quantization_perm = gptq_quantize(model=model, weight_config=weight_config, *args, **kwargs)
@@ -156,12 +156,7 @@ def static_quant_entry(
     assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
     quantizer = StaticQuantQuantizer(tune_cfg=quant_config_mapping)
-    model = quantizer.execute(
-        model,
-        mode=mode,
-        run_fn=run_fn,
-        example_inputs=example_inputs,
-        inplace=inplace)
+    model = quantizer.execute(model, mode=mode, run_fn=run_fn, example_inputs=example_inputs, inplace=inplace)
     return model
 
 

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -376,6 +376,7 @@ def autoround_quantize_entry(
             scale_dtype = quant_config.scale_dtype
 
     kwargs.pop("example_inputs")
+    kwargs.pop("mode")  # TODO: will be removed after auto_round refactoring
     model, autoround_config = autoround_quantize(
         model=model,
         weight_config=weight_config,

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -155,12 +155,7 @@ def static_quant_entry(
     assert example_inputs is not None, "Please provide example_inputs for static quantization."
 
     quantizer = StaticQuantQuantizer(tune_cfg=quant_config_mapping)
-    model = quantizer.execute(
-        model,
-        mode=mode,
-        run_fn=run_fn,
-        example_inputs=example_inputs,
-        inplace=inplace)
+    model = quantizer.execute(model, mode=mode, run_fn=run_fn, example_inputs=example_inputs, inplace=inplace)
     return model
 
 

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -40,32 +40,12 @@ def rtn_entry(
     model: torch.nn.Module, configs_mapping: Dict[Tuple[str, callable], RTNConfig], *args, **kwargs
 ) -> torch.nn.Module:
     """The main entry to apply rtn quantization."""
-    from neural_compressor.torch.algorithms.weight_only.rtn import rtn_quantize
+    from neural_compressor.torch.algorithms.weight_only.rtn import RTNQuantizer
 
-    # rebuild weight_config for rtn_quantize function
-    weight_config = {}
-    for (op_name, op_type), quant_config in configs_mapping.items():
-        if quant_config.name != RTN:
-            continue
-        weight_config[op_name] = {
-            "dtype": quant_config.dtype,
-            "bits": quant_config.bits,
-            "scheme": "sym" if quant_config.use_sym else "asym",
-            "group_size": quant_config.group_size,
-            "group_dim": quant_config.group_dim,
-            "use_full_range": quant_config.use_full_range,
-            "use_mse_search": quant_config.use_mse_search,
-            "use_layer_wise": quant_config.use_layer_wise,
-            "export_compressed_model": quant_config.export_compressed_model,
-            "use_double_quant": quant_config.use_double_quant,
-            "double_quant_dtype": quant_config.double_quant_dtype,
-            "double_quant_bits": quant_config.double_quant_bits,
-            "double_quant_scheme": "sym" if quant_config.double_quant_use_sym else "asym",
-            "double_quant_group_size": quant_config.double_quant_group_size,
-        }
-
-    model = rtn_quantize(model, weight_config=weight_config)
-    return model
+    logger.info("Quantize model with the RTN algorithm.")
+    algo = RTNQuantizer(configs_mapping)
+    q_model = algo.quantize(model)
+    return q_model
 
 
 ###################### GPTQ Algo Entry ##################################
@@ -120,46 +100,17 @@ def gptq_entry(
 def static_quant_entry(
     model: torch.nn.Module, configs_mapping: Dict[Tuple[str, callable], StaticQuantConfig], *args, **kwargs
 ) -> torch.nn.Module:
+    from neural_compressor.torch.algorithms.static_quant import StaticQuantQuantizer
+
     logger.info("Quantize model with the static quant algorithm.")
-    from neural_compressor.torch.algorithms.static_quant import save, static_quantize
-
-    # convert the user config into internal format
-    quant_config_mapping = {}
-    cfgs = deepcopy(configs_mapping)
-    quant_config_mapping["op"] = cfgs
-    for (op_name, op_type), cfg in cfgs.items():
-        if cfg.name != STATIC_QUANT:
-            continue
-        quant_config_mapping["op"][(op_name, op_type)] = {
-            "weight": {
-                "dtype": cfg.w_dtype,
-                "scheme": "sym",
-                "granularity": cfg.w_granularity,
-                "algorithm": cfg.w_algo,
-            },
-            "activation": {
-                "dtype": cfg.act_dtype,
-                "scheme": "sym" if cfg.act_sym else "asym",
-                "granularity": cfg.act_granularity,
-                "algorithm": cfg.act_algo,
-            },
-        }
-
+    algo = StaticQuantQuantizer(configs_mapping)
     run_fn = kwargs.get("run_fn", None)
     example_inputs = kwargs.get("example_inputs", None)
     inplace = kwargs.get("inplace", True)
-    assert example_inputs is not None, "Please provide example_inputs for static quantization."
-    q_model = static_quantize(
-        model=model,
-        tune_cfg=quant_config_mapping,
-        run_fn=run_fn,
-        example_inputs=example_inputs,
-        inplace=inplace,
-    )
-    logger.info("Static quantization done.")
-    q_model.ori_save = q_model.save
-    q_model.save = MethodType(save, q_model)
-    return q_model
+    model = algo.prepare(model, example_inputs=example_inputs, inplace=inplace)
+    run_fn(model)
+    model = algo.convert(model, example_inputs=example_inputs, inplace=inplace)
+    return model
 
 
 ###################### Smooth Quant Algo Entry ##################################

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -21,7 +21,7 @@ import torch
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig, config_registry
 from neural_compressor.common.utils import log_quant_execution
 from neural_compressor.torch.quantization.config import SmoothQuantConfig, StaticQuantConfig
-from neural_compressor.torch.utils import is_ipex_available, logger, Mode
+from neural_compressor.torch.utils import Mode, is_ipex_available, logger
 from neural_compressor.torch.utils.utility import WHITE_MODULE_LIST, algos_mapping, get_model_info
 
 FRAMEWORK_NAME = "torch"
@@ -92,7 +92,7 @@ def prepare(
     quant_config: BaseConfig,
     inplace: bool = True,
     example_inputs: Any = None,
-): # pragma: no cover
+):  # pragma: no cover
     """Prepare the model for calibration.
 
     Insert observers into the model so that it can monitor the input and output tensors during calibration.
@@ -149,7 +149,7 @@ def convert(
     model: torch.nn.Module,
     quant_config: BaseConfig = None,
     inplace: bool = True,
-): # pragma: no cover
+):  # pragma: no cover
     """Convert the prepared model to a quantized model.
 
     Args:

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -21,7 +21,7 @@ import torch
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig, config_registry
 from neural_compressor.common.utils import log_quant_execution
 from neural_compressor.torch.quantization.config import SmoothQuantConfig, StaticQuantConfig
-from neural_compressor.torch.utils import is_ipex_available, logger, Mode
+from neural_compressor.torch.utils import Mode, is_ipex_available, logger
 from neural_compressor.torch.utils.utility import WHITE_MODULE_LIST, algos_mapping, get_model_info
 
 FRAMEWORK_NAME = "torch"

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -21,7 +21,7 @@ import torch
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig, config_registry
 from neural_compressor.common.utils import log_quant_execution
 from neural_compressor.torch.quantization.config import SmoothQuantConfig, StaticQuantConfig
-from neural_compressor.torch.utils import Mode, is_ipex_available, logger
+from neural_compressor.torch.utils import is_ipex_available, logger, Mode
 from neural_compressor.torch.utils.utility import WHITE_MODULE_LIST, algos_mapping, get_model_info
 
 FRAMEWORK_NAME = "torch"
@@ -92,7 +92,7 @@ def prepare(
     quant_config: BaseConfig,
     inplace: bool = True,
     example_inputs: Any = None,
-):
+): # pragma: no cover
     """Prepare the model for calibration.
 
     Insert observers into the model so that it can monitor the input and output tensors during calibration.
@@ -106,6 +106,7 @@ def prepare(
     Returns:
         prepared and calibrated module.
     """
+    # TODO: remove '# pragma: no cover' once CI test can cover this function
     prepared_model = model if inplace else copy.deepcopy(model)
     registered_configs = config_registry.get_cls_configs()
     if isinstance(quant_config, dict):
@@ -148,7 +149,7 @@ def convert(
     model: torch.nn.Module,
     quant_config: BaseConfig = None,
     inplace: bool = True,
-):
+): # pragma: no cover
     """Convert the prepared model to a quantized model.
 
     Args:
@@ -159,6 +160,7 @@ def convert(
     Returns:
         The quantized model.
     """
+    # TODO: remove '# pragma: no cover' once CI test can cover this function
     q_model = model if inplace else copy.deepcopy(model)
 
     # TODO: Optimize the check for prepared flag after adding HQT FP8 Quant

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import copy
-from typing import Any, Callable, Dict, Tuple
+from pathlib import Path
+from typing import Any, Callable, Dict, Tuple, Union
 
 import torch
 
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig, config_registry
 from neural_compressor.common.utils import log_quant_execution
+from neural_compressor.torch.algorithms import algo_quantizers
 from neural_compressor.torch.quantization.config import SmoothQuantConfig, StaticQuantConfig
 from neural_compressor.torch.utils import is_ipex_available, logger
 from neural_compressor.torch.utils.utility import WHITE_MODULE_LIST, algos_mapping, get_model_info
@@ -80,6 +82,122 @@ def quantize(
                 configs_mapping,
                 run_fn=run_fn,
                 run_args=run_args,
+                example_inputs=example_inputs,
+            )
+    return q_model
+
+
+@log_quant_execution
+def prepare(
+    model: torch.nn.Module,
+    quant_config: BaseConfig,
+    inplace: bool = True,
+    example_inputs: Any = None,
+):
+    """Prepare the model for calibration.
+
+    Insert observers into the model so that it can monitor the input and output tensors during calibration.
+
+    Args:
+        model (torch.nn.Module): origin model
+        quant_config (BaseConfig): path to quantization config
+        inplace (bool): It will change the given model in-place if True.
+        example_inputs: used to trace torch model.
+
+    Returns:
+        prepared and calibrated module.
+    """
+    prepared_model = model if inplace else copy.deepcopy(model)
+    registered_configs = config_registry.get_cls_configs()
+    if isinstance(quant_config, dict):
+        quant_config = ComposableConfig.from_dict(quant_config, config_registry=registered_configs[FRAMEWORK_NAME])
+        logger.info(f"Parsed a config dict to construct the quantization config: {quant_config}.")
+    else:
+        assert isinstance(
+            quant_config, BaseConfig
+        ), f"Please pass a dict or config instance as the quantization configuration, but got {type(quant_config)}."
+    logger.info("Prepare model with config:")
+    logger.info(quant_config.to_dict())
+
+    # select quantization algo according to config
+    if is_ipex_available and (
+        isinstance(quant_config, StaticQuantConfig) or isinstance(quant_config, SmoothQuantConfig)
+    ):
+        model_info = quant_config.get_model_info(prepared_model, example_inputs)
+    else:
+        model_info = quant_config.get_model_info(model=prepared_model)
+    configs_mapping = quant_config.to_config_mapping(model_info=model_info)
+    logger.debug(configs_mapping)
+
+    # TODO: Need to consider composableConfig situation
+    for algo_name, algo_quantizer in algo_quantizers.items():
+        if need_apply(configs_mapping, algo_name):
+            logger.info(f"Start to prepare model with {algo_name}.")
+            quantizer = algo_quantizer(configs_mapping)
+            prepared_model = quantizer.prepare(
+                prepared_model,
+                example_inputs=example_inputs,
+            )
+            setattr(prepared_model, "prepared", True)
+    setattr(prepared_model, "quant_config", quant_config)
+    setattr(prepared_model, "example_inputs", example_inputs)
+    return prepared_model
+
+
+@log_quant_execution
+def convert(
+    model: torch.nn.Module,
+    quant_config: BaseConfig = None,
+    inplace: bool = True,
+):
+    """Convert the prepared model to a quantized model.
+
+    Args:
+        model (torch.nn.Module): the prepared model
+        quant_config (BaseConfig, optional): path to quantization config
+        inplace (bool, optional): It will change the given model in-place if True.
+
+    Returns:
+        The quantized model.
+    """
+    q_model = model if inplace else copy.deepcopy(model)
+
+    # TODO: Optimize the check for prepared flag after adding HQT FP8 Quant
+    assert getattr(model, "prepared", False), "Please run prepare function before convert."
+
+    if getattr(model, "prepared", False):
+        if quant_config is None:
+            quant_config = model.quant_config
+    example_inputs = model.example_inputs if getattr(model, "prepared", False) else None
+
+    registered_configs = config_registry.get_cls_configs()
+    if isinstance(quant_config, dict):
+        quant_config = ComposableConfig.from_dict(quant_config, config_registry=registered_configs[FRAMEWORK_NAME])
+        logger.info(f"Parsed a config dict to construct the quantization config: {quant_config}.")
+    else:
+        assert isinstance(
+            quant_config, BaseConfig
+        ), f"Please pass a dict or config instance as the quantization configuration, but got {type(quant_config)}."
+    logger.info("Convert model with config:")
+    logger.info(quant_config.to_dict())
+
+    # select quantization algo according to config
+    if is_ipex_available and (
+        isinstance(quant_config, StaticQuantConfig) or isinstance(quant_config, SmoothQuantConfig)
+    ):
+        model_info = quant_config.get_model_info(q_model, example_inputs)
+    else:
+        model_info = quant_config.get_model_info(model=q_model)
+    configs_mapping = quant_config.to_config_mapping(model_info=model_info)
+    logger.debug(configs_mapping)
+
+    # TODO: Need to consider composableConfig situation
+    for algo_name, algo_quantizer in algo_quantizers.items():
+        if need_apply(configs_mapping, algo_name):
+            logger.info(f"Start to convert model with {algo_name}.")
+            quantizer = algo_quantizer(configs_mapping)
+            q_model = quantizer.convert(
+                q_model,
                 example_inputs=example_inputs,
             )
     return q_model

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -145,7 +145,6 @@ def prepare(
     return prepared_model
 
 
-
 @log_quant_execution
 def convert(
     model: torch.nn.Module,

--- a/neural_compressor/torch/quantization/quantize.py
+++ b/neural_compressor/torch/quantization/quantize.py
@@ -21,7 +21,7 @@ import torch
 from neural_compressor.common.base_config import BaseConfig, ComposableConfig, config_registry
 from neural_compressor.common.utils import log_quant_execution
 from neural_compressor.torch.quantization.config import SmoothQuantConfig, StaticQuantConfig
-from neural_compressor.torch.utils import is_ipex_available, logger
+from neural_compressor.torch.utils import is_ipex_available, logger, Mode
 from neural_compressor.torch.utils.utility import WHITE_MODULE_LIST, algos_mapping, get_model_info
 
 FRAMEWORK_NAME = "torch"
@@ -82,12 +82,11 @@ def quantize(
                 run_fn=run_fn,
                 run_args=run_args,
                 example_inputs=example_inputs,
-                mode="quantize",
+                mode=Mode.QUANTIZE,
             )
     return q_model
 
 
-@log_quant_execution
 def prepare(
     model: torch.nn.Module,
     quant_config: BaseConfig,
@@ -137,7 +136,7 @@ def prepare(
                 prepared_model,
                 configs_mapping,
                 example_inputs=example_inputs,
-                mode="prepare",
+                mode=Mode.PREPARE,
             )
             setattr(prepared_model, "prepared", True)
     setattr(prepared_model, "quant_config", quant_config)
@@ -145,7 +144,6 @@ def prepare(
     return prepared_model
 
 
-@log_quant_execution
 def convert(
     model: torch.nn.Module,
     quant_config: BaseConfig = None,
@@ -200,6 +198,6 @@ def convert(
                 q_model,
                 configs_mapping,
                 example_inputs=example_inputs,
-                mode="convert",
+                mode=Mode.CONVERT,
             )
     return q_model

--- a/neural_compressor/torch/utils/utility.py
+++ b/neural_compressor/torch/utils/utility.py
@@ -126,6 +126,7 @@ def get_double_quant_config(double_quant_type):
     )
     return DOUBLE_QUANT_CONFIGS[double_quant_type]
 
+
 class Mode(Enum):
     PREPARE = "prepare"
     CONVERT = "convert"

--- a/neural_compressor/torch/utils/utility.py
+++ b/neural_compressor/torch/utils/utility.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from enum import Enum
 from typing import Callable, Dict, List, Tuple, Union
 
 import torch
@@ -124,3 +125,8 @@ def get_double_quant_config(double_quant_type):
         list(DOUBLE_QUANT_CONFIGS.keys())
     )
     return DOUBLE_QUANT_CONFIGS[double_quant_type]
+
+class Mode(Enum):
+    PREPARE = "prepare"
+    CONVERT = "convert"
+    QUANTIZE = "quantize"

--- a/test/3x/torch/quantization/test_static_quant.py
+++ b/test/3x/torch/quantization/test_static_quant.py
@@ -3,7 +3,13 @@ import copy
 import pytest
 import torch
 
-from neural_compressor.torch.quantization import StaticQuantConfig, get_default_static_config, quantize
+from neural_compressor.torch.quantization import (
+    StaticQuantConfig,
+    convert,
+    get_default_static_config,
+    prepare,
+    quantize,
+)
 from neural_compressor.torch.utils import is_ipex_available
 
 if is_ipex_available():
@@ -141,6 +147,141 @@ class TestStaticQuant:
         fp32_model = copy.deepcopy(self.fp32_model)
         quant_config = get_default_static_config()
         q_model = quantize(fp32_model, quant_config=quant_config, run_fn=run_fn, example_inputs=example_inputs)
+        assert q_model is not None, "Quantization failed!"
+        inc_out = q_model(example_inputs)
+        # set a big atol to avoid random issue
+        assert torch.allclose(inc_out, ipex_out, atol=2e-02), "Unexpected result. Please double check."
+        q_model.save("saved_results")
+
+        from neural_compressor.torch.algorithms.static_quant import load
+
+        # load
+        loaded_model = load("saved_results")
+        assert isinstance(loaded_model, torch.jit.ScriptModule)
+
+
+class TestStaticQuantWithNewAPI:
+    def setup_class(self):
+        self.fp32_model = build_simple_torch_model()
+        self.input = torch.randn(1, 30)
+
+    def teardown_class(self):
+        pass
+
+    @pytest.mark.skipif(not is_ipex_available(), reason="Requires IPEX")
+    def test_static_quant_default(self):
+        fp32_model = copy.deepcopy(self.fp32_model)
+        quant_config = get_default_static_config()
+        example_inputs = self.input
+        prepared_model = prepare(fp32_model, quant_config=quant_config, example_inputs=example_inputs)
+        run_fn(prepared_model)
+        q_model = convert(prepared_model)
+        assert q_model is not None, "Quantization failed!"
+
+    @pytest.mark.skipif(not is_ipex_available(), reason="Requires IPEX")
+    def test_static_quant_fallback(self):
+        fp32_model = copy.deepcopy(self.fp32_model)
+        quant_config = get_default_static_config()
+        example_inputs = self.input
+        # fallback by op_type
+        quant_config.set_local(torch.nn.modules.linear.Linear, StaticQuantConfig(w_dtype="fp32", act_dtype="fp32"))
+        prepared_model = prepare(fp32_model, quant_config=quant_config, example_inputs=example_inputs)
+        run_fn(prepared_model)
+        q_model = convert(prepared_model)
+        assert q_model is not None, "Quantization failed!"
+
+        # fallback by op_name
+        quant_config.set_local("fc1", StaticQuantConfig(w_dtype="fp32", act_dtype="fp32"))
+        prepared_model = prepare(fp32_model, quant_config=quant_config, example_inputs=example_inputs)
+        run_fn(prepared_model)
+        q_model = convert(prepared_model)
+        assert q_model is not None, "Quantization failed!"
+
+
+    @pytest.mark.skipif(not is_ipex_available(), reason="Requires IPEX")
+    @pytest.mark.parametrize(
+        "act_sym, act_algo",
+        [
+            (True, "kl"),
+            (True, "minmax"),
+            (False, "kl"),
+            (False, "minmax"),
+        ],
+    )
+    def test_static_quant_params(self, act_sym, act_algo):
+        fp32_model = copy.deepcopy(self.fp32_model)
+        quant_config = StaticQuantConfig(act_sym=act_sym, act_algo=act_algo)
+        example_inputs = self.input
+        prepared_model = prepare(fp32_model, quant_config=quant_config, example_inputs=example_inputs)
+        run_fn(prepared_model)
+        q_model = convert(prepared_model)
+        assert q_model is not None, "Quantization failed!"
+
+    @pytest.mark.skipif(not is_ipex_available(), reason="Requires IPEX")
+    def test_static_quant_accuracy(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(2, 2, False)
+
+            def forward(self, x):
+                x = self.linear(x)
+                x = x + x
+                return x
+
+        model = M()
+
+        def run_fn(model):
+            model(torch.randn(3, 2))
+
+        fp32_model = copy.deepcopy(model)
+        fp32_model.linear.weight = torch.nn.Parameter(torch.tensor([[0.0, 1.0], [1.0, 0.0]]))
+        example_inputs = torch.zeros(3, 2)
+        quant_config = StaticQuantConfig(act_sym=True, act_algo="kl")
+        prepared_model = prepare(fp32_model, quant_config=quant_config, example_inputs=example_inputs)
+        run_fn(prepared_model)
+        q_model = convert(prepared_model)
+        output1 = fp32_model(example_inputs)
+        output2 = q_model(example_inputs)
+        # set a big atol to avoid random issue
+        assert torch.allclose(output1, output2, atol=2e-2), "Accuracy gap atol > 0.02 is unexpected. Please check."
+
+    @pytest.mark.skipif(not is_ipex_available(), reason="Requires IPEX")
+    def test_static_quant_save_load(self):
+        from intel_extension_for_pytorch.quantization import convert as ipex_convert
+        from intel_extension_for_pytorch.quantization import prepare as ipex_prepare
+
+        example_inputs = torch.zeros(1, 30)
+        try:
+            qconfig = ipex.quantization.default_static_qconfig_mapping
+        except:
+            from torch.ao.quantization import MinMaxObserver, PerChannelMinMaxObserver, QConfig
+
+            qconfig = QConfig(
+                activation=MinMaxObserver.with_args(qscheme=torch.per_tensor_affine, dtype=torch.quint8),
+                weight=PerChannelMinMaxObserver.with_args(dtype=torch.qint8, qscheme=torch.per_channel_symmetric),
+            )
+        user_model = copy.deepcopy(self.fp32_model)
+        user_model = ipex_prepare(user_model.eval(), qconfig, example_inputs=example_inputs, inplace=True)
+
+        def run_fn(model):
+            model(example_inputs)
+
+        run_fn(user_model)
+        with torch.no_grad():
+            user_model = ipex_convert(user_model.eval(), inplace=True).eval()
+            user_model(example_inputs)
+            user_model = torch.jit.trace(user_model.eval(), example_inputs, strict=False)
+            user_model = torch.jit.freeze(user_model.eval())
+            user_model(example_inputs)
+            user_model(example_inputs)
+        ipex_out = user_model(example_inputs)
+
+        fp32_model = copy.deepcopy(self.fp32_model)
+        quant_config = get_default_static_config()
+        prepared_model = prepare(fp32_model, quant_config=quant_config, example_inputs=example_inputs)
+        run_fn(prepared_model)
+        q_model = convert(prepared_model)
         assert q_model is not None, "Quantization failed!"
         inc_out = q_model(example_inputs)
         # set a big atol to avoid random issue

--- a/test/3x/torch/quantization/test_static_quant.py
+++ b/test/3x/torch/quantization/test_static_quant.py
@@ -197,7 +197,6 @@ class TestStaticQuantWithNewAPI:
         q_model = convert(prepared_model)
         assert q_model is not None, "Quantization failed!"
 
-
     @pytest.mark.skipif(not is_ipex_available(), reason="Requires IPEX")
     @pytest.mark.parametrize(
         "act_sym, act_algo",


### PR DESCRIPTION
## Type of Change

feature: Refactor PT 3.x static quant API
API changed or not: yes

## Description

Refactor PT 3.x static quant API

- Add new user-facing API: `from neural_compressor.torch.quantization import prepare` and `from 
 neural_compressor.torch.quantization import convert`
- Add base class: `Quantizer`. Any algorithm needs to inherit `Quantizer` base class.
- Modify internal algorithm entry to call member functions of algorithm Quantizer class.

### Usage
**static quant**
```diff
- from neural_compressor.torch.quantization import get_default_static_config, quantize
+ from neural_compressor.torch.quantization import get_default_static_config, prepare, convert

quant_config = get_default_static_config()
example_inputs = self.input
- q_model = quantize(fp32_model, quant_config=quant_config, run_fn=run_fn, example_inputs=example_inputs)
+ prepared_model = prepare(fp32_model, quant_config=quant_config, example_inputs=example_inputs)
+ run_fn(prepared_model)
+ q_model = convert(prepared_model)
```

**rtn quant** (user-facing API will not change)
```python
from neural_compressor.torch.quantization import RTNConfig, quantize
quant_config = RTNConfig()
q_model = quantize(model, quant_config)
```
## How has this PR been tested?

CI

## Dependency Change?

No
