### PR TITLE
set automatic return_dict=False for GraphTrace

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/awq.py
+++ b/neural_compressor/torch/algorithms/weight_only/awq.py
@@ -130,7 +130,7 @@ class ActAwareWeightQuant:
         self.example_inputs = example_inputs
         self.model = model
         if example_inputs is None:
-            assert dataloader is not None, "datalaoder or example_inputs is required."
+            assert dataloader is not None, "dataloader or example_inputs is required."
             self.example_inputs = get_example_input(dataloader)
         self.device = device
         self._move_model_and_data_to_device()

--- a/neural_compressor/torch/algorithms/weight_only/utility.py
+++ b/neural_compressor/torch/algorithms/weight_only/utility.py
@@ -729,12 +729,11 @@ class GraphTrace:
         if orig_device != "cpu" and orig_device != "meta":  # pragma: no cover
             model = model.to("cpu")
             dummy_input = move_input_to_device(dummy_input, "cpu")
-        try:
-            # set return_dict=False to help transformers model jit.trace success
-            orig_return_dict = model.config.return_dict
+        reset_model_config_return_dict = False
+        if getattr(getattr(model, "config", None), "return_dict", False):
+            # set return_dict=False to help transformers model jit.trace success, orig_return_dict is True here
+            reset_model_config_return_dict = True
             model.config.return_dict = False
-        except:
-            pass
         if isinstance(dummy_input, dict) or isinstance(dummy_input, UserDict):
             try:
                 # pylint: disable=E1123, E1120
@@ -756,11 +755,9 @@ class GraphTrace:
                 except Exception as e:
                     logger.warning(e)
                     logger.warning("Jit trace in GraphTrace failed, absorb layer detection is skipped")
-        try:
+        if reset_model_config_return_dict:
             # recover return_dict original value for transformers model
-            model.config.return_dict = orig_return_dict
-        except:
-            pass
+            model.config.return_dict = True
         model = model.to(orig_device)
         return traced_model
 

--- a/neural_compressor/torch/algorithms/weight_only/utility.py
+++ b/neural_compressor/torch/algorithms/weight_only/utility.py
@@ -729,6 +729,12 @@ class GraphTrace:
         if orig_device != "cpu" and orig_device != "meta":  # pragma: no cover
             model = model.to("cpu")
             dummy_input = move_input_to_device(dummy_input, "cpu")
+        try:
+            # set return_dict=False to help transformers model jit.trace success
+            orig_return_dict = model.config.return_dict
+            model.config.return_dict = False
+        except:
+            pass
         if isinstance(dummy_input, dict) or isinstance(dummy_input, UserDict):
             try:
                 # pylint: disable=E1123, E1120
@@ -750,6 +756,11 @@ class GraphTrace:
                 except Exception as e:
                     logger.warning(e)
                     logger.warning("Jit trace in GraphTrace failed, absorb layer detection is skipped")
+        try:
+            # recover return_dict original value for transformers model
+            model.config.return_dict = orig_return_dict
+        except:
+            pass
         model = model.to(orig_device)
         return traced_model
 

--- a/test/3x/torch/quantization/weight_only/test_awq.py
+++ b/test/3x/torch/quantization/weight_only/test_awq.py
@@ -8,7 +8,7 @@ import transformers
 from neural_compressor.common import Logger
 
 logger = Logger().get_logger()
-from neural_compressor.torch.algorithms.weight_only.modules import WeightOnlyLinear
+from neural_compressor.torch.algorithms.weight_only.modules import MulLinear, WeightOnlyLinear
 from neural_compressor.torch.quantization import AWQConfig, convert, get_default_awq_config, prepare, quantize
 from neural_compressor.torch.utils import accelerator
 
@@ -68,6 +68,7 @@ class TestAWQQuant:
 
         # default awq_quantize is 4 bits, 32 group size, use big atol=1e-1
         if (bits, use_sym, group_size) == (8, True, -1):
+            assert not isinstance(qdq_model.transformer.h[0].attn.k_proj, MulLinear), "mul in k_proj should be folded."
             assert torch.allclose(out, self.label, atol=1e-2), "Accuracy gap atol > 0.01 is unexpected."
         elif (bits, use_sym, group_size) == (2, True, 8):
             assert torch.allclose(out, self.label, atol=0.5), "Accuracy gap atol > 0.5 is unexpected."


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Currenly, AWQ UTs doesn't set return_dict/torchscript for transformers model, so the GraphTrace is always failed.
MulLinear will be inserted to help AWQ work, and is not necessary. 
Ber this PR, return_dict is automatically set and make AWQ ease-of-use. 

## Expected Behavior & Potential Risk

UT pass

