### PR TITLE
Fix `g_idx` init in transformers-like API

### DIFF
--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -70,6 +70,7 @@ def build_woq_model(model, quantization_config):
                 not getattr(quantization_config, "sym", False),
             )
             use_optimum_format = True
+            g_idx = hasattr(m, "g_idx") and m.g_idx is not None
 
             with init_empty_weights():
                 new_module = INCWeightOnlyLinear(
@@ -80,7 +81,7 @@ def build_woq_model(model, quantization_config):
                     group_size=quantization_config.group_size,
                     zp=zp,
                     bias=m.bias is not None,
-                    g_idx=True,
+                    g_idx=g_idx,
                     use_optimum_format=use_optimum_format,
                 )
             set_module(model, n, new_module)

--- a/neural_compressor/transformers/quantization/utils.py
+++ b/neural_compressor/transformers/quantization/utils.py
@@ -206,14 +206,8 @@ def _replace_linear(
                         device=device,
                         use_optimum_format=getattr(module, "use_optimum_format", True),
                     )
-                    if quantization_config.quant_method.value == "gptq":
-                        g_idx = getattr(
-                            module,
-                            "g_idx",
-                            torch.zeros(in_features, dtype=torch.int32).to(device),
-                        )
-                    else:
-                        g_idx = None
+                    # g_idx is only present when using GPTQ quantization method
+                    g_idx = module.g_idx if hasattr(module, "g_idx") else None
                     model._modules[name].set_scales_zps_gidx(
                         (
                             module.scales


### PR DESCRIPTION
## Type of Change

 bug fix 

## Description
error:
```
The size of tensor a (4096) must match the size of tensor b (128) at non-singleton dimension 0
```

When loading a GPTQ INT8 model, g_idx should be either None or a correct value, rather than a tensor of zeros.
![image](https://github.com/user-attachments/assets/1c84a879-d236-4651-9668-73b675ddfd7e)

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
