### PR TITLE
add mxfp8 qat

### DIFF
--- a/neural_compressor/torch/algorithms/qat/__init__.py
+++ b/neural_compressor/torch/algorithms/qat/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint:disable=import-error
+"""QAT (Quantization Aware Tuning)."""

--- a/neural_compressor/torch/algorithms/qat/quant_linear.py
+++ b/neural_compressor/torch/algorithms/qat/quant_linear.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Quantized Linear."""
+
+
+import torch
+import torch.nn as nn
+
+from .tensor_quantizer import TensorQuantizer
+
+class QuantLinear(nn.Module):
+    """Quantized version of nn.Linear."""
+
+    def forward(self, input: torch.Tensor):
+        """Add weight/input/output of quantization for the original forward method."""
+        qw = self.weight_quantizer(self.weight)
+        qi = self.input_quantizer(input)
+        out = F.linear(qi, qw, self.bias)
+        out = self.output_quantizer(out)
+        return out
+
+    def _setup(self, quant_cfg: "QuantizationSchem"):
+        """Init quantizer"""
+        self.weight_quantizer = TensorQuantizer(
+            data_type=quant_cfg.data_type,
+            block_size=quant_cfg.group_size,
+            bits=quant_cfg.bits,
+            sym=quant_cfg.sym,
+            if_quant=True,
+            learn_exponent=False,
+        )
+        self.input_quantizer = TensorQuantizer(
+            data_type=quant_cfg.act_data_type,
+            block_size=quant_cfg.act_group_size,
+            bits=quant_cfg.act_bits,
+            sym=quant_cfg.act_sym,
+            if_quant=True,
+            learn_exponent=False,
+        )
+        self.output_quantizer = TensorQuantizer(
+            data_type=quant_cfg.act_data_type,
+            block_size=quant_cfg.act_group_size,
+            bits=quant_cfg.act_bits,
+            sym=quant_cfg.act_sym,
+            if_quant=False,
+        )
+        # Currently don't quant output
+        self.output_quantizer.disable()
+
+        # TODO: remove
+        self.original_weight_dtype = None if self.weight is None else self.weight.dtype
+
+    def extra_repr(self) -> str:
+        """Generate extra_repr making sure import keys exist in self.__dict__."""
+        return f"in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}"
+
+    def __repr__(self):
+        """Overriding the __repr__ method, makes the output more concise and meaningful."""
+        return f"QuantLinear(\n" \
+               f"  in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}\n" \
+               f"  (input_quantizer): {self.input_quantizer}\n" \
+               f"  (output_quantizer): {self.output_quantizer}\n" \
+               f"  (weight_quantizer): {self.weight_quantizer}\n" \
+               f")"

--- a/neural_compressor/torch/algorithms/qat/quant_utils.py
+++ b/neural_compressor/torch/algorithms/qat/quant_utils.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utils for quantization"""
+
+import types
+import torch
+import torch.nn as nn
+from typing import Any
+from .quant_linear import QuantLinear
+
+
+def convert(module: nn.Module, quant_cfg=None, quant_module=None):
+    """Convert the model to a quantized one with quant config"""
+
+    # update class
+    original_cls = type(module)
+    module.__class__ = quant_module
+    module.forward = types.MethodType(quant_module.forward, module)
+
+    # setup quantizers
+    module._setup(quant_cfg)
+
+    return module
+
+
+def replace_with_quant_linear(model, quant_cfg=None):
+    """Recursively replace the module with quantized module."""
+
+    # TODO: support more modules, like kv.
+    for name, child in model.named_children():
+        if isinstance(child, nn.Linear):
+            if "lm_head" in name:
+                continue
+            # REPLACE on the parent (model), not on child
+            quantized = convert(child, quant_cfg, QuantLinear)
+            setattr(model, name, quantized)
+
+        # now recurse into whichever module is now at `model.name`
+        replace_with_quant_linear(getattr(model, name), quant_cfg=quant_cfg)
+
+    return model
+
+
+def get_quant_config(scheme: str) -> dict[str, Any]:
+    """Generate quantization config for a torch model.
+
+    Args:
+        model: The PyTorch model to analyze
+
+    Returns:
+        Dictionary containing the quantization configuration
+    """
+
+    # TODO: support more quant config
+    try:
+        from auto_round.export.export_to_llmcompressor.config import initialize_quantization
+        quantization_config = initialize_quantization(scheme=scheme)
+        quantization_config = quantization_config.to_dict()
+        quantization_config["provider"] = "auto-round"
+        quantization_config["config_groups"]["group_0"]["weights"]["is_mx"] = True
+        quantization_config["config_groups"]["group_0"]["input_activations"]["is_mx"] = True
+
+    except ImportError:
+        quantization_config = None
+
+    return quantization_config
+
+
+def get_quantization_format(module) -> str | None:
+    """Gets the quantization string.
+
+    Gets the quantization string by iterating through the module and its children.
+    The first non-None quantization string is returned.
+    """
+
+    def _get_quantization_from_layer(layer):
+        weight_quantizer = getattr(layer, "weight_quantizer", None)
+        input_quantizer = getattr(layer, "input_quantizer", None)
+
+        if weight_quantizer is None or weight_quantizer._disabled:
+            return None
+
+        # TODO: support more quant format
+        if weight_quantizer.num_bits == 8 and weight_quantizer.data_type == "mx_fp8":
+            return "MXFP8"
+
+        # Raise error for unsupported num_bits
+        raise NotImplementedError(
+            f"Unsupported quantizer with num_bits: {weight_quantizer.num_bits}"
+        )
+
+    quantization = _get_quantization_from_layer(module)
+    if quantization != None:
+        return quantization
+
+    for _, layer in module.named_children():
+        format = get_quantization_format(layer)
+        if format != None:
+            return format
+
+    return None
+
+
+def is_quantlinear(module: nn.Module) -> bool:
+    """Returns whether the module is a quantized linear layer."""
+    return "QuantLinear" in type(module).__name__

--- a/neural_compressor/torch/algorithms/qat/tensor_quantizer.py
+++ b/neural_compressor/torch/algorithms/qat/tensor_quantizer.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TensorQuantizer Module."""
+
+import torch
+from torch import nn
+
+try:
+    from auto_round.data_type import get_quant_func
+except ImportError:
+    get_quant_func = None
+
+class TensorQuantizer(nn.Module):
+    """Tensor quantizer module."""
+
+    def __init__(
+        self,
+        data_type="mx_fp8",
+        bits=8,
+        block_size=32,
+        sym=True,
+        if_quant=True,
+        learn_exponent=False,
+        amax=None,
+        scale_shape=None,
+        device=None,
+    ):
+        """Initialize quantizer and set up required variables."""
+        super().__init__()
+        self.amax = amax
+        self.data_type = data_type
+        self.num_bits = bits
+        self.block_size = block_size
+        self.sym = sym
+        self._if_quant = if_quant
+        self.learn_exponent = learn_exponent
+        self._dequantize = False
+        self._input_dtype = None
+        self._fake_quant = True
+
+        # enable quantizer
+        self.enable()
+
+        assert get_quant_func is not None, (
+                f"The quantization function is imported from AutoRound, please intall it. 'pip install auto-round'"
+            )
+
+        # self.data_type will be overided 'mx_fp' -> 'mx_fp8'
+        self.quant_func, self.data_type = get_quant_func(self.data_type, self.num_bits, self.sym)
+
+        if scale_shape is not None:
+            # E8M0 scales (exponent)
+            self.register_buffer(
+                "scale",
+                torch.empty(scale_shape[0], scale_shape.shape[1] // self.block_size, dtype=torch.uint8, device=device),
+            )
+            self.save_scale = True
+        else:
+            self.save_scale = False
+
+    def forward(self, inputs: torch.Tensor):
+        """Apply tensor_quant function to inputs.
+
+        Args:
+            inputs: A Tensor of type float32/float16/bfloat16.
+
+        Returns:
+            outputs: A Tensor of type output_dtype
+        """
+
+        if self._disabled or (not self._if_quant):
+            self._input_dtype = inputs.dtype
+            return inputs
+
+        x = inputs
+        if not x.is_contiguous():
+            x = x.contiguous()
+
+        if self.fake_quant:
+            q = self._fake_quantize(x)[0]
+        else:
+            # TODO: add implementation
+            q = self._real_quantize(x)
+
+        return q.to(inputs.dtype)
+
+    def _fake_quantize(self, inputs: torch.Tensor):
+        """Fake quantization."""
+
+        # the shared_exp can be trainable
+        if self.learn_exponent:
+            q, shared_exp, _ = self.quant_func(
+                inputs,
+                bits=self.num_bits,
+                group_size=self.block_size,
+                data_type=self.data_type,
+            )
+        else:
+            # wrapper no_grad, because the function includes extra trainable variables
+            with torch.no_grad():
+                q, shared_exp, _ = self.quant_func(
+                    inputs,
+                    bits=self.num_bits,
+                    group_size=self.block_size,
+                    data_type=self.data_type,
+                )
+
+            # simple STE, since we add no_grad in the quant function
+            q = q.detach() + (inputs - inputs.detach())
+
+        if self.save_scale:
+            # TODO: PACK uint8
+            self.scale.data.copy_(shared_exp.detach())
+
+        return q, shared_exp
+
+    @property
+    def fake_quant(self):
+        """Return True if fake quantization is used."""
+        return self._fake_quant
+
+    def disable(self):
+        """Bypass the module."""
+        self._disabled = True
+
+    def enable(self):
+        """Enable the module."""
+        self._disabled = False
+
+    def weight_pack(self, weight, scale):
+        """pack weight and scale when saving."""
+        original_shape = weight.shape
+
+        # TODO: support more quantization format
+        if self.data_type == "mx_fp8":
+            qweight = (weight.reshape(-1, self.block_size) \
+                    / torch.exp2(scale.float()).reshape(-1, 1)).to(torch.float8_e4m3fn)
+
+            e8m0_scale = (scale + 127).to(torch.uint8)
+            return qweight.reshape(original_shape), e8m0_scale
+
+    def __repr__(self):
+        if self._disabled or not self._if_quant:
+            return "TensorQuantizer(disabled)"
+
+        qformat_str = f"({self.data_type}) format"
+        bits_str = f"({self.num_bits}) bit"
+
+        if self.block_size:
+            bs_str = f"block_size={self.block_size}"
+        else:
+            bs_str = "block_size=None"
+
+        # amax
+        amax_str = f"amax={self.amax}" if self.amax is not None else "amax=?"
+        # fake / real
+        mode_str = "fake" if self._fake_quant else "real"
+        # sym
+        sym_str = "sym" if self.sym else "asym"
+        # quant enable
+        qflag = "quant" if self._if_quant else "no-quant"
+
+        return f"TensorQuantizer({qformat_str} {bits_str} {mode_str} {bs_str}, {amax_str} {qflag})"

--- a/neural_compressor/torch/export/export_hf.py
+++ b/neural_compressor/torch/export/export_hf.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Export quantized hf model to compatible formats"""
+
+import tempfile
+from pathlib import Path
+import warnings
+from typing import Any
+import torch
+import torch.nn as nn
+
+def _export_quantized_weight(
+    sub_module: nn.Module, quantization_format: str = None, weight_name: str = "weight"
+):
+    """For the given weight attr of the sub_module, export the quantization info of it.
+
+    The export includes converting weight tensor to correct quantized values and quantized dtype,
+    and registering scaling factors.
+    """
+    if quantization_format == None:
+        return
+
+    weight: nn.Parameter = getattr(sub_module, weight_name)
+    weight_quantizer = getattr(
+        sub_module, "weight_quantizer"
+    )
+
+    qdq_weight, scale = weight_quantizer._fake_quantize(weight)
+
+    # TODO: support more scale dtype when there are other quantization format except mxfp8/mxfp4
+    quantized_weight, e8m0_scale = weight_quantizer.weight_pack(qdq_weight, scale)
+
+    sub_module.register_buffer("weight_scale", e8m0_scale.reshape(*weight.shape[:-1], -1))
+
+    setattr(sub_module, weight_name, nn.Parameter(quantized_weight, requires_grad=False))
+
+def _export_hf_checkpoint(
+    model: nn.Module, scheme: str | None = None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Exports the torch model to the packed checkpoint with original HF naming.
+
+    The packed checkpoint will be consumed by the TensorRT-LLM unified converter.
+
+    Args:
+        model: the torch model.
+        dtype: the weights data type to export the unquantized layers or the default model data type if None.
+
+    Returns:
+        post_state_dict: Dict containing quantized weights
+        quant_config: config information to export hf_quant_cfg.json
+    """
+
+    # Create a model layer pool
+    # If `model.model` exists use that, otherwise use `model` itself, e.g., Nemotron-H
+    root = getattr(model, "model", model)
+    # If that has a `.layers`, use it, otherwise fall back to the object itself
+    root = getattr(root, "layers", root)
+    layer_pool = {f"model.layers.{name}": sub_module for name, sub_module in root.named_modules()}
+
+    from ..algorithms.qat.quant_utils import get_quant_config, get_quantization_format, is_quantlinear
+    # compressored config
+    quant_config = get_quant_config(scheme=scheme)
+
+    for name, sub_module in layer_pool.items():
+        quantization_format = get_quantization_format(sub_module)
+        if quantization_format != None:
+            if is_quantlinear(sub_module):
+                _export_quantized_weight(sub_module, quantization_format)
+
+    quantized_state_dict = model.state_dict()
+
+
+    return quantized_state_dict, quant_config
+
+
+def export_hf2compressored_model(
+    model: nn.Module,
+    export_dir: Path | str = tempfile.gettempdir(),
+    scheme: str = None
+):
+    """Exports the torch model to the packed checkpoint with original HF naming.
+
+    The packed checkpoint will be consumed by the VLLM.
+    """
+
+    export_dir = Path(export_dir)
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        _, quant_config = _export_hf_checkpoint(model, scheme)
+        model.save_pretrained(export_dir)
+        model.config.quantization_config = quant_config
+        model.config.save_pretrained(export_dir)
+
+    except Exception as e:
+        warnings.warn(
+            "Cannot export model and config, the state"
+            " can be saved with torch.save for further inspection."
+        )
+        raise e
+


### PR DESCRIPTION
## Type of Change

add mxfp8 QAT code

## Description

1. support mxfp8 forward and bf16 backward for QAT
2. export quantized hf model to llm-compressor, which can be deployed using vllm with mxfp8
3. add a simple qat example for testing currently


