### PR TITLE
[BUG Fix] Fix forward list based on latest vllm-fork

### DIFF
--- a/neural_compressor/torch/algorithms/fp8_quant/_quant_common/helper_modules.py
+++ b/neural_compressor/torch/algorithms/fp8_quant/_quant_common/helper_modules.py
@@ -624,18 +624,14 @@ class PatchedVLLMKVCache(nn.Module):
             self.fetch_from_cache = mod.fetch_from_cache
             self.forward = self.forward_measure
 
-    def forward(self, input, cache, num_kv_cache_passes, num_slots_available, block_indices, block_offset):
+    def forward(self, input, *args, **kwargs):
         qinput = self.quant_input(input)
-        output_cache = self.forward_orig(
-            qinput, cache, num_kv_cache_passes, num_slots_available, block_indices, block_offset
-        )
+        output_cache = self.forward_orig(qinput, *args, **kwargs)
         return self.quant_output(output_cache)
 
-    def forward_measure(self, input, cache, num_kv_cache_passes, num_slots_available, block_indices, block_offset):
+    def forward_measure(self, input, *args, **kwargs):
         measure_input((input), self._mod_extra_config.inputs)
-        output_cache = self.forward_orig(
-            input, cache, num_kv_cache_passes, num_slots_available, block_indices, block_offset
-        )
+        output_cache = self.forward_orig(input, *args, **kwargs)
         measure_output((output_cache), self._mod_extra_config.outputs)
         return output_cache
 


### PR DESCRIPTION
## Type of Change

Fix forward list based on latest vllm-fork

## Description

In latest vllm-fork habana_main, KVcache forward arguments list is changed
![image](https://github.com/user-attachments/assets/b4c79ec9-9eea-4c5c-9e1e-10e5f4fd5c9a)
![image](https://github.com/user-attachments/assets/430800f8-a4c6-4431-b14c-d03b5a4b5fbd)

## Expected Behavior & Potential Risk

No

## How has this PR been tested?

Now we are able to use INC FP8 on vllm-fork habana_main 

## Dependency Change?

No