### PR TITLE
Add `add_bos_token` for Llama3 evaluation

### DIFF
--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/run_generation_cpu_woq.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/run_generation_cpu_woq.py
@@ -388,7 +388,7 @@ if args.accuracy:
                         model_args=model_args,
                         tasks = args.tasks,
                         device = "cpu",
-                        batch_size = args.eval_batch_size
+                        batch_size = args.eval_batch_size,
                         add_bos_token = args.add_bos_token,)
     results = evaluate(args)
     for task_name in args.tasks.split(","):

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/run_generation_cpu_woq.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/run_generation_cpu_woq.py
@@ -40,6 +40,7 @@ parser.add_argument(
     type=str,
     help="tasks list for accuracy validation",
 )
+parser.add_argument("--add_bos_token", action="store_true", help="whether to add bos token for accuracy validation.")
 # ============WeightOnlyQuant configs===============
 parser.add_argument("--woq", action="store_true")
 parser.add_argument(
@@ -387,7 +388,8 @@ if args.accuracy:
                         model_args=model_args,
                         tasks = args.tasks,
                         device = "cpu",
-                        batch_size = args.eval_batch_size)
+                        batch_size = args.eval_batch_size
+                        add_bos_token = args.add_bos_token,)
     results = evaluate(args)
     for task_name in args.tasks.split(","):
         if task_name == "wikitext":


### PR DESCRIPTION
## Type of Change

bug fix 

## Description

model: meta-llama/Llama-3.1-8B-Instruct
`add_bos_token` default is False.
If the model was trained or fine-tuned with a BOS token, this may lead to incorrect results.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
