### PR TITLE
Adapt transformers v4.57.0

### DIFF
--- a/neural_compressor/transformers/models/modeling_auto.py
+++ b/neural_compressor/transformers/models/modeling_auto.py
@@ -745,13 +745,13 @@ class _BaseINCAutoModelClass:
                 tmp_kwargs = {
                     "sharded_metadata": sharded_metadata,
                     "disk_offload_folder": offload_folder,
-                    "offload_state_dict": offload_state_dict,
                     "dtype": torch_dtype,
                 }
+                if parse(transformers.__version__) < parse("4.57"):
+                    tmp_kwargs["offload_state_dict"] = offload_state_dict
                 if parse(transformers.__version__) < parse("4.51"):
                     tmp_kwargs["_fast_init"] = _fast_init
                     tmp_kwargs["low_cpu_mem_usage"] = True
-
             model_message = model_class._load_pretrained_model(*tmp_args, **tmp_kwargs)
             model = model_message[0]
 


### PR DESCRIPTION
## Type of Change

bug fix

## Description

From transformers https://github.com/huggingface/transformers/pull/41103:
completely remove offload_state_dict: it was added several years ago to avoid loading 2x memory on cpu between the model and the state dict -> this is no longer needed from some time as the model is loaded on meta device, then params are loaded one after the other -> removes quite a bit of convoluted logic


## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
