### PR TITLE
fix GPTQ oom issue on HPU

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/gptq.py
+++ b/neural_compressor/torch/algorithms/weight_only/gptq.py
@@ -587,7 +587,7 @@ class RAWGPTQuantizer(object):
 
                         W = load_value(self.model, full_layer_name + ".weight", self.model_path)
                     else:
-                        if "hpu" in self.device:
+                        if "hpu" in self.device:  # pragma: no cover
                             # [SW-206677] memory is not release when module is moved out of HPU
                             sequential_layers[layer_name] = sequential_layers[layer_name].cpu()
                             W = sequential_layers[layer_name].weight.data.clone()
@@ -801,7 +801,7 @@ class RAWGPTQuantizer(object):
                     full_layer_name = self.gptq_related_blocks["transformers_post"]["name"]
                     W = load_value(self.model, full_layer_name + ".weight", self.model_path)
                 else:
-                    if "hpu" in self.device:
+                    if "hpu" in self.device:  # pragma: no cover
                         # [SW-206677] memory is not release when module is moved out of HPU
                         sub_layers[layer_name] = sub_layers[layer_name].cpu()
                         W = sub_layers[layer_name].weight.data.clone()
@@ -1145,7 +1145,7 @@ class GPTQ:
             zero.append(self.quantizer.zero)
         scale = torch.cat(scale, dim=1)
         zero = torch.cat(zero, dim=1)
-        if "hpu" in self.device:
+        if "hpu" in self.device:  # pragma: no cover
             scale = scale.to(self.device)
             zero = zero.to(self.device)
             Q = Q.to(self.device)

--- a/neural_compressor/torch/algorithms/weight_only/gptq.py
+++ b/neural_compressor/torch/algorithms/weight_only/gptq.py
@@ -881,13 +881,13 @@ class RAWGPTQuantizer(object):
             for layer_name in sub_layers:
                 full_layer_name = self.gptq_related_blocks["transformers_post"]["name"]
                 weight_config_this_layer = self.get_layer_config(full_layer_name)
-                gptq_scale = gptq_config[full_layer_name]["scale"]
+                gptq_scale = gptq_config[full_layer_name]["scale"].cpu()
                 if not weight_config_this_layer["sym"]:
-                    gptq_zp = gptq_config[full_layer_name]["zero"]
+                    gptq_zp = gptq_config[full_layer_name]["zero"].cpu()
                 else:
                     gptq_zp = None
                 if weight_config_this_layer["act_order"]:  # save perm for restoring the weights
-                    gptq_perm = gptq_config[full_layer_name]["perm"]
+                    gptq_perm = gptq_config[full_layer_name]["perm"].cpu()
                 else:
                     gptq_perm = None
                 if self.use_layer_wise:  # pragma: no cover
@@ -940,7 +940,7 @@ class RAWGPTQuantizer(object):
                     zp=gptq_zp is not None,
                     bias=bias is not None,
                     g_idx=gptq_perm is not None,
-                    device=self.device,
+                    device="cpu",
                 )
                 new_module.pack(int_weight, gptq_scale, gptq_zp, bias, gptq_perm)
                 set_module(self.model, layer_name, new_module)

--- a/neural_compressor/torch/algorithms/weight_only/gptq.py
+++ b/neural_compressor/torch/algorithms/weight_only/gptq.py
@@ -587,7 +587,10 @@ class RAWGPTQuantizer(object):
 
                         W = load_value(self.model, full_layer_name + ".weight", self.model_path)
                     else:
+                        # [SW-206677] memory is not release when module is moved out of HPU
+                        sequential_layers[layer_name] = sequential_layers[layer_name].cpu()
                         W = sequential_layers[layer_name].weight.data.clone()
+                        sequential_layers[layer_name] = sequential_layers[layer_name].to("hpu")
 
                     gptq_for_this_block[layer_name] = GPTQ(sequential_layers[layer_name], W, self.device)
                     # gptq_for_this_block[layer_name].quantizer = Quantizer()


### PR DESCRIPTION
## Type of Change

bug fix

## Description

some memory is not released due to lack of `torch.hpu.synchronize()` and `gc.collect()`
Making sure the process is working as below:
![image](https://github.com/user-attachments/assets/4f4740d2-ad50-4fb5-8b1b-dcc4287703e6)

## Expected Behavior & Potential Risk

llama2-70b works on one Gaudi2 card.
