### PR TITLE
[SW-214087] Fix error message for different python version

### DIFF
--- a/test/3x/torch/algorithms/fp8_quant/unit_tests/test_functions/test_config_json.py
+++ b/test/3x/torch/algorithms/fp8_quant/unit_tests/test_functions/test_config_json.py
@@ -1,7 +1,7 @@
 """Use this module as an example of how to write new unit tests for layers."""
 
 import os
-
+import sys
 import pytest
 import torch
 
@@ -58,7 +58,12 @@ def test_predefined_config(lp_dtype, scale_method, quant_mode):
             run_with_raised_exception(run_predefined_config, FileNotFoundError, "Failed to load file ")
         # TODO [SW-196641]: fix the following issue:
         elif quant_mode == QuantMode.SHAPE:
-            run_with_raised_exception(run_predefined_config, UnboundLocalError, "local variable 'fname_base' referenced before assignment")
+            error_message = (
+                "cannot access local variable 'fname_base' where it is not associated with a value"
+                if sys.version_info >= (3, 11)
+                else "local variable 'fname_base' referenced before assignment"
+            )
+            run_with_raised_exception(run_predefined_config, UnboundLocalError, error_message)
     else:
         run_predefined_config()
 


### PR DESCRIPTION
## Type of Change

https://jira.habana-labs.com/browse/SW-214087
https://jira.devtools.intel.com/browse/ILITV-3839
## Description

The root cause is not the code itself but rather the environment. The IDC machine（local machine） uses Docker with Python 3.12.3, while the unit test's expected error message is based on Python 3.10. This discrepancy leads to an assertion error.

the python new unboundlocalerror message is introduced by python 3.11, https://github.com/python/cpython/blob/30efede33ca1fe32debbae93cc40b0e7e0b133b3/Python/ceval_macros.h#L351

In Python 3.12.3: UnboundLocalError: "cannot access local variable 'fname_base' where it is not associated with a value"
In Python 3.10.12: UnboundLocalError: "local variable 'fname_base' referenced before assignment"

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
