### PR TITLE
Update the Gaudi container example in the README and fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,12 @@ pip install "neural-compressor>=2.3" "transformers>=4.34.0" torch torchvision
 After successfully installing these packages, try your first quantization program.
 
 ### Weight-Only Quantization (LLMs)
-Following example code demonstrates Weight-Only Quantization on LLMs, it supports Intel CPU, Intel Gauid2 AI Accelerator, Nvidia GPU, best device will be selected automatically. 
+Following example code demonstrates Weight-Only Quantization on LLMs, it supports Intel CPU, Intel Gaudi2 AI Accelerator, Nvidia GPU, best device will be selected automatically. 
 
 To try on Intel Gaudi2, docker image with Gaudi Software Stack is recommended, please refer to following script for environment setup. More details can be found in [Gaudi Guide](https://docs.habana.ai/en/latest/Installation_Guide/Bare_Metal_Fresh_OS.html#launch-docker-image-that-was-built). 
 ```bash
+# Run a container with an interactive shell
 docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.14.0/ubuntu22.04/habanalabs/pytorch-installer-2.1.1:latest
-
-# Check the container ID
-docker ps
-
-# Login into container
-docker exec -it <container_id> bash
 
 # Install the optimum-habana
 pip install --upgrade-strategy eager optimum[habana]


### PR DESCRIPTION
## Type of Change

This PR fixes a bug in the documentation for running a Gaudi container and fixes a misspelling (`Gauid2` ➡️  `Gaudi2`).

## Description

 The `docker run` command is using `-it` which will run the container with an interactive shell. The two commands after the `docker run` (`docker ps` and `docker exec`) aren't needed since you are already in the container at that point, and they will fail if the user tries to do run them:
```
$ docker run -it --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --net=host --ipc=host vault.habana.ai/gaudi-docker/1.14.0/ubuntu22.04/habanalabs/pytorch-installer-2.1.1:latest
 * Starting OpenBSD Secure Shell server sshd                                                                                                                                                                                                   [ OK ] 
root@<machine>:/# docker ps
bash: docker: command not found
```

I removed the `docker ps` and `docker exec`.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

I tested the updated example on a Gaudi 2 machine. I also noticed that when running this example, only one Gaudi card seemed to be used (I watched `hl-smi` as the example ran). Is this expected? If so, the example could also be updated to specify a single Gaudi processor for `HABANA_VISIBLE_DEVICES` instead of `all`.

## Dependency Change?

None
