### PR TITLE
add OoTPatchedModuleFusedSDPA

### DIFF
--- a/neural_compressor/torch/algorithms/fp8_quant/_quant_common/patched_helper_modules.py
+++ b/neural_compressor/torch/algorithms/fp8_quant/_quant_common/patched_helper_modules.py
@@ -109,16 +109,16 @@ class OoTPatchedVllmMixtureOfExpertsOpFP8(INCPatchedVllmMixtureOfExpertsOpFP8):
 class OoTPatchedModuleFusedSDPA(INCPatchedModuleFusedSDPA):
     def __init__(self, mod, parent, mod_extra_config, *args, **kwargs):
         super().__init__(mod, parent, mod_extra_config, *args, **kwargs)
-        self.qkv_slice_thld = int(os.getenv("PT_HPU_QKV_SLICE_SEQ_LEN_THLD", 4096))
+        self.qkv_slice_thld = int(os.getenv("VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD", 4096))
         if self.qkv_slice_thld > 0:
-            self.qkv_chunk_size = int(os.getenv("VLLM_FUSEDSDPA_QKV_SLICE_CHUNK_SIZE", self.qkv_slice_thld))
+            self.qkv_chunk_size = int(os.getenv("VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE", self.qkv_slice_thld))
 
         impl_mapping = {
             'split_kv': self.fp8_fsdpa_split_kv,
             'slice_causal': self.fp8_fsdpa_slice_causal,
             'slice_qkv': self.fp8_fsdpa_slice_qkv,
         }
-        qkv_slice_impl = os.getenv("PT_HPU_QKV_SLICE_IMPL", 'slice_qkv').lower()
+        qkv_slice_impl = os.getenv("VLLM_HPU_FSDPA_SLICE_IMPL", 'slice_qkv').lower()
         assert qkv_slice_impl in impl_mapping, (
             f"Invalid QKV slice implementation: {qkv_slice_impl}, "
             f"available options: {list(impl_mapping.keys())}"


### PR DESCRIPTION
## Motivation
Current implementation in vLLM will call FusedSDPA with a huge attention mask, which leads to bad performance. This PR introduced three implementations to get better performance.

## Usage
Three environment variables are introduced to control the implementation:
- `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD`: `int`, the threshold for `kv_len` (=q_len+prefix_len) to apply the implementations, defaults to `8192`, set to a value less equal to 0 to disable slicing.
- `VLLM_HPU_FSDPA_SLICE_CHUNK_SIZE`: `int`, chunk size for the slicing in the implementation, defaults to `4096`.
- `VLLM_HPU_FSDPA_SLICE_IMPL`: `str` with choices in `['split_kv', 'slice_causal', 'slice_qkv']`, used to select the implementations, defaults to `slice_qkv`.

## Implementations
For a FusedSDPA with `q_len=11525` and `prefix_len=10752`. The lengths will be padded and be truncated respectively to `q_len=16384` and `prefix_len=8192` before calling the FusedSDPA. The full attention mask is shown bellow, in which the Gray parts steads for the values to be masked out.
<img width="24576" height="16384" alt="attention_mask" src="https://github.com/user-attachments/assets/355100be-4d3d-434b-8757-0c699c5f706d" />

### Notation
The following images include rectangles with three colors:
- `rgb(255,0,0)`: `is_causal=False` and `attn_mask is not None`
- `rgb(255,255,0)`: `is_causal=True` and `attn_mask=None`
- `rgb(255,0,255)`: `is_causal=False` and `attn_mask=None`

### The original implementation
The original implementation pass the full attention mask and set `is_causal=False` and `valid_seq_len=None`, which results in bad TPC/MME pipeline. The implementation could be visualized as the following image.
<img width="24576" height="16384" alt="slicing_schedule_fp8_origin" src="https://github.com/user-attachments/assets/d1b2708f-4855-4c19-99ad-8abe1af14c04" />

### The `SplitKV` implementation
This implementation call the FusedSPDA twice for the prefix part and causal part respectively. And do not pass `attn_mask` for the prefix part thus gives better performance.
<img width="24576" height="16384" alt="slicing_schedule_fp8_SplitKV" src="https://github.com/user-attachments/assets/43286c9c-4efd-43d1-ac55-0a5df74fde20" />

### The `SliceCausal` implementation
This implementation further slice the causal part into smaller chunks as illustrated in the following image.
<img width="24576" height="16384" alt="slicing_schedule_fp8_SliceCausal" src="https://github.com/user-attachments/assets/e5858191-46ca-412e-80cf-7fdddbfedf0e" />

### The `SliceQKV` implementation
This implementation further slice the prefix part as shown below.
<img width="24576" height="16384" alt="slicing_schedule_fp8_SliceQKV" src="https://github.com/user-attachments/assets/291bb7a4-dced-45cb-9ccb-04dff3990378" />

