### PR TITLE
Use --index-url instead of --extra-index-url for oneccl_bind_pt

### DIFF
--- a/.azure-pipelines/scripts/install_nc.sh
+++ b/.azure-pipelines/scripts/install_nc.sh
@@ -11,7 +11,7 @@ if [[ $1 = *"3x_pt"* ]]; then
     else
         echo -e "\n Install torch CPU ... "
         pip install torch==2.7.0 torchvision --index-url https://download.pytorch.org/whl/cpu
-        python -m pip install intel-extension-for-pytorch==2.7.0 oneccl_bind_pt==2.7.0 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
+        python -m pip install intel-extension-for-pytorch==2.7.0 oneccl_bind_pt==2.7.0 --index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
         python -m pip install --no-cache-dir -r requirements.txt
         python setup.py bdist_wheel
     fi

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/requirements_cpu_woq.txt
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/requirements_cpu_woq.txt
@@ -16,5 +16,5 @@ huggingface_hub
 numba
 tbb
 intel-extension-for-pytorch==2.4.0
---extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
+--index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
 oneccl_bind_pt==2.4.0


### PR DESCRIPTION
## Type of Change



## Description

Use --index-url instead of --extra-index-url for oneccl_bind_pt, fix the code attack risk.  
If the attacker release a oneccl_bind_pt in pypi, the pip will pull the code from the attacker controlled package (released in pypi)! This leads to remote code execution.    
https://intelait.intel.com/nav_to.do?uri=%2Fx_volt2_csi_product_vulnerability.do%3Fsys_id%3Deaea4203df2fa21068deb094c23889ee%26sysparm_view%3Dcsi%26sysparm_view_forced%3Dtrue 

## Expected Behavior & Potential Risk

Restrict the oneccl_bind_pt source. 

## How has this PR been tested?

CI test. 

## Dependency Change?

any library dependency introduced or removed
