### PR TITLE
add buckets setting for lm_eval

### DIFF
--- a/neural_compressor/evaluation/lm_eval/accuracy.py
+++ b/neural_compressor/evaluation/lm_eval/accuracy.py
@@ -199,6 +199,7 @@ def cli_evaluate(args) -> None:
             },
         )
     lm.pad_to_buckets = args.pad_to_buckets
+    lm.buckets = args.buckets
 
     results = evaluator.simple_evaluate(
         model=lm,

--- a/neural_compressor/evaluation/lm_eval/utils.py
+++ b/neural_compressor/evaluation/lm_eval/utils.py
@@ -49,7 +49,7 @@ class LMEvalParser:
         seed=[0, 1234, 1234],
         trust_remote_code=False,
         pad_to_buckets=None,  # used by HPU to align input length for performance.
-        buckets=[64, 128, 256, 512, 1024, 2048],  # used by HPU to limit input length range.
+        buckets=[32, 64, 128, 256, 512, 1024, 2048, 4096],  # used by HPU to limit input length range.
     ):
         self.model = model
         self.tasks = tasks

--- a/neural_compressor/evaluation/lm_eval/utils.py
+++ b/neural_compressor/evaluation/lm_eval/utils.py
@@ -49,6 +49,7 @@ class LMEvalParser:
         seed=[0, 1234, 1234],
         trust_remote_code=False,
         pad_to_buckets=None,  # used by HPU to align input length for performance.
+        buckets=[64, 128, 256, 512, 1024, 2048],  # used by HPU to limit input length range.
     ):
         self.model = model
         self.tasks = tasks
@@ -81,3 +82,4 @@ class LMEvalParser:
                 self.pad_to_buckets = False
         else:
             self.pad_to_buckets = pad_to_buckets
+        self.buckets = buckets


### PR DESCRIPTION
## Type of Change

feature

## Description

add buckets argument for lm_eval, it is used by HPU to limit static input length range.
By default, `buckets: Optional[list] = [64, 128, 256, 512, 1024, 2048, 4096]`


If default buckets are not enough to hold input length, it will cause error.
If used buckets is too many, it will take too much memory. (Each used bucket will cause the model to be copied)

