### PR TITLE
improve load_empty_model function.

### DIFF
--- a/neural_compressor/torch/utils/utility.py
+++ b/neural_compressor/torch/utils/utility.py
@@ -351,9 +351,8 @@ def load_empty_model(pretrained_model_name_or_path, cls=None, **kwargs):
     else:
         path = dowload_hf_model(pretrained_model_name_or_path)
     if cls.__base__ == _BaseAutoModelClass:
-        config = AutoConfig.from_pretrained(path, **kwargs)
         with init_empty_weights():
-            model = cls.from_config(config, **kwargs)
+            model = cls.from_pretrained(path, **kwargs)
     else:  # pragma: no cover
         config = cls.config_class.from_pretrained(path, **kwargs)
         with init_empty_weights():


### PR DESCRIPTION
## Type of Change

request from optimum-intel https://github.com/huggingface/optimum-intel/pull/1018#discussion_r1866211746
to make `load_empty_model` have the same input kwargs with `AutoModelForCausalLM.from_pretrained`


## Description

load_empty_function couldn't pass the **loading_kwargs from `AutoModelForCausalLM.from_pretrained` , because we initialize the config first, and then initialize the model in load_empty_model function. some loading_kwargs like "subfolder", "revision" doesn't be accepted by `AutoConfig.from_pretrained` kwargs.
https://github.com/intel/neural-compressor/blob/e2696603f45f5796f1c048aab33eef11aaeb2cdb/neural_compressor/torch/utils/utility.py#L356
when the **loading_kwargs passed, config initialization will raise error like the following.
![image](https://github.com/user-attachments/assets/a4cb7ffc-78e7-4b60-baeb-423e0277019b)
![image](https://github.com/user-attachments/assets/57b19fea-bea8-4d5a-81e8-3cddb9815788)


## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
