### PR TITLE
fix bug during HPU inference

### DIFF
--- a/neural_compressor/evaluation/lm_eval/models/huggingface.py
+++ b/neural_compressor/evaluation/lm_eval/models/huggingface.py
@@ -359,7 +359,7 @@ class HFLM(TemplateLM):
     @property
     def model(self):
         # returns the model, unwrapping it if using Accelerate
-        if hasattr(self, "accelerator"):
+        if hasattr(self, "accelerator") and self._model is not None:
             return self.accelerator.unwrap_model(self._model)
         else:
             return self._model


### PR DESCRIPTION
self._model is None when initializing, and accelerator.unwrapper() will return error. 
It happens when using deepspeed tensor parallel.