### PR TITLE
refine load API for 3.x ipex backend

### DIFF
--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/habana_fp8/run_llm.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/habana_fp8/run_llm.py
@@ -143,7 +143,7 @@ if args.approach in ["dynamic", "static"] and not args.load:
 
 if args.load:
     from neural_compressor.torch.quantization import load
-    user_model = load(user_model, "saved_results")
+    user_model = load("saved_results", user_model)
 
 
 if args.approach in ["dynamic", "static"] or args.load:

--- a/neural_compressor/common/utils/save_load.py
+++ b/neural_compressor/common/utils/save_load.py
@@ -19,7 +19,7 @@ import json
 import os
 
 
-def save_config_mapping(config_mapping, qconfig_file_path): # pragma: no cover
+def save_config_mapping(config_mapping, qconfig_file_path):  # pragma: no cover
     """Save config mapping to json file.
 
     Args:
@@ -36,7 +36,7 @@ def save_config_mapping(config_mapping, qconfig_file_path): # pragma: no cover
         json.dump(per_op_qconfig, f, indent=4)
 
 
-def load_config_mapping(qconfig_file_path, config_name_mapping): # pragma: no cover
+def load_config_mapping(qconfig_file_path, config_name_mapping):  # pragma: no cover
     """Reload config mapping from json file.
 
     Args:

--- a/neural_compressor/common/utils/save_load.py
+++ b/neural_compressor/common/utils/save_load.py
@@ -19,7 +19,7 @@ import json
 import os
 
 
-def save_config_mapping(config_mapping, qconfig_file_path):
+def save_config_mapping(config_mapping, qconfig_file_path): # pragma: no cover
     """Save config mapping to json file.
 
     Args:
@@ -36,7 +36,7 @@ def save_config_mapping(config_mapping, qconfig_file_path):
         json.dump(per_op_qconfig, f, indent=4)
 
 
-def load_config_mapping(qconfig_file_path, config_name_mapping):
+def load_config_mapping(qconfig_file_path, config_name_mapping): # pragma: no cover
     """Reload config mapping from json file.
 
     Args:

--- a/test/3x/torch/quantization/habana_fp8/test_fp8.py
+++ b/test/3x/torch/quantization/habana_fp8/test_fp8.py
@@ -153,7 +153,7 @@ class TestPytorchFP8Adaptor:
         from neural_compressor.torch.quantization import load
 
         m = copy.deepcopy(self.model)
-        m = load(m, "saved_results")
+        m = load("saved_results", m)
         recovered_out = m(inp)
         assert (recovered_out == fp8_out).all(), "Unexpected result. Please double check."
         assert isinstance(m.fc1, FP8Linear), "Unexpected result. Please double check."

--- a/test/3x/torch/quantization/test_smooth_quant.py
+++ b/test/3x/torch/quantization/test_smooth_quant.py
@@ -133,8 +133,8 @@ class TestSmoothQuant:
         q_model.save("saved_results")
         inc_out = q_model(example_inputs)
 
-        from neural_compressor.torch.quantization import load
         from neural_compressor.torch.algorithms.smooth_quant import recover_model_from_json
+        from neural_compressor.torch.quantization import load
 
         # load using saved model
         loaded_model = load("saved_results")

--- a/test/3x/torch/quantization/test_smooth_quant.py
+++ b/test/3x/torch/quantization/test_smooth_quant.py
@@ -133,7 +133,8 @@ class TestSmoothQuant:
         q_model.save("saved_results")
         inc_out = q_model(example_inputs)
 
-        from neural_compressor.torch.algorithms.smooth_quant import load, recover_model_from_json
+        from neural_compressor.torch.quantization import load
+        from neural_compressor.torch.algorithms.smooth_quant import recover_model_from_json
 
         # load using saved model
         loaded_model = load("saved_results")

--- a/test/3x/torch/quantization/test_static_quant.py
+++ b/test/3x/torch/quantization/test_static_quant.py
@@ -147,7 +147,7 @@ class TestStaticQuant:
         assert torch.allclose(inc_out, ipex_out, atol=2e-02), "Unexpected result. Please double check."
         q_model.save("saved_results")
 
-        from neural_compressor.torch.algorithms.static_quant import load
+        from neural_compressor.torch.quantization import load
 
         # load
         loaded_model = load("saved_results")


### PR DESCRIPTION
## Type of Change

refine 3.x ipex backend load API

## Description
move load API from algorithm to quantization
`from neural_compressor.torch.algorithms.static_quant import load` --> `from neural_compressor.torch.quantization import load`

## Expected Behavior & Potential Risk

## How has this PR been tested?
ut passed

## Dependency Change?
