### PR TITLE
Add autoround xpu ut

### DIFF
--- a/test/3x/torch/quantization/weight_only/test_autoround.py
+++ b/test/3x/torch/quantization/weight_only/test_autoround.py
@@ -39,6 +39,8 @@ def set_hpu_torch_compile_envs():
 if is_habana_framework_installed():
     set_hpu_torch_compile_envs()
 
+def is_xpu_available():
+    return torch.xpu.is_available()
 
 from neural_compressor.torch.quantization import (
     AutoRoundConfig,
@@ -572,7 +574,7 @@ class TestAutoRoundHPU:
         )
         assert isinstance(q_model.model.layers[0].self_attn.k_proj, WeightOnlyLinear), "packing model failed."
 
-@pytest.mark.skipif(is_xpu_available=True, reason="These tests are not supported on XPU for now.")
+@pytest.mark.skipif(not is_xpu_available(), reason="These tests are not supported on XPU for now.")
 @pytest.mark.skipif(not auto_round_installed, reason="auto_round module is not installed")
 class TestAutoRoundGPU:
     @pytest.mark.parametrize("scheme", ["W4A16","W2A16","W3A16","W8A16","MXFP4","MXFP8", "NVFP4","FPW8A16","FP8_STATIC"])
@@ -688,7 +690,7 @@ class TestAutoRoundGPU:
             seqlen=10,
             # quant_nontext_module=True,
             processor=processor,
-            device_map="xpu",
+            device_map="xpu:0",
             scheme=scheme,
             export_format="auto_round",
             output_dir=output_dir, # default is "temp_auto_round"


### PR DESCRIPTION
### **User description**
## Type of Change

UT

## Description

for BMG
pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
If encountering ipex error: pip uninstall intel_extension_for_pytorch
or use nightly
pip3 install --pre torch torchvision torchaudio --index-url <a href="https://download.pytorch.org/whl/nightly/xpu" rel="noreferrer noopener" title="https://download.pytorch.org/whl/nightly/xpu" target="_blank">https://download.pytorch.org/whl/nightly/xpu</a>
or
pip3 install torch==2.8 torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed


___

### **PR Type**
Tests


___

### **Description**
- Add XPU unit tests for autoround

- Test various schemes and formats

- Include VLM and LM head quantization tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add XPU UT"] -- "Test schemes" --> B["Test formats"]
  B -- "Test VLM models" --> C["Test LM head quantization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_autoround.py</strong><dd><code>Add XPU autoround unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/3x/torch/quantization/weight_only/test_autoround.py

<ul><li>Added XPU unit tests for autoround<br> <li> Included tests for different schemes and formats<br> <li> Added tests for VLM models and LM head quantization</ul>


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2332/files#diff-5767d835ec25fe413a700db09e70c11fb5bb483735cffd7aa958d96cf8c9c377">+161/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

