### PR TITLE
Set a string to `tokenizer` to initialize AutoRound

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/autoround.py
+++ b/neural_compressor/torch/algorithms/weight_only/autoround.py
@@ -166,7 +166,7 @@ class AutoRoundQuantizer(Quantizer):
             The quantized model.
         """
         super().__init__(quant_config)
-        self.tokenizer = "Placeholder" # for AutoRound initialization
+        self.tokenizer = "Placeholder"  # for AutoRound initialization
         self.enable_full_range = enable_full_range
         self.batch_size = batch_size
         self.amp = amp


### PR DESCRIPTION
## Type of Change

bug fix 

## Description

set "Placeholder" str to `tokenizer` to skip AutoRound initialization check

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
