### PR TITLE
Update AutoRound `layer_config` usage

### DIFF
--- a/docs/source/3x/PT_WeightOnlyQuant.md
+++ b/docs/source/3x/PT_WeightOnlyQuant.md
@@ -298,9 +298,9 @@ quant_config.set_local("lm_head", lm_head_config)
 #          "W8A16"
 #       }
 # }
+# Use the AutoRound specific 'layer_config' instead of the 'set_local' API.
 layer_config = {"lm_head": {"data_type": "int"}}
 quant_config = AutoRoundConfig(layer_config=layer_config)
-quant_config.set_local("lm_head", lm_head_config)
 ```
 
 ### Saving and Loading


### PR DESCRIPTION
### **User description**
## Type of Change

documentation

## Description

detail description

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed


___

### **PR Type**
Documentation


___

### **Description**
- Added `scheme` and `layer_config` to AutoRound documentation

- Provided example usage of `layer_config` for AutoRound


___

### Diagram Walkthrough


```mermaid
flowchart LR
  doc_update["Update documentation"]
  scheme_addition["Add scheme parameter"]
  layer_config_addition["Add layer_config parameter"]
  example_usage["Provide example usage of layer_config"]

  doc_update -- "includes" --> scheme_addition
  doc_update -- "includes" --> layer_config_addition
  layer_config_addition -- "example" --> example_usage
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PT_WeightOnlyQuant.md</strong><dd><code>Document `scheme` and `layer_config` for AutoRound</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/source/3x/PT_WeightOnlyQuant.md

<ul><li>Added <code>scheme</code> and <code>layer_config</code> to table<br> <li> Provided example usage of <code>layer_config</code> for AutoRound</ul>


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2331/files#diff-0eea436583eadc1e41029bcce88c9d27f02bef481e81abdb6821275066bd2541">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

