### PR TITLE
Fix hf_device_map setting for transformers-like api

### DIFF
--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -226,11 +226,11 @@ class _BaseINCAutoModelClass:
 
         # add quantization_config and save_low_bit to pretrained model dynamically
         model.device_map = device_map
-        
+
         # StaticCache's device is initialized by `hf_device_map` in `from_pretrained` method.
         if hasattr(model, "hf_device_map"):
             device_map = torch.device(device_map) if isinstance(device_map, str) else device_map
-            model.hf_device_map = {"" : device_map}
+            model.hf_device_map = {"": device_map}
         model.quantization_config = quantization_config
 
         model.save_pretrained = types.MethodType(save_low_bit, model)

--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -226,8 +226,10 @@ class _BaseINCAutoModelClass:
 
         # add quantization_config and save_low_bit to pretrained model dynamically
         model.device_map = device_map
+        
         # StaticCache's device is initialized by `hf_device_map` in `from_pretrained` method.
-        model.hf_device_map = dict(device_map)
+        if hasattr(model, "hf_device_map"):
+            model.hf_device_map = {"" : model.device_map}
         model.quantization_config = quantization_config
 
         model.save_pretrained = types.MethodType(save_low_bit, model)

--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -229,7 +229,8 @@ class _BaseINCAutoModelClass:
         
         # StaticCache's device is initialized by `hf_device_map` in `from_pretrained` method.
         if hasattr(model, "hf_device_map"):
-            model.hf_device_map = {"" : model.device_map}
+            device_map = torch.device(device_map) if isinstance(device_map, str) else device_map
+            model.hf_device_map = {"" : device_map}
         model.quantization_config = quantization_config
 
         model.save_pretrained = types.MethodType(save_low_bit, model)

--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -226,6 +226,8 @@ class _BaseINCAutoModelClass:
 
         # add quantization_config and save_low_bit to pretrained model dynamically
         model.device_map = device_map
+        # StaticCache's device is initialized by `hf_device_map` in `from_pretrained` method.
+        model.hf_device_map = dict(device_map)
         model.quantization_config = quantization_config
 
         model.save_pretrained = types.MethodType(save_low_bit, model)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Business impact: The int4 llama model runs into crash with IPEX LLM workload.

Defect/regression: The error message is shown below:
![image](https://github.com/user-attachments/assets/82a514b9-b2d3-4465-9500-0e97624c6c77)



The root cause is that `hf_device_map` is assigned to `dict(device_map)` in [Accelerate ](https://github.com/huggingface/accelerate/blob/main/src/accelerate/big_modeling.py#L502)while `device_map` is changed to "cpu" in [INC](https://github.com/intel/neural-compressor/blob/master/neural_compressor/transformers/models/modeling_auto.py#L168). StaticCache's device is initialized by `hf_device_map` and is "cpu" while the other tensor's device is "xpu".

solution: add `hf_device_map` setting after quantization

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
