### PR TITLE
Add fallback support for HQQ

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/hqq/quantizer.py
+++ b/neural_compressor/torch/algorithms/weight_only/hqq/quantizer.py
@@ -149,5 +149,8 @@ class HQQuantizer(Quantizer):
             if quant_config.skip_lm_head and "lm_head" in op_name:
                 logger.warning("Skip quantizing %s due to `skip_lm_head` is True.", op_name)
                 continue
+            if quant_config is not None and quant_config.dtype == "fp32":
+                logger.warning("Fallback %s.", op_name)
+                continue
             qconfig_mapping[op_name] = self._convert_hqq_module_config(quant_config)
         return qconfig_mapping

--- a/neural_compressor/torch/quantization/config.py
+++ b/neural_compressor/torch/quantization/config.py
@@ -1179,6 +1179,7 @@ class HQQConfig(BaseConfig):
 
     def __init__(
         self,
+        dtype: str = "int",
         bits: int = 4,
         group_size: int = 64,
         quant_zero: bool = True,
@@ -1188,6 +1189,7 @@ class HQQConfig(BaseConfig):
         white_list: Optional[List[OP_NAME_OR_MODULE_TYPE]] = DEFAULT_WHITE_LIST,
     ):
         super().__init__(white_list=white_list)
+        self.dtype = dtype
         self.bits = bits
         self.group_size = group_size
         self.quant_zero = quant_zero


### PR DESCRIPTION
## Type of Change

feature 
API changed or not:

```python
quant_config = HQQConfig().set_local("fc1", HQQConfig(dtype="fp32"))
qmodel = convert(prepare(model=ToyModel(), quant_config=quant_config))
```

## How has this PR been tested?
Pre-CI

## Dependency Change?
None
