### PR TITLE
Fix sdxl `q_unet` config

### DIFF
--- a/examples/3.x_api/pytorch/diffusion_model/diffusers/stable_diffusion/smooth_quant/run_benchmark.sh
+++ b/examples/3.x_api/pytorch/diffusion_model/diffusers/stable_diffusion/smooth_quant/run_benchmark.sh
@@ -50,9 +50,6 @@ function run_benchmark {
 
     if [[ ${mode} == "performance" ]]; then
       extra_cmd=$extra_cmd" --performance"
-      if [[ ${int8} == "true" ]]; then
-        extra_cmd=$extra_cmd" --int8"
-      fi
       echo $extra_cmd
 
       python -u sdxl_smooth_quant.py \
@@ -60,9 +57,6 @@ function run_benchmark {
         --latent ${latent} \
         ${extra_cmd}
     else
-      if [[ ${int8} == "true" ]]; then
-        extra_cmd=$extra_cmd" --int8"
-      fi
       echo $extra_cmd
 
       python -u sdxl_smooth_quant.py \
@@ -82,7 +76,7 @@ function run_benchmark {
       cd mlperf_sd_inference
       cp ../main.py ./
       if [ -d "../saved_results/" ]; then
-        mv ../saved_results/ ./
+        cp -r ../saved_results/ ./
       fi
       
       python -u main.py \

--- a/examples/3.x_api/pytorch/diffusion_model/diffusers/stable_diffusion/smooth_quant/sdxl_smooth_quant.py
+++ b/examples/3.x_api/pytorch/diffusion_model/diffusers/stable_diffusion/smooth_quant/sdxl_smooth_quant.py
@@ -408,8 +408,8 @@ def main():
             q_unet = load(os.path.abspath(os.path.expanduser(args.output_dir)))
         else:
             q_unet = pipeline.unet
-
-    setattr(q_unet, "config", pipeline.unet.config)
+    if not hasattr(q_unet, "config"):
+        setattr(q_unet, "config", pipeline.unet.config)
     pipeline.unet = q_unet
     quant_images = prompts2images(pipeline, prompts, n_steps=args.n_steps, latent=init_latent)
     save_images(prompts, quant_images, args.output_dir, prefix='quant')

--- a/examples/3.x_api/pytorch/diffusion_model/diffusers/stable_diffusion/smooth_quant/sdxl_smooth_quant.py
+++ b/examples/3.x_api/pytorch/diffusion_model/diffusers/stable_diffusion/smooth_quant/sdxl_smooth_quant.py
@@ -406,10 +406,10 @@ def main():
         if args.int8:
             from neural_compressor.torch.quantization import load
             q_unet = load(os.path.abspath(os.path.expanduser(args.output_dir)))
-            setattr(q_unet, "config", pipeline.unet.config)
         else:
             q_unet = pipeline.unet
-    
+
+    setattr(q_unet, "config", pipeline.unet.config)
     pipeline.unet = q_unet
     quant_images = prompts2images(pipeline, prompts, n_steps=args.n_steps, latent=init_latent)
     save_images(prompts, quant_images, args.output_dir, prefix='quant')


### PR DESCRIPTION
## Type of Change

bug fix

## Description

- error

```AttributeError: 'StableDiffusionXLPipelineSQ' object has no attribute 'do_classifier_free_guidance'```

- solution

Set the config attribute of the quantized UNet to match the original UNet's config.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
