### PR TITLE
[3x] fix bug in gptq g_idx

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/gptq.py
+++ b/neural_compressor/torch/algorithms/weight_only/gptq.py
@@ -671,42 +671,6 @@ class RAWGPTQuantizer(object):
                     act_order=weight_config_this_layer["act_order"],
                     static_groups=weight_config_this_layer["static_groups"],
                 )
-                if self.export_compressed_model:
-                    m = fetch_module(transformer_block, layer_name)
-                    gptq_scale = scale
-                    gptq_zp = None if weight_config_this_layer["sym"] else torch.tensor(zp, dtype=torch.int32)
-                    # recover INT weight
-                    gptq_perm = gptq_for_this_block[layer_name].perm if weight_config_this_layer["act_order"] else None
-                    if weight_config_this_layer["act_order"]:
-                        Q.copy_(Q[:, gptq_perm])
-                    from .utility import quant_weight_w_scale
-
-                    quant_weight_w_scale(
-                        Q,
-                        gptq_scale,
-                        gptq_zp,
-                        weight_config_this_layer["group_size"],
-                        dtype=weight_config_this_layer["dtype"],
-                    )
-                    # import pdb;pdb.set_trace()
-                    if weight_config_this_layer["act_order"]:
-                        invperm = torch.argsort(gptq_perm)
-                        Q.copy_(Q[:, invperm])
-                    int_weight = Q.type(torch.int32)  # copy_ is not workable for different types.
-                    # replace module
-                    new_module = WeightOnlyLinear(
-                        m.in_features,
-                        m.out_features,
-                        dtype=weight_config_this_layer["dtype"],
-                        bits=weight_config_this_layer["bits"],
-                        group_size=weight_config_this_layer["group_size"],
-                        zp=gptq_zp is not None,
-                        bias=m.bias is not None,
-                        g_idx=gptq_perm is not None,
-                        device=self.device,
-                    )
-                    new_module.pack(int_weight, gptq_scale, gptq_zp, m.bias)
-                    set_module(transformer_block, layer_name, new_module)
                 if self.use_layer_wise:
                     from neural_compressor.torch.algorithms.layer_wise import (
                         LWQ_WORKSPACE,
@@ -754,6 +718,50 @@ class RAWGPTQuantizer(object):
                 self.gptq_related_blocks["transformers"][block_idx] = transformer_block
             else:
                 self.gptq_related_blocks["transformers"][block_idx] = transformer_block.cpu()
+            # Step 2.6: export to compressed model
+            if self.export_compressed_model:
+                for layer_name in sub_layers:
+                    weight_config_this_layer = self.get_layer_config(self.get_full_layer_name(layer_name, block_idx))
+                    gptq_scale = gptq_config[self.get_full_layer_name(layer_name, block_idx)]["scale"]
+                    if not weight_config_this_layer["sym"]:
+                        gptq_zp = gptq_config[self.get_full_layer_name(layer_name, block_idx)]["zero"]
+                    else:
+                        gptq_zp = None
+                    if weight_config_this_layer["act_order"]:  # save perm for restoring the weights
+                        gptq_perm = gptq_config[self.get_full_layer_name(layer_name, block_idx)]["perm"]
+                    else:
+                        gptq_perm = None
+                    Q = sub_layers[layer_name].weight.data
+                    if weight_config_this_layer["act_order"]:
+                        Q.copy_(Q[:, gptq_perm])
+                    from .utility import quant_weight_w_scale
+
+                    quant_weight_w_scale(
+                        Q,
+                        gptq_scale,
+                        gptq_zp,
+                        weight_config_this_layer["group_size"],
+                        dtype=weight_config_this_layer["dtype"],
+                    )
+                    # import pdb;pdb.set_trace()
+                    if weight_config_this_layer["act_order"]:
+                        invperm = torch.argsort(gptq_perm)
+                        Q.copy_(Q[:, invperm])
+                    int_weight = Q.type(torch.int32)  # copy_ is not workable for different types.
+                    # replace module
+                    new_module = WeightOnlyLinear(
+                        sub_layers[layer_name].in_features,
+                        sub_layers[layer_name].out_features,
+                        dtype=weight_config_this_layer["dtype"],
+                        bits=weight_config_this_layer["bits"],
+                        group_size=weight_config_this_layer["group_size"],
+                        zp=gptq_zp is not None,
+                        bias=sub_layers[layer_name].bias is not None,
+                        g_idx=gptq_perm is not None,
+                        device=self.device,
+                    )
+                    new_module.pack(int_weight, gptq_scale, gptq_zp, sub_layers[layer_name].bias, gptq_perm)
+                    set_module(transformer_block, layer_name, new_module)
             del gptq_for_this_block
             torch.cuda.empty_cache()
             # iteratively replace the input with output, thus layerwise quantization can continue.

--- a/neural_compressor/torch/algorithms/weight_only/modules.py
+++ b/neural_compressor/torch/algorithms/weight_only/modules.py
@@ -190,7 +190,7 @@ class WeightOnlyLinear(torch.nn.Module):
         if g_idx is not None:
             assert hasattr(self, "g_idx"), "g_idx is not set when initializing."
             self.g_idx = g_idx.type(torch.int32).to(self.device)
-            if self.use_optimum_format:
+            if self.use_optimum_format or "int" not in self.dtype:
                 invperm = torch.argsort(self.g_idx)
                 self.g_idx = invperm // self.group_size
                 self.g_idx = self.g_idx.type(torch.int32).to(self.device)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

- [x] g_idx is not passed when exporting compressed model
- [x] export_compressed_model should be called after generating next layer input
- [x] support nf4, fp4 with gptq g_idx format

## Expected Behavior & Potential Risk

pre-ci pass
