### PR TITLE
Update MXQuant doc

### DIFF
--- a/docs/source/3x/PT_MXQuant.md
+++ b/docs/source/3x/PT_MXQuant.md
@@ -78,7 +78,7 @@ The memory and computational limits of LLMs are more severe than other general n
 |  Zero point  |   0 (None)   | $2^{bits - 1}$ or $-min * scale$ |   0 (None)   |
 |  Granularity  |  per-block (default blocksize is 32)   |  per-channel or per-tensor  | per-channel or per-tensor  |
 
-The exponent (exp) is equal to torch.floor(torch.log2(amax)), MAX is the representation range of the data type, amax is the max absolute value of per-block tensor, and rmin is the minimum value of the per-block tensor.
+The exponent (exp) is equal to clamp(floor(log2(amax)) - maxExp, -127, 127), MAX is the representation range of the data type, amax is the max absolute value of per-block tensor, and rmin is the minimum value of the per-block tensor.
 
 
 ## Get Started with Microscaling Quantization API


### PR DESCRIPTION
### **User description**
## Type of Change

documentation
## Description

transfer to AutoRound Quant

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Updated documentation for AutoRound Quantization API

- Added example using Hugging Face models

- Included code snippet for model quantization and inference


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MXQuantConfig"] -- "updated to" --> B["AutoRoundConfig"]
  B -- "added example" --> C["Hugging Face models"]
  C -- "included code" --> D["Model quantization and inference"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PT_MXQuant.md</strong><dd><code>Updated to AutoRound Quantization API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/source/3x/PT_MXQuant.md

<ul><li>Updated API usage from MXQuant to AutoRound<br> <li> Added example with Hugging Face models<br> <li> Included code for quantization and inference</ul>


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2309/files#diff-212b1f1ca2f061a560946ee8e66ad935d66436a8126924525563857b44ab01e0">+30/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

