### PR TITLE
Fix WOQ Linear pack/unpack slow issue 2x

### DIFF
--- a/neural_compressor/adaptor/torch_utils/model_wrapper.py
+++ b/neural_compressor/adaptor/torch_utils/model_wrapper.py
@@ -421,7 +421,7 @@ class WeightOnlyLinear(torch.nn.Module):
         # pack weight
         self.qweight.copy_(self.pack_tensor(int_weight))
         if not self.use_optimum_format and self.compression_dim == 0:
-            self.qweight = self.qweight.T.contiguous()
+            self.qweight = self.qweight.t_().contiguous()
 
         if zp is not None:
             zp = zp.to(self.device)


### PR DESCRIPTION
## Type of Change

bug fix

## Description
solution: use numpy for pack_tensor/unpack_tensor
As we found that cuda is more quick than cpu in some cases, we use below behavior as default.

```
def pack_tensor():
  if 'cuda' in self.device:  # may be xpu also needs it
      pack_tensor_with_torch()
  else:
      pack_tensor_with_numpy()
```
local test on Xeon(R) 6248
code: https://github.com/intel/intel-extension-for-transformers/tree/main/examples/huggingface/pytorch/text-generation/quantization

cmd: `python run_generation_cpu_woq.py  --model Phi-3-mini-4k-instruct     --woq     --woq_algo Rtn 2>&1 | tee test_np.log`

original result
```
2024-05-29 10:27:16 [INFO] Pass quantize model elapsed time: 1050.21 ms
2024-05-29 10:27:16 [INFO] Save tuning history to /home2/kaihuita/code/intel-extension-for-transformers/examples/huggingface/pytorch/text-generation/quantization/nc_workspace/2024-05-29_10-27-08/./history.snapshot.
2024-05-29 10:27:16 [INFO] [Strategy] Found the model meets accuracy requirements, ending the tuning process.
2024-05-29 10:27:16 [INFO] Specified timeout or max trials is reached! Found a quantized model which meet accuracy goal. Exit.
2024-05-29 10:27:16 [INFO] Save deploy yaml to /home2/kaihuita/code/intel-extension-for-transformers/examples/huggingface/pytorch/text-generation/quantization/nc_workspace/2024-05-29_10-27-08/deploy.yaml
2024-05-29 10:31:28 [INFO] WeightOnlyQuant done.
2024-05-29 10:36:21 [INFO] Configuration saved in ./saved_results/quantize_config.json
```

numpy result (this PR)
```
2024-06-04 11:28:33 [INFO] Pass quantize model elapsed time: 1242.06 ms
2024-06-04 11:28:33 [INFO] Save tuning history to /home2/kaihuita/code/intel-extension-for-transformers/examples/huggingface/pytorch/text-generation/quantization/nc_workspace/2024-06-04_11-27-20/./history.snapshot.
2024-06-04 11:28:33 [INFO] [Strategy] Found the model meets accuracy requirements, ending the tuning process.
2024-06-04 11:28:33 [INFO] Specified timeout or max trials is reached! Found a quantized model which meet accuracy goal. Exit.
2024-06-04 11:28:33 [INFO] Save deploy yaml to /home2/kaihuita/code/intel-extension-for-transformers/examples/huggingface/pytorch/text-generation/quantization/nc_workspace/2024-06-04_11-27-20/deploy.yaml
2024-06-04 11:29:46 [INFO] WeightOnlyQuant done.
2024-06-04 11:31:42 [INFO] Configuration saved in ./saved_results/quantize_config.json
```



## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
