### PR TITLE
Add `update_g_idx` flag for setting qweight&g_idx

### DIFF
--- a/neural_compressor/transformers/quantization/utils.py
+++ b/neural_compressor/transformers/quantization/utils.py
@@ -238,7 +238,7 @@ def _replace_linear(
                             dtype=torch.int32,
                             device=torch.device(device),
                         )
-                    
+
                     # Note: update_g_idx is only applicable for ipex versions >=2.7
                     model._modules[name].set_weights_bias(
                         module.qweight.data if hasattr(module, "qweight") else weight,
@@ -247,7 +247,7 @@ def _replace_linear(
                             {"update_g_idx": not empty_weights}
                             if "update_g_idx" in model._modules[name].set_weights_bias.__code__.co_varnames
                             else {}
-                        )
+                        ),
                     )
                 else:
                     raise Exception("{} device Unsupported weight only quantization!".format(device))

--- a/neural_compressor/transformers/quantization/utils.py
+++ b/neural_compressor/transformers/quantization/utils.py
@@ -21,6 +21,7 @@ import re
 import types
 
 from datasets import load_dataset
+from packaging.version import Version
 
 from neural_compressor.common.utils import LazyImport, logger
 from neural_compressor.torch.algorithms.weight_only.modules import INCWeightOnlyLinear
@@ -34,12 +35,12 @@ from neural_compressor.torch.quantization import (
     convert,
     prepare,
 )
-from neural_compressor.torch.utils import is_ipex_available, is_package_available, get_ipex_version
-from packaging.version import Version
+from neural_compressor.torch.utils import get_ipex_version, is_ipex_available, is_package_available
 
 if is_ipex_available():
     import intel_extension_for_pytorch as ipex
-    ipex_version= get_ipex_version()
+
+    ipex_version = get_ipex_version()
 
 if is_package_available("auto_round"):
     import auto_round

--- a/neural_compressor/transformers/quantization/utils.py
+++ b/neural_compressor/transformers/quantization/utils.py
@@ -241,6 +241,7 @@ def _replace_linear(
                     model._modules[name].set_weights_bias(
                         module.qweight.data if hasattr(module, "qweight") else weight,
                         None if module.bias is None else module.bias.data,
+                        update_g_idx=not empty_weights,
                     )
                 else:
                     raise Exception("{} device Unsupported weight only quantization!".format(device))

--- a/neural_compressor/transformers/quantization/utils.py
+++ b/neural_compressor/transformers/quantization/utils.py
@@ -21,7 +21,6 @@ import re
 import types
 
 from datasets import load_dataset
-from packaging.version import Version
 
 from neural_compressor.common.utils import LazyImport, logger
 from neural_compressor.torch.algorithms.weight_only.modules import INCWeightOnlyLinear

--- a/neural_compressor/transformers/quantization/utils.py
+++ b/neural_compressor/transformers/quantization/utils.py
@@ -35,7 +35,10 @@ from neural_compressor.torch.quantization import (
     convert,
     prepare,
 )
-from neural_compressor.torch.utils import  is_package_available
+from neural_compressor.torch.utils import is_ipex_available, is_package_available
+
+if is_ipex_available():
+    import intel_extension_for_pytorch as ipex
 
 if is_package_available("auto_round"):
     import auto_round


### PR DESCRIPTION
## Type of Change

bug fix

## Description
```
error:
 [ERROR][modeling_auto.py:128] index 133 is out of bounds for dimension 0 with size 128
 [ERROR][modeling_auto.py:129] Saved low bit model loading failed, please check your model.
```
add `update_g_idx` flag to avoid secondary value updates.
note:
waiting for the release of ipex-gpu v2.7 ...
related PR: https://github.com/intel-innersource/frameworks.ai.pytorch.ipex-gpu/pull/5411

results:
meta-llama/Meta-Llama-3-8B-Instruct on PVC
|    Tasks     |Version|Filter|n-shot|  Metric  |   |Value |   |Stderr|
|--------------|------:|------|-----:|----------|---|-----:|---|-----:|
|lambada_openai|      1|none  |     0|acc       |↑  |0.7093|±  |0.0063|
|              |       |none  |     0|perplexity|↓  |3.5535|±  |0.0997|

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
