### PR TITLE
Remove index-url global setting in requirements.txt

### DIFF
--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/README.md
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/README.md
@@ -9,6 +9,7 @@ We provide the inference benchmarking script `run_generation.py` for large langu
 python version requests equal or higher than 3.9 due to [text evaluation library](https://github.com/EleutherAI/lm-evaluation-harness/tree/master) limitation, the dependent packages are listed in requirements, we recommend create environment as the following steps.
 
 ```bash
+pip install oneccl_bind_pt==2.4.0 --index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
 pip install -r requirements_cpu_woq.txt
 ```
 

--- a/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/requirements_cpu_woq.txt
+++ b/examples/3.x_api/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/requirements_cpu_woq.txt
@@ -15,6 +15,5 @@ lm-eval>=0.4.2
 huggingface_hub
 numba
 tbb
+--extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
 intel-extension-for-pytorch==2.4.0
---index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
-oneccl_bind_pt==2.4.0


### PR DESCRIPTION
## Type of Change

bug fix

## Description

`--index-url` always be global setting in `requirements.txt`, so it could not be set directly in `requirements_cpu_woq.txt`. But in this case, we are not allowed to use `--extra-index-url` for `oneccl_bind_pt`, see https://github.com/intel/neural-compressor/pull/2273. So have to install `oneccl_bind_pt` separately. 

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
