### PR TITLE
Add torch WOQ tuning 

### DIFF
--- a/neural_compressor/torch/quantization/__init__.py
+++ b/neural_compressor/torch/quantization/__init__.py
@@ -34,6 +34,7 @@ from neural_compressor.torch.quantization.config import (
     FP8Config,
     get_default_fp8_config,
     get_default_fp8_config_set,
+    get_woq_tuning_config,
 )
 
 from neural_compressor.torch.quantization.autotune import (

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -308,6 +308,7 @@ def awq_quantize_entry(
             use_full_range = op_config.use_full_range
 
     run_fn = kwargs.get("run_fn", None)
+    run_args = kwargs.get("run_args", None)
     example_inputs = kwargs.get("example_inputs", None)
     assert example_inputs is not None, "Please provide example_inputs for AWQ quantization."
 
@@ -318,6 +319,7 @@ def awq_quantize_entry(
         bits=-1,  # no quantize for op not in weight_config
         example_inputs=example_inputs,  # must be required
         run_fn=run_fn,
+        run_args=run_args,
         use_auto_scale=use_auto_scale,
         use_mse_search=use_mse_search,
         folding=folding,


### PR DESCRIPTION
## Type of Change

feature
API changed or not: `get_woq_tuning_config`

## Description

Add torch WOQ tuning
https://github.com/intel/neural-compressor/blob/master/docs/source/quantization_weight_only.md#woq-algorithms-tuning


## How has this PR been tested?
Pre-CI

## Dependency Change?
None
