### PR TITLE
Fix TF 2x LLM SQ Legacy Keras Environment Variable Issue

### DIFF
--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/benchmark.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/benchmark.py
@@ -167,18 +167,9 @@ if args.int8:
 else:
     print("benchmaking fp32 model")
     model = transformers.TFAutoModelForCausalLM.from_pretrained(model_name)
-    # fp32_folder = model_name.split('/')[-1] + "_fp32"
-    # model.save(fp32_folder)
-    # model = tf.keras.models.load_model(fp32_folder)
     from neural_compressor.experimental import common
-    def keras2SavedModel(model):
-        model = common.Model(model)
-        return model.model
-    model = keras2SavedModel(model) # tensorflow.python.trackable.autotrackable.AutoTrackable object
 
-# TODO current neural_compressor.benchmark does not support AutoTrackable model, we will write our own
-# from neural_compressor.benchmark import fit
-# from neural_compressor.config import BenchmarkConfig
-# conf = BenchmarkConfig(cores_per_instance=28, num_of_instance=1)
-# fit(model, conf, b_func=evaluator.evaluate_tf_v1)
+    os.environ["TF_USE_LEGACY_KERAS"]="False"
+    model = common.Model(model).model # tensorflow.python.trackable.autotrackable.AutoTrackable object
+
 evaluator.evaluate_tf_v1(model)

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/main.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/main.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os.path
+import os
 import transformers
 import tensorflow as tf
 from tqdm import tqdm
@@ -186,9 +186,9 @@ def eval_func(model):
 
 from neural_compressor import PostTrainingQuantConfig
 from neural_compressor.config import AccuracyCriterion
-
 from neural_compressor import quantization
 
+os.environ["TF_USE_LEGACY_KERAS"]=False
 recipes = {}
 if args.sq:
     recipes = {"smooth_quant": True, "smooth_quant_args": {'alpha': args.alpha}}

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/main.py
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/main.py
@@ -188,7 +188,7 @@ from neural_compressor import PostTrainingQuantConfig
 from neural_compressor.config import AccuracyCriterion
 from neural_compressor import quantization
 
-os.environ["TF_USE_LEGACY_KERAS"]=False
+os.environ["TF_USE_LEGACY_KERAS"]="False"
 recipes = {}
 if args.sq:
     recipes = {"smooth_quant": True, "smooth_quant_args": {'alpha': args.alpha}}


### PR DESCRIPTION
## Type of Change

bug fix

## Description

The environment variable `TF_USE_LEGACY_KERAS` is set to be `True` when loading the gpt2_medium_sq or opt_125m_sq example model from `Transformers`. We need to set it back so that we can still use `tf.keras` API without installing `tf_keras`.

## Expected Behavior & Potential Risk

The `TF_USE_LEGACY_KERAS` is set to be `False` after the models have been loaded.

## How has this PR been tested?

Extension Test

## Dependency Change?

No
