### PR TITLE
upgrade numpy from 1.23.5 to 1.26.4

### DIFF
--- a/requirements_pt.txt
+++ b/requirements_pt.txt
@@ -1,4 +1,4 @@
-numpy==1.23.5 ; python_version < '3.12'
+numpy==1.26.4 ; python_version < '3.12'
 numpy<2.0 ; python_version >= '3.12'
 prettytable
 psutil


### PR DESCRIPTION
## Type of Change

upgrade numpy from 1.23.5 to 1.26.4 for pytorch 3x
