### PR TITLE
Fix `is_sharded` setting for loading quant model

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/save_load.py
+++ b/neural_compressor/torch/algorithms/weight_only/save_load.py
@@ -559,7 +559,7 @@ class WOQModelLoader:
             "_raise_exceptions_for_missing_entries": False,
             "_commit_hash": commit_hash,
         }
-        resolved_archive_file = self._get_resolved_archive_file(**kwargs)
+        resolved_archive_file, is_sharded = self._get_resolved_archive_file(**kwargs)
 
         self._model_local_dir = os.path.abspath(os.path.expanduser(os.path.dirname(resolved_archive_file)))
         # if hpu format tensor can be used directly, then update resolved_archive_file to the hpu format tensor file
@@ -623,6 +623,7 @@ class WOQModelLoader:
         subfolder = kwargs.get("subfolder")
 
         resolved_archive_file = None
+        is_sharded = False
         is_local = os.path.isdir(self.model_name_or_path)
         if is_local:  # pragma: no cover
             # self.model_name_or_path is a local directory
@@ -770,7 +771,7 @@ class WOQModelLoader:
         if is_local:
             resolved_archive_file = archive_file
 
-        return resolved_archive_file
+        return resolved_archive_file, is_sharded
 
     def _init_hf_model(self, model_class, config):
         from accelerate.big_modeling import init_empty_weights

--- a/test/3x/torch/quantization/weight_only/test_transfomers.py
+++ b/test/3x/torch/quantization/weight_only/test_transfomers.py
@@ -203,7 +203,6 @@ class TestTansformersLikeAPI:
         self.generate_kwargs = dict(do_sample=False, temperature=0.9, num_beams=4)
         gen_ids = user_model.generate(input_ids, **self.generate_kwargs)
         gen_text = tokenizer.batch_decode(gen_ids, skip_special_tokens=True)
-        # target_text = ["One day, the little girl in the back of my mind will ask me if I'm a"]
         if Version(transformers.__version__) < Version("4.47.0"):
             target_text = ["One day, the little girl in the back of my mind will ask me if I'm a"]
         else:

--- a/test/3x/torch/quantization/weight_only/test_transfomers.py
+++ b/test/3x/torch/quantization/weight_only/test_transfomers.py
@@ -3,6 +3,7 @@ from math import isclose
 
 import pytest
 import torch
+import transformers
 from packaging.version import Version
 from transformers import AutoTokenizer
 
@@ -202,5 +203,9 @@ class TestTansformersLikeAPI:
         self.generate_kwargs = dict(do_sample=False, temperature=0.9, num_beams=4)
         gen_ids = user_model.generate(input_ids, **self.generate_kwargs)
         gen_text = tokenizer.batch_decode(gen_ids, skip_special_tokens=True)
-        target_text = ["One day, the little girl in the back of my mind will ask me if I'm a"]
+        # target_text = ["One day, the little girl in the back of my mind will ask me if I'm a"]
+        if Version(transformers.__version__) < Version("4.47.0"):
+            target_text = ["One day, the little girl in the back of my mind will ask me if I'm a"]
+        else:
+            target_text = ["One day, the little girl in the back of my mind will say, “I’m so glad you’"]
         assert gen_text == target_text, "loading autoawq quantized model failed."

--- a/test/3x/torch/quantization/weight_only/test_transfomers.py
+++ b/test/3x/torch/quantization/weight_only/test_transfomers.py
@@ -3,7 +3,6 @@ from math import isclose
 
 import pytest
 import torch
-import transformers
 from packaging.version import Version
 from transformers import AutoTokenizer
 
@@ -203,8 +202,5 @@ class TestTansformersLikeAPI:
         self.generate_kwargs = dict(do_sample=False, temperature=0.9, num_beams=4)
         gen_ids = user_model.generate(input_ids, **self.generate_kwargs)
         gen_text = tokenizer.batch_decode(gen_ids, skip_special_tokens=True)
-        if Version(transformers.__version__) < Version("4.47.0"):
-            target_text = ["One day, the little girl in the back of my mind will ask me if I'm a"]
-        else:
-            target_text = ["One day, the little girl in the back of my mind will say, “I’m so glad you’"]
+        target_text = ["One day, the little girl in the back of my mind will ask me if I'm a"]
         assert gen_text == target_text, "loading autoawq quantized model failed."


### PR DESCRIPTION
## Type of Change

bug fix

## Description

```
raise EnvironmentError(
OSError: hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4 does not appear to have a file named model.safetensors. Checkout 'https://huggingface.co/hugging-quants/Meta-Llama-3.1-8B-Instruct-GPTQ-INT4/tree/main' for available files.
```

is_sharded not changed 
## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
