### PR TITLE
skip unexpected time consuming FP8 UTs

### DIFF
--- a/test/3x/torch/algorithms/fp8_quant/unit_tests/test_layers/test_linear.py
+++ b/test/3x/torch/algorithms/fp8_quant/unit_tests/test_layers/test_linear.py
@@ -134,6 +134,8 @@ def test_linear_dynamic_quantization(
     scale_format: ScaleFormat,
     use_hpu_graphs: bool
 ):
+    if not use_hpu_graphs and (hp_dtype == torch.bfloat16) and device_type == GAUDI2:
+        pytest.xfail("[SW-242200] Temporary skip them since the time usage is more than expected.")
     check_tests_to_skip(scale_method, scale_format, True)
     N = 1
     D_in = 8


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Skip time-consuming FP8 unit tests under specific conditions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Identify specific test conditions"] -- "Check use_hpu_graphs, hp_dtype, device_type" --> B["Skip tests if conditions met"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_linear.py</strong><dd><code>Add condition to skip time-consuming tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/3x/torch/algorithms/fp8_quant/unit_tests/test_layers/test_linear.py

- Added condition to skip tests
- Used pytest.xfail for skipping


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2307/files#diff-c73a30cac0b2300ab5f9c721a270f8e7b7d7984b137fb4b0a4e9911afebe2be0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

