### PR TITLE
remove peft from installation requirement

### DIFF
--- a/requirements_pt.txt
+++ b/requirements_pt.txt
@@ -1,6 +1,5 @@
 numba
 numpy < 2.0
-peft
 prettytable
 psutil
 py-cpuinfo

--- a/test/3x/torch/requirements.txt
+++ b/test/3x/torch/requirements.txt
@@ -2,6 +2,7 @@ auto_round @ git+https://github.com/intel/auto-round.git@e24b9074af6cdb099e31c92
 expecttest
 intel_extension_for_pytorch
 numpy
+peft
 prettytable
 psutil
 pytest


### PR DESCRIPTION
## Type of Change

others  

## Description

remove peft from installation requirement.
peft is a higher-level package than transformer, and we should not introduce it in the installation requirements
