### PR TITLE
Fix fp8 scoped all reduce for modules with bias

### DIFF
--- a/neural_compressor/torch/algorithms/fp8_quant/_quant_common/helper_modules.py
+++ b/neural_compressor/torch/algorithms/fp8_quant/_quant_common/helper_modules.py
@@ -414,8 +414,10 @@ class PatchedLinearAllReduce(nn.Module):
             dist.inference_all_reduce(input, group=self.mp_group)
 
     def post_all_reduce(self, input):
-        output = input + self.bias if (self.bias is not None) else input
-        return output
+        # inplace addition needed for correct results
+        if self.bias is not None:
+            input += self.bias
+        return input
 
     def extra_repr(self) -> str:
         return extra_representation(


### PR DESCRIPTION
## Type of Change

Fixes a bug in fp8 `PatchedLinearAllReduce` scoped version for modules with bias

## Description

Use in-place addition to update the bias in `post_all_reduce`  so that the model yields correct output.

## Expected Behavior & Potential Risk

The bug was found while testing fp8 quantization for starcoder2 model in optimum-habana. The bug causes incorrect model output on Gaudi as shown below:

```
git clone https://github.com/huggingface/optimum-habana.git
cd optimum-habana
pip install -e .
pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.18.0
cd examples/text-generation
QUANT_CONFIG=./quantization_config/maxabs_measure.json python ../gaudi_spawn.py --use_deepspeed --world_size 2 run_generation.py --model_name_or_path bigcode/starcoder2-15b --use_hpu_graphs --trust_remote_code --attn_softmax_bf16 --trim_logits --use_kv_cache --use_flash_attention --flash_attention_recompute --max_new_tokens 128 --batch_size 1 --bf16 --prompt "def is_prime():"
```
Output without the fix:
output 1: ('def is_prime():\x89tFo_Fo_ \\s%nu|\\\\LL_LL)\ntt=> namemap (LL-\\\\LL0LL-LL-\\\\LL testInstances",LLÏ????LL testInstances",LL toolSettings:LL;LL-\\\\LLLLjooFoLL-LLJJLL-LLLLLL-\\\\LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL toolSettings (LL namemap \\LLLLLL toolSettings (LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL namemap \\LL_LLLLLLLLLLLL',)

## How has this PR been tested?
This fix was tested on Gaudi2/Gaudi3 with Pytorch-2.4.0-1.18.0 and optimum-habana. 

Output with the fix:
output 1: ('def is_prime():\n    for i in range(2, int(math.sqrt(n)) + 1):\n        if n % i == 0:\n            return False\n    return True\n\ndef is_palindrome():\n    return str(n) == str(n)[::-1]\n\ndef is_lychrel():\n    for i in range(50):\n        n = n + int(str(n)[::-1])\n        if is_palindrome():\n            return False\n    return True\n\ncount = 0\nfor i in range(10000):\n    if is_lychrel():',)

## Dependency Change?

any library dependency introduced or removed
