### PR TITLE
Remove `mark_step` for cuda and cpu

### DIFF
--- a/neural_compressor/torch/utils/auto_accelerator.py
+++ b/neural_compressor/torch/utils/auto_accelerator.py
@@ -137,7 +137,6 @@ class Auto_Accelerator(ABC):
     def synchronize(self):
         pass
 
-    @abstractmethod
     def mark_step(self):
         pass
 
@@ -173,9 +172,6 @@ class CPU_Accelerator(Auto_Accelerator):
         pass
 
     def synchronize(self):
-        pass
-
-    def mark_step(self):
         pass
 
 


### PR DESCRIPTION
## Type of Change

API changed or not: None

## Description

The cpu and cuda do not have `mark_step`, reuse the `Auto_Accelerator`'s `mark_step` (return None).


## How has this PR been tested?
Local test on machine with cuda.

## Dependency Change?
None
