### PR TITLE
Reset `accelerator` when `INC_TARGET_DEVICE` is set in code

### DIFF
--- a/neural_compressor/torch/utils/environ.py
+++ b/neural_compressor/torch/utils/environ.py
@@ -151,10 +151,7 @@ def get_accelerator(device_name="auto"):
 
     accelerator = auto_detect_accelerator(device_name)
     inc_target_device = os.environ.get("INC_TARGET_DEVICE", None)
-    if (
-        inc_target_device is not None
-        and accelerator._name != inc_target_device.lower()
-    ):
+    if inc_target_device is not None and accelerator._name != inc_target_device.lower():
         auto_detect_accelerator.cache_clear()
         accelerator = auto_detect_accelerator(device_name)
     return accelerator

--- a/neural_compressor/torch/utils/environ.py
+++ b/neural_compressor/torch/utils/environ.py
@@ -150,9 +150,10 @@ def get_accelerator(device_name="auto"):
     from neural_compressor.torch.utils.auto_accelerator import auto_detect_accelerator
 
     accelerator = auto_detect_accelerator(device_name)
+    inc_target_device = os.environ.get("INC_TARGET_DEVICE", None)
     if (
-        os.environ.get("INC_TARGET_DEVICE", None) is not None
-        and accelerator._name != os.environ.get("INC_TARGET_DEVICE", None).lower()
+        inc_target_device is not None
+        and accelerator._name != inc_target_device.lower()
     ):
         auto_detect_accelerator.cache_clear()
         accelerator = auto_detect_accelerator(device_name)

--- a/neural_compressor/torch/utils/environ.py
+++ b/neural_compressor/torch/utils/environ.py
@@ -150,6 +150,10 @@ def get_accelerator(device_name="auto"):
     from neural_compressor.torch.utils.auto_accelerator import auto_detect_accelerator
 
     accelerator = auto_detect_accelerator(device_name)
+    if os.environ.get("INC_TARGET_DEVICE", None) is not None and \
+        accelerator._name != os.environ.get("INC_TARGET_DEVICE", None).lower():
+        auto_detect_accelerator.cache_clear()
+        accelerator = auto_detect_accelerator(device_name)
     return accelerator
 
 

--- a/neural_compressor/torch/utils/environ.py
+++ b/neural_compressor/torch/utils/environ.py
@@ -150,8 +150,10 @@ def get_accelerator(device_name="auto"):
     from neural_compressor.torch.utils.auto_accelerator import auto_detect_accelerator
 
     accelerator = auto_detect_accelerator(device_name)
-    if os.environ.get("INC_TARGET_DEVICE", None) is not None and \
-        accelerator._name != os.environ.get("INC_TARGET_DEVICE", None).lower():
+    if (
+        os.environ.get("INC_TARGET_DEVICE", None) is not None
+        and accelerator._name != os.environ.get("INC_TARGET_DEVICE", None).lower()
+    ):
         auto_detect_accelerator.cache_clear()
         accelerator = auto_detect_accelerator(device_name)
     return accelerator


### PR DESCRIPTION
## Type of Change

feature 

## Description

When we set the environment variable `INC_TARGET_DEVICE` in the code, this setting does not take effect and the previously cached accelerator from lru_cache is used instead.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
