### PR TITLE
Adapt transformers 4.56.0

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/save_load.py
+++ b/neural_compressor/torch/algorithms/weight_only/save_load.py
@@ -937,7 +937,10 @@ class WOQModelLoader:
                 else:  # pragma: no cover
                     assert False, f'`torch_dtype` can be either `torch.dtype` or `"auto"`, but received {torch_dtype}'
 
-            dtype_orig = model_class._set_default_dtype(torch_dtype)
+            if parse(transformers.__version__) >= parse("4.56.0"):
+                dtype_orig = model_class._set_default_dtype(torch_dtype)
+            else:
+                dtype_orig = model_class._set_default_torch_dtype(torch_dtype)
 
         init_contexts = (
             [no_init_weights(_enable=_fast_init)]

--- a/neural_compressor/torch/algorithms/weight_only/save_load.py
+++ b/neural_compressor/torch/algorithms/weight_only/save_load.py
@@ -937,7 +937,7 @@ class WOQModelLoader:
                 else:  # pragma: no cover
                     assert False, f'`torch_dtype` can be either `torch.dtype` or `"auto"`, but received {torch_dtype}'
 
-            dtype_orig = model_class._set_default_torch_dtype(torch_dtype)
+            dtype_orig = model_class._set_default_dtype(torch_dtype)
 
         init_contexts = (
             [no_init_weights(_enable=_fast_init)]

--- a/neural_compressor/torch/utils/utility.py
+++ b/neural_compressor/torch/utils/utility.py
@@ -38,7 +38,7 @@ from neural_compressor.torch.utils import SaveLoadFormat, is_optimum_habana_avai
 if is_transformers_imported():
     import transformers
 
-    SUPPORTED_LAYERS = [nn.Linear, transformers.modeling_utils.Conv1D]
+    SUPPORTED_LAYERS = [nn.Linear, transformers.pytorch_utils.Conv1D]
 else:
     SUPPORTED_LAYERS = [nn.Conv1d, nn.Linear]
 

--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -636,7 +636,7 @@ class _BaseINCAutoModelClass:
                 else:
                     assert False, f'`torch_dtype` can be either `torch.dtype` or `"auto"`, but received {torch_dtype}'
 
-            dtype_orig = model_class._set_default_torch_dtype(torch_dtype)
+            dtype_orig = model_class._set_default_dtype(torch_dtype)
         if quantization_config.compute_dtype is None:
             if use_xpu:
                 quantization_config.compute_dtype = (

--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -393,7 +393,7 @@ class _BaseINCAutoModelClass:
         # index of the files.
         is_sharded = False
         sharded_metadata = None
-        if transformers.__version__ >= "4.50":
+        if parse(transformers.__version__) >= parse("4.50"):
             from transformers.modeling_utils import _get_resolved_checkpoint_files
 
             gguf_file = kwargs.pop("gguf_file", None)
@@ -635,8 +635,10 @@ class _BaseINCAutoModelClass:
                             torch_dtype = torch.float32
                 else:
                     assert False, f'`torch_dtype` can be either `torch.dtype` or `"auto"`, but received {torch_dtype}'
-
-            dtype_orig = model_class._set_default_dtype(torch_dtype)
+            if parse(transformers.__version__) >= parse("4.56.0"):
+                dtype_orig = model_class._set_default_dtype(torch_dtype)
+            else:
+                dtype_orig = model_class._set_default_torch_dtype(torch_dtype)
         if quantization_config.compute_dtype is None:
             if use_xpu:
                 quantization_config.compute_dtype = (

--- a/neural_compressor/transformers/quantization/utils.py
+++ b/neural_compressor/transformers/quantization/utils.py
@@ -579,7 +579,7 @@ def convert_to_quantized_model(model, config, device="cpu", for_inference=True):
             set_nontext_module_config(model, to_quant_block_names, config)
 
             for n, m in model.named_modules():
-                if isinstance(m, torch.nn.Linear) or isinstance(m, transformers.modeling_utils.Conv1D):
+                if isinstance(m, torch.nn.Linear) or isinstance(m, transformers.pytorch_utils.Conv1D):
                     if m.weight.shape[0] % 32 != 0 or m.weight.shape[1] % 32 != 0:
                         config.modules_to_not_convert.append(n)
                         print(

--- a/test/3x/torch/algorithms/pt2e_quant/test_pt2e_w8a8.py
+++ b/test/3x/torch/algorithms/pt2e_quant/test_pt2e_w8a8.py
@@ -75,24 +75,18 @@ class TestW8A8PT2EQuantizer:
 
         model_name = "facebook/opt-125m"
         model = AutoModelForCausalLM.from_pretrained(model_name)
+        model_config = model.config
         tokenizer = AutoTokenizer.from_pretrained(model_name)
-        input_ids = tokenizer("Hello, my dog is cute", return_tensors="pt")["input_ids"]
+        inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
         # example_inputs = (input_ids,)
         # model = export_model_for_pt2e_quant(model, example_inputs=example_inputs)
+        attention_mask = inputs.attention_mask
+        input_ids = inputs.input_ids
+       
+        
+        from transformers.integrations.executorch import export_with_dynamic_cache
         from transformers import DynamicCache
-        example_inputs =                 {
-                    "input_ids": input_ids,
-                    "attention_mask": None,
-                    "past_key_values": DynamicCache(),
-                    "use_cache": True,
-                }
-        with torch.no_grad():
-            ep = torch.export.export_for_training(
-                model,
-                (),
-                example_inputs,
-                strict=False,
-            )
+        ep = export_with_dynamic_cache(model, input_ids, attention_mask)
         model = ep.module()
         model._exported = True
 
@@ -102,7 +96,12 @@ class TestW8A8PT2EQuantizer:
         prepare_model = w8a8_static_quantizer.prepare(model)
         # calibrate
         for i in range(2):
-            prepare_model(**example_inputs)
+            prepare_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                past_key_values=DynamicCache(config=model_config),
+                use_cache=True,
+            )
         # convert
         converted_model = w8a8_static_quantizer.convert(prepare_model)
         # inference
@@ -110,7 +109,11 @@ class TestW8A8PT2EQuantizer:
 
         config.freezing = True
         opt_model = torch.compile(converted_model)
-        out = opt_model(**example_inputs)
+        out = opt_model(input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=DynamicCache(config=model_config),
+            use_cache=True,
+            )
         assert out.logits is not None
 
     @patch("neural_compressor.torch.algorithms.pt2e_quant.core.logger.error")


### PR DESCRIPTION
## Type of Change

adapt transformers 4.56.0

## Description

transformers==4.56.0 changed the import path, we now need to use transformers.pytorch_utils.Conv1D instead of transformers.modeling_utils.Conv1D
1. Use `transformers.pytorch_utils.Conv1D` instead of `transformers.modeling_utils.Conv1D`
2. use `_set_default_dtype` instead of `_set_default_torch_dtype`
3. fix pt2e ut: from transformers.integrations.executorch import export_with_dynamic_cache

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
