### PR TITLE
Add `add_bos_token` for Llama3(Instruct) xpu evaluation

### DIFF
--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/run_generation_gpu_woq.py
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/run_generation_gpu_woq.py
@@ -50,6 +50,7 @@ parser.add_argument("--save_accuracy_path", default=None,
                     help="Save accuracy results path.")
 parser.add_argument("--tasks", default="lambada_openai", type=str, \
                     help="tasks list for accuracy validation")
+parser.add_argument("--add_bos_token", action="store_true", help="whether to add bos token for accuracy validation.")
 # ============WeightOnlyQuant configs===============
 parser.add_argument("--bits", type=int, default=4, choices=[4])
 parser.add_argument("--woq", action="store_true")
@@ -339,7 +340,8 @@ if args.accuracy:
                         user_model = user_model,
                         tasks = args.tasks,
                         device = args.device,
-                        batch_size = args.eval_batch_size)
+                        batch_size = args.eval_batch_size,
+                        add_bos_token = args.add_bos_token,)
     results = evaluate(args)
     for task_name in args.tasks.split(","):
         if task_name == "wikitext":


### PR DESCRIPTION
## Type of Change

example

## Description

model: meta-llama/Llama-3.1-8B-Instruct
add_bos_token default is False.
If the model was trained or fine-tuned with a BOS token, this may lead to incorrect results.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
