### PR TITLE
[Document] Update Gaudi version mapping table for v3.1

### DIFF
--- a/docs/source/3x/gaudi_version_map.md
+++ b/docs/source/3x/gaudi_version_map.md
@@ -13,4 +13,10 @@
             <td>v1.17</td>
         </tr>
     </tbody>
+    <tbody>
+        <tr>
+            <td>v3.1</td>
+            <td>v1.18</td>
+        </tr>
+    </tbody>
 </table>


### PR DESCRIPTION
## Type of Change

 documentation 

rendered [page ](https://github.com/intel/neural-compressor/blob/thuang6/update_ver_map/docs/source/3x/gaudi_version_map.md)