### PR TITLE
Fix text-to-image example

### DIFF
--- a/examples/pytorch/nlp/huggingface_models/text-to-image/quantization/README.md
+++ b/examples/pytorch/nlp/huggingface_models/text-to-image/quantization/README.md
@@ -23,7 +23,7 @@ FID metric is used to evaluate the model in this case, so we should download [tr
 python run_diffusion.py \
     --model_name_or_path lambdalabs/sd-pokemon-diffusers \
     --tune \
-    --quantization_approach PostTrainingStatic \
+    --quantization_approach static \
     --perf_tol 0.02 \
     --output_dir /tmp/diffusion_output \
     --base_images base_images \


### PR DESCRIPTION
## Type of Change
- Simple bug fix (in documentation)
- API not changed

## Description
Example in README is crashing due to invalid argument passing

**Before fix:**
Output **Error**:
```bash
Traceback (most recent call last):
  File "/root/flux_peft_fp8/neural-compressor/examples/pytorch/nlp/huggingface_models/text-to-image/quantization/run_diffusion.py", line 337, in <module>
    main()
  File "/root/flux_peft_fp8/neural-compressor/examples/pytorch/nlp/huggingface_models/text-to-image/quantization/run_diffusion.py", line 290, in main
    quantization_config = PostTrainingQuantConfig(
  File "/usr/local/lib/python3.10/dist-packages/neural_compressor/config.py", line 1322, in __init__
    self.approach = approach
  File "/usr/local/lib/python3.10/dist-packages/neural_compressor/config.py", line 1337, in approach
    if _check_value("approach", approach, str, ["static", "dynamic", "auto", "weight_only"]):
  File "/usr/local/lib/python3.10/dist-packages/neural_compressor/config.py", line 102, in _check_value
    assert False, "{} is not in supported {}: {}. Skip setting it.".format(src, name, str(supported_value))
AssertionError: PostTrainingStatic is not in supported approach: ['static', 'dynamic', 'auto', 'weight_only']. Skip setting it.
```

**After fix:**
Output **OK**
