### PR TITLE
Fix GPTQ NF4&FP4 quant

### DIFF
--- a/neural_compressor/torch/algorithms/weight_only/utility.py
+++ b/neural_compressor/torch/algorithms/weight_only/utility.py
@@ -516,7 +516,7 @@ def quant_weight_w_scale(weight, scale, scale_bf16_to_fp8, zp=None, group_size=-
         if dtype in FLOAT_MAPPING.keys():  # NF4 FP4
             int_weight_tmp = weight[:, i * group_size : (i + 1) * group_size]
             quantize_4bit(int_weight_tmp, scale=scale[:, i].unsqueeze(1), dtype=dtype, return_int=True)[0]
-            int_weight[:, leng * group_size :].copy_(int_weight_tmp)
+            int_weight[:, i * group_size : (i + 1) * group_size].copy_(int_weight_tmp)
         else:
             int_weight_tmp = weight[:, i * group_size : (i + 1) * group_size].div_(scale[:, i].unsqueeze(1))
             if zp is not None:


### PR DESCRIPTION
### **User description**
## Type of Change

bug fix

## Description

fix return int_weight `torch.zeros(weight. Shape).to(device)`) 

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect assignment of quantized weights for NF4 & FP4

- Ensure `int_weight` is correctly updated with quantized values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Initialize int_weight"] -- "Loop through groups" --> B["Quantize group"]
  B -- "Update int_weight for NF4/FP4" --> C["Copy quantized values"]
  C -- "Handle tail group" --> D["Quantize tail group"]
  D -- "Update int_weight for NF4/FP4" --> E["Copy tail quantized values"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utility.py</strong><dd><code>Correct weight assignment in quant_weight_w_scale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

neural_compressor/torch/algorithms/weight_only/utility.py

<ul><li>Added correct assignment of quantized weights to <code>int_weight</code> for NF4 & <br>FP4<br> <li> Ensured <code>int_weight</code> is updated with quantized values in both loop and <br>tail handling</ul>


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2314/files#diff-c9033e8055d324731fffc9533291b83b1b0e3e5f0969deb602dceeb2845a919e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

