### PR TITLE
Add pt2e dynamic quantization

### DIFF
--- a/neural_compressor/torch/algorithms/pt2e_quant/__init__.py
+++ b/neural_compressor/torch/algorithms/pt2e_quant/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8StaticQuantizer
+from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8PT2EQuantizer

--- a/neural_compressor/torch/algorithms/pt2e_quant/core.py
+++ b/neural_compressor/torch/algorithms/pt2e_quant/core.py
@@ -18,9 +18,7 @@
 
 from typing import Any
 
-import torch
 import torch.ao.quantization.quantizer.x86_inductor_quantizer as xiq
-from torch._export import capture_pre_autograd_graph
 from torch.ao.quantization.quantize_pt2e import convert_pt2e, prepare_pt2e
 from torch.ao.quantization.quantizer.x86_inductor_quantizer import X86InductorQuantizer
 from torch.fx.graph_module import GraphModule
@@ -31,6 +29,10 @@ from neural_compressor.torch.utils import create_xiq_quantizer_from_pt2e_config
 
 
 class W8A8StaticQuantizer(Quantizer):
+
+    def __init__(self, quant_config, is_dynamic=False):
+        super().__init__(quant_config)
+        self.is_dynamic = is_dynamic
 
     @staticmethod
     def update_quantizer_based_on_quant_config(quant_config=None) -> X86InductorQuantizer:

--- a/neural_compressor/torch/algorithms/pt2e_quant/core.py
+++ b/neural_compressor/torch/algorithms/pt2e_quant/core.py
@@ -28,22 +28,21 @@ from neural_compressor.torch.algorithms.base_algorithm import Quantizer
 from neural_compressor.torch.utils import create_xiq_quantizer_from_pt2e_config
 
 
-class W8A8StaticQuantizer(Quantizer):
+class W8A8PT2EQuantizer(Quantizer):
     is_dynamic = False
 
     def __init__(self, quant_config):
         super().__init__(quant_config)
-        W8A8StaticQuantizer.is_dynamic = getattr(quant_config, "_is_dynamic", False)
 
     @staticmethod
     def update_quantizer_based_on_quant_config(quant_config=None) -> X86InductorQuantizer:
         if not quant_config:
             quantizer = X86InductorQuantizer()
             quantizer.set_global(
-                xiq.get_default_x86_inductor_quantization_config(is_dynamic=W8A8StaticQuantizer.is_dynamic)
+                xiq.get_default_x86_inductor_quantization_config(is_dynamic=W8A8PT2EQuantizer.is_dynamic)
             )
         else:
-            quantizer = create_xiq_quantizer_from_pt2e_config(quant_config)
+            quantizer = create_xiq_quantizer_from_pt2e_config(quant_config, is_dynamic=W8A8PT2EQuantizer.is_dynamic)
         return quantizer
 
     def prepare(self, model: GraphModule, example_inputs=None, inplace=True, *args, **kwargs) -> GraphModule:

--- a/neural_compressor/torch/algorithms/pt2e_quant/core.py
+++ b/neural_compressor/torch/algorithms/pt2e_quant/core.py
@@ -31,7 +31,7 @@ from neural_compressor.torch.utils import create_xiq_quantizer_from_pt2e_config
 class W8A8PT2EQuantizer(Quantizer):
     is_dynamic = False
 
-    def __init__(self, quant_config):
+    def __init__(self, quant_config=None):
         super().__init__(quant_config)
 
     @staticmethod

--- a/neural_compressor/torch/algorithms/pt2e_quant/core.py
+++ b/neural_compressor/torch/algorithms/pt2e_quant/core.py
@@ -29,16 +29,19 @@ from neural_compressor.torch.utils import create_xiq_quantizer_from_pt2e_config
 
 
 class W8A8StaticQuantizer(Quantizer):
+    is_dynamic = False
 
-    def __init__(self, quant_config, is_dynamic=False):
+    def __init__(self, quant_config):
         super().__init__(quant_config)
-        self.is_dynamic = is_dynamic
+        W8A8StaticQuantizer.is_dynamic = getattr(quant_config, "_is_dynamic", False)
 
     @staticmethod
     def update_quantizer_based_on_quant_config(quant_config=None) -> X86InductorQuantizer:
         if not quant_config:
             quantizer = X86InductorQuantizer()
-            quantizer.set_global(xiq.get_default_x86_inductor_quantization_config())
+            quantizer.set_global(
+                xiq.get_default_x86_inductor_quantization_config(is_dynamic=W8A8StaticQuantizer.is_dynamic)
+            )
         else:
             quantizer = create_xiq_quantizer_from_pt2e_config(quant_config)
         return quantizer

--- a/neural_compressor/torch/quantization/__init__.py
+++ b/neural_compressor/torch/quantization/__init__.py
@@ -35,6 +35,8 @@ from neural_compressor.torch.quantization.config import (
     get_default_fp8_config,
     get_default_fp8_config_set,
     get_woq_tuning_config,
+    DynamicQuantConfig,
+    get_default_dynamic_config,
 )
 
 from neural_compressor.torch.quantization.autotune import (

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -191,14 +191,15 @@ def static_quant_entry(
 @torch.no_grad()
 def pt2e_dynamic_quant_entry(model: torch.nn.Module, configs_mapping, mode: Mode, *args, **kwargs) -> torch.nn.Module:
     logger.info("Quantize model with the PT2E static quant algorithm.")
-    from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8StaticQuantizer
+    from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8PT2EQuantizer
 
     run_fn = kwargs.get("run_fn", None)
     example_inputs = kwargs.get("example_inputs", None)
     inplace = kwargs.get("inplace", True)
+    W8A8PT2EQuantizer.is_dynamic = True
     for _, quant_config in configs_mapping.items():
         if quant_config.name == PT2E_DYNAMIC_QUANT:
-            w8a8_quantizer = W8A8StaticQuantizer(quant_config=quant_config)
+            w8a8_quantizer = W8A8PT2EQuantizer(quant_config=quant_config)
             model = w8a8_quantizer.execute(
                 model, mode=mode, run_fn=run_fn, example_inputs=example_inputs, inplace=inplace
             )
@@ -210,14 +211,14 @@ def pt2e_dynamic_quant_entry(model: torch.nn.Module, configs_mapping, mode: Mode
 @torch.no_grad()
 def pt2e_static_quant_entry(model: torch.nn.Module, configs_mapping, mode: Mode, *args, **kwargs) -> torch.nn.Module:
     logger.info("Quantize model with the PT2E static quant algorithm.")
-    from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8StaticQuantizer
+    from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8PT2EQuantizer
 
     run_fn = kwargs.get("run_fn", None)
     example_inputs = kwargs.get("example_inputs", None)
     inplace = kwargs.get("inplace", True)
     for _, quant_config in configs_mapping.items():
         if quant_config.name == STATIC_QUANT:
-            w8a8_quantizer = W8A8StaticQuantizer(quant_config=quant_config)
+            w8a8_quantizer = W8A8PT2EQuantizer(quant_config=quant_config)
             model = w8a8_quantizer.execute(
                 model, mode=mode, run_fn=run_fn, example_inputs=example_inputs, inplace=inplace
             )

--- a/neural_compressor/torch/quantization/algorithm_entry.py
+++ b/neural_compressor/torch/quantization/algorithm_entry.py
@@ -198,7 +198,7 @@ def pt2e_dynamic_quant_entry(model: torch.nn.Module, configs_mapping, mode: Mode
     inplace = kwargs.get("inplace", True)
     for _, quant_config in configs_mapping.items():
         if quant_config.name == PT2E_DYNAMIC_QUANT:
-            w8a8_quantizer = W8A8StaticQuantizer(quant_config=quant_config, is_dynamic=True)
+            w8a8_quantizer = W8A8StaticQuantizer(quant_config=quant_config)
             model = w8a8_quantizer.execute(
                 model, mode=mode, run_fn=run_fn, example_inputs=example_inputs, inplace=inplace
             )

--- a/neural_compressor/torch/quantization/config.py
+++ b/neural_compressor/torch/quantization/config.py
@@ -819,6 +819,7 @@ class DynamicQuantConfig(BaseConfig):
         self.act_sym = act_sym
         self.act_granularity = act_granularity
         self.act_algo = act_algo
+        self._is_dynamic = True
         self._post_init()
 
     @classmethod

--- a/neural_compressor/torch/quantization/config.py
+++ b/neural_compressor/torch/quantization/config.py
@@ -17,7 +17,7 @@
 # pylint:disable=import-error
 
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, NamedTuple, Optional
+from typing import Callable, Dict, List, NamedTuple, Optional
 from typing import OrderedDict as OrderedDictType
 from typing import Tuple, Union
 
@@ -50,6 +50,7 @@ from neural_compressor.torch.utils.constants import (
     PRIORITY_HQQ,
     PRIORITY_RTN,
     PRIORITY_TEQ,
+    PT2E_DYNAMIC_QUANT,
 )
 
 __all__ = [
@@ -776,6 +777,80 @@ def get_default_AutoRound_config() -> AutoRoundConfig:
         the default AUTOROUND config.
     """
     return AutoRoundConfig()
+
+
+######################## Static Quant Config ###############################
+@register_config(framework_name=FRAMEWORK_NAME, algo_name=PT2E_DYNAMIC_QUANT)
+class DynamicQuantConfig(BaseConfig):
+    """Config class for dynamic quantization."""
+
+    name = PT2E_DYNAMIC_QUANT
+    params_list = [
+        "w_dtype",
+        "w_sym",
+        "w_granularity",
+        "w_algo",
+        "act_dtype",
+        "act_sym",
+        "act_granularity",
+        "act_algo",
+    ]
+    supported_configs: List[OperatorConfig] = []
+
+    def __init__(
+        self,
+        w_dtype: str = "int8",
+        w_sym: bool = True,
+        w_granularity: str = "per_channel",
+        w_algo: str = "minmax",
+        act_dtype: str = "uint8",
+        act_sym: bool = False,
+        act_granularity: str = "per_tensor",
+        act_algo: str = "kl",
+        white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = DEFAULT_WHITE_LIST,
+    ):
+        """Init Dynamic Quant Configs."""
+        super().__init__(white_list=white_list)
+        self.w_dtype = w_dtype
+        self.w_sym = w_sym
+        self.w_granularity = w_granularity
+        self.w_algo = w_algo
+        self.act_dtype = act_dtype
+        self.act_sym = act_sym
+        self.act_granularity = act_granularity
+        self.act_algo = act_algo
+        self._post_init()
+
+    @classmethod
+    def register_supported_configs(cls) -> List[OperatorConfig]:
+        supported_configs = []
+        linear_static_config = cls()
+        operators = [torch.nn.Linear]
+        supported_configs.append(OperatorConfig(config=linear_static_config, operators=operators))
+        cls.supported_configs = supported_configs
+
+    @staticmethod
+    def get_model_info(model: torch.nn.Module, example_inputs=None):
+        return None
+
+    def to_config_mapping(
+        self, config_list: List[BaseConfig] = None, model_info: List[Tuple[str, str]] = None
+    ) -> OrderedDictType[Union[str, str], OrderedDictType[str, BaseConfig]]:
+        config_mapping = OrderedDict({self.name: self})
+        return config_mapping
+
+    @classmethod
+    def get_config_set_for_tuning(cls) -> Union[None, "DynamicQuantConfig", List["DynamicQuantConfig"]]:
+        return cls(act_sym=[True, False], act_algo=["kl", "minmax"])
+
+
+def get_default_dynamic_config() -> DynamicQuantConfig:
+    """Generate the default dynamic quant config.
+
+    Returns:
+        the default dynamic quant config.
+    """
+    return DynamicQuantConfig()
 
 
 ######################## Static Quant Config ###############################

--- a/neural_compressor/torch/quantization/config.py
+++ b/neural_compressor/torch/quantization/config.py
@@ -779,7 +779,7 @@ def get_default_AutoRound_config() -> AutoRoundConfig:
     return AutoRoundConfig()
 
 
-######################## Static Quant Config ###############################
+######################## Dynamic Quant Config ###############################
 @register_config(framework_name=FRAMEWORK_NAME, algo_name=PT2E_DYNAMIC_QUANT)
 class DynamicQuantConfig(BaseConfig):
     """Config class for dynamic quantization."""

--- a/neural_compressor/torch/quantization/config.py
+++ b/neural_compressor/torch/quantization/config.py
@@ -801,7 +801,7 @@ class DynamicQuantConfig(BaseConfig):
         self,
         w_dtype: str = "int8",
         w_sym: bool = True,
-        w_granularity: str = "per_channel",
+        w_granularity: str = "per_tensor",
         w_algo: str = "minmax",
         act_dtype: str = "uint8",
         act_sym: bool = False,
@@ -819,7 +819,6 @@ class DynamicQuantConfig(BaseConfig):
         self.act_sym = act_sym
         self.act_granularity = act_granularity
         self.act_algo = act_algo
-        self._is_dynamic = True
         self._post_init()
 
     @classmethod

--- a/neural_compressor/torch/utils/constants.py
+++ b/neural_compressor/torch/utils/constants.py
@@ -52,3 +52,4 @@ PRIORITY_AUTOROUND = 50
 
 
 PT2E_STATIC_QUANT = "pt2e_static_quant"
+PT2E_DYNAMIC_QUANT = "pt2e_dynamic_quant"

--- a/neural_compressor/torch/utils/environ.py
+++ b/neural_compressor/torch/utils/environ.py
@@ -31,20 +31,20 @@ def is_hpex_available():
     return _hpex_available
 
 
-try:
-    import intel_extension_for_pytorch as ipex
-
-    _ipex_available = True
-except:
-    _ipex_available = False
-
-
 def is_ipex_available():
+    try:
+        import intel_extension_for_pytorch as ipex
+
+        _ipex_available = True
+    except:
+        _ipex_available = False
     return _ipex_available
 
 
 def get_ipex_version():
-    if _ipex_available:
+    if is_ipex_available():
+        import intel_extension_for_pytorch as ipex
+
         try:
             ipex_version = ipex.__version__.split("+")[0]
         except ValueError as e:  # pragma: no cover

--- a/neural_compressor/torch/utils/utility.py
+++ b/neural_compressor/torch/utils/utility.py
@@ -17,7 +17,7 @@ from typing import Callable, Dict, List, Tuple, Union
 
 import torch
 import torch.ao.quantization.quantizer.x86_inductor_quantizer as xiq
-from torch.ao.quantization.observer import HistogramObserver, MinMaxObserver
+from torch.ao.quantization.observer import HistogramObserver, MinMaxObserver, PlaceholderObserver
 from torch.ao.quantization.quantizer import QuantizationSpec
 from torch.ao.quantization.quantizer.x86_inductor_quantizer import QuantizationConfig, X86InductorQuantizer
 from typing_extensions import TypeAlias
@@ -174,20 +174,27 @@ def postprocess_model(model, mode, quantizer):
 
 def create_quant_spec_from_config(dtype, sym, granularity, algo, is_dynamic=False) -> QuantizationSpec:
     dtype_mapping: Dict[str, torch.dtype] = {"int8": torch.int8, "uint8": torch.uint8}
+    select_dtype = dtype_mapping[dtype]
+    min_max_mapping = {torch.int8: (-128, 127), torch.uint8: (0, 255)}
     qscheme_mapping = {
         "per_channel": {True: torch.per_channel_symmetric, False: torch.per_tensor_affine},
         "per_tensor": {True: torch.per_tensor_symmetric, False: torch.per_tensor_affine},
     }
     observer_mapping = {
+        "placeholder": PlaceholderObserver,
         "minmax": MinMaxObserver,
         "kl": HistogramObserver,
     }
+    if is_dynamic:
+        algo = "placeholder"
     # algo
     observer_or_fake_quant_ctr = observer_mapping[algo]
     # qscheme
     qscheme = qscheme_mapping[granularity][sym]
     quantization_spec = QuantizationSpec(
-        dtype=dtype_mapping[dtype],
+        dtype=select_dtype,
+        quant_min=min_max_mapping[select_dtype][0],
+        quant_max=min_max_mapping[select_dtype][1],
         observer_or_fake_quant_ctr=observer_or_fake_quant_ctr,
         qscheme=qscheme,
         is_dynamic=is_dynamic,
@@ -195,8 +202,7 @@ def create_quant_spec_from_config(dtype, sym, granularity, algo, is_dynamic=Fals
     return quantization_spec
 
 
-def _map_inc_config_to_torch_quant_config(inc_config) -> QuantizationConfig:
-    is_dynamic = hasattr(inc_config, "_is_dynamic", False)
+def _map_inc_config_to_torch_quant_config(inc_config, is_dynamic=False) -> QuantizationConfig:
     default_quant_config = xiq.get_default_x86_inductor_quantization_config(is_dynamic=is_dynamic)
     input_act_quant_spec = create_quant_spec_from_config(
         inc_config.act_dtype, inc_config.act_sym, inc_config.act_granularity, inc_config.act_algo, is_dynamic=is_dynamic
@@ -214,14 +220,14 @@ def _map_inc_config_to_torch_quant_config(inc_config) -> QuantizationConfig:
     return quant_config
 
 
-def create_xiq_quantizer_from_pt2e_config(config) -> X86InductorQuantizer:
+def create_xiq_quantizer_from_pt2e_config(config, is_dynamic=False) -> X86InductorQuantizer:
     quantizer = xiq.X86InductorQuantizer()
     # set global
-    global_config = _map_inc_config_to_torch_quant_config(config)
+    global_config = _map_inc_config_to_torch_quant_config(config, is_dynamic)
     quantizer.set_global(global_config)
     # set local
     for module_or_func_name, local_config in config.local_config.items():
-        local_quant_config = _map_inc_config_to_torch_quant_config(local_config)
+        local_quant_config = _map_inc_config_to_torch_quant_config(local_config, is_dynamic)
         if isinstance(module_or_func_name, torch.nn.Module):
             quantizer.set_module_type_qconfig(module_or_func_name, local_quant_config)
         else:

--- a/neural_compressor/torch/utils/utility.py
+++ b/neural_compressor/torch/utils/utility.py
@@ -185,6 +185,7 @@ def create_quant_spec_from_config(dtype, sym, granularity, algo, is_dynamic=Fals
         "minmax": MinMaxObserver,
         "kl": HistogramObserver,
     }
+    # Force to use placeholder observer for dynamic quantization
     if is_dynamic:
         algo = "placeholder"
     # algo

--- a/test/3x/torch/algorithms/pt2e_quant/test_pt2e_w8a8.py
+++ b/test/3x/torch/algorithms/pt2e_quant/test_pt2e_w8a8.py
@@ -5,12 +5,12 @@ import pytest
 import torch
 
 from neural_compressor.common.utils import logger
-from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8StaticQuantizer
+from neural_compressor.torch.algorithms.pt2e_quant.core import W8A8PT2EQuantizer
 from neural_compressor.torch.export import export_model_for_pt2e_quant
 from neural_compressor.torch.utils import TORCH_VERSION_2_2_2, get_torch_version
 
 
-class TestW8A8StaticQuantizer:
+class TestW8A8PT2EQuantizer:
 
     @staticmethod
     def get_toy_model():
@@ -52,7 +52,7 @@ class TestW8A8StaticQuantizer:
     @pytest.mark.skipif(get_torch_version() <= TORCH_VERSION_2_2_2, reason="Requires torch>=2.3.0")
     def test_quantizer_on_simple_model(self):
         model, example_inputs = self.build_simple_torch_model_and_example_inputs()
-        w8a8_static_quantizer = W8A8StaticQuantizer()
+        w8a8_static_quantizer = W8A8PT2EQuantizer()
         # prepare
         prepare_model = w8a8_static_quantizer.prepare(model, example_inputs=example_inputs)
         # calibrate
@@ -81,7 +81,7 @@ class TestW8A8StaticQuantizer:
         model = export_model_for_pt2e_quant(model, example_inputs=example_inputs)
 
         quant_config = None
-        w8a8_static_quantizer = W8A8StaticQuantizer()
+        w8a8_static_quantizer = W8A8PT2EQuantizer()
         # prepare
         prepare_model = w8a8_static_quantizer.prepare(model)
         # calibrate

--- a/test/3x/torch/quantization/test_pt2e_quant.py
+++ b/test/3x/torch/quantization/test_pt2e_quant.py
@@ -19,6 +19,14 @@ from neural_compressor.torch.quantization import (
 from neural_compressor.torch.utils import TORCH_VERSION_2_2_2, get_torch_version, is_ipex_imported
 
 
+@pytest.fixture
+def force_not_import_ipex(monkeypatch):
+    def _is_ipex_imported():
+        return False
+
+    monkeypatch.setattr("neural_compressor.torch.utils.is_ipex_imported", _is_ipex_imported)
+
+
 class TestPT2EQuantization:
 
     @staticmethod
@@ -58,9 +66,8 @@ class TestPT2EQuantization:
         exported_model = export(model, example_inputs=example_inputs)
         return exported_model, example_inputs
 
-    @pytest.mark.skipif(is_ipex_imported(), reason="IPEX is imported")
     @pytest.mark.skipif(get_torch_version() <= TORCH_VERSION_2_2_2, reason="Requires torch>=2.3.0")
-    def test_quantize_simple_model(self):
+    def test_quantize_simple_model(self, force_not_import_ipex):
         model, example_inputs = self.build_simple_torch_model_and_example_inputs()
         quant_config = None
 
@@ -78,10 +85,9 @@ class TestPT2EQuantization:
         logger.warning("out shape is %s", out.shape)
         assert out is not None
 
-    @pytest.mark.skipif(is_ipex_imported(), reason="IPEX is imported")
     @pytest.mark.skipif(get_torch_version() <= TORCH_VERSION_2_2_2, reason="Requires torch>=2.3.0")
     @pytest.mark.parametrize("is_dynamic", [False, True])
-    def test_prepare_and_convert_on_simple_model(self, is_dynamic):
+    def test_prepare_and_convert_on_simple_model(self, is_dynamic, force_not_import_ipex):
         model, example_inputs = self.build_simple_torch_model_and_example_inputs()
         quant_config = None
 
@@ -107,9 +113,8 @@ class TestPT2EQuantization:
         logger.warning("out shape is %s", out.shape)
         assert out is not None
 
-    @pytest.mark.skipif(is_ipex_imported(), reason="IPEX is imported")
     @pytest.mark.skipif(get_torch_version() <= TORCH_VERSION_2_2_2, reason="Requires torch>=2.3.0")
-    def test_prepare_and_convert_on_llm(self):
+    def test_prepare_and_convert_on_llm(self, force_not_import_ipex):
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         # set TOKENIZERS_PARALLELISM to false

--- a/test/3x/torch/quantization/test_pt2e_quant.py
+++ b/test/3x/torch/quantization/test_pt2e_quant.py
@@ -16,7 +16,7 @@ from neural_compressor.torch.quantization import (
     prepare,
     quantize,
 )
-from neural_compressor.torch.utils import TORCH_VERSION_2_2_2, get_torch_version, is_ipex_imported
+from neural_compressor.torch.utils import TORCH_VERSION_2_2_2, get_torch_version
 
 
 @pytest.fixture
@@ -24,7 +24,9 @@ def force_not_import_ipex(monkeypatch):
     def _is_ipex_imported():
         return False
 
-    monkeypatch.setattr("neural_compressor.torch.utils.is_ipex_imported", _is_ipex_imported)
+    monkeypatch.setattr("neural_compressor.torch.quantization.config.is_ipex_imported", _is_ipex_imported)
+    monkeypatch.setattr("neural_compressor.torch.quantization.algorithm_entry.is_ipex_imported", _is_ipex_imported)
+    monkeypatch.setattr("neural_compressor.torch.export._export.is_ipex_imported", _is_ipex_imported)
 
 
 class TestPT2EQuantization:


### PR DESCRIPTION
## Type of Change

feature
API changed or not

## Description

### Usage

```python
# User script
model = UserModel()
example_inputs = ...

# quantize script

# import intel_extension_for_pytorch ### <--- if user want to use ipex' static quant

from neural_compressor.torch.quantization import get_default_dynamic_config, prepare, convert
from neural_compressor.torch.export import export

# export
dynamic_shapes = {"input_ids": (None, Dim("seq_len"))}
exported_model = export(model, example_inputs=example_inputs, dynamic_shapes=dynamic_shapes)

# prepare
quant_config = get_default_dynamic_config()
prepare_model = prepare(model, quant_config)

# calibrate
run_fn(prepare_model)

# convert
converted_model = convert(prepare_model)

# compile and inference
opt_model = torch.compile(converted_model)
out = opt_model(*example_inputs)
```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
