### PR TITLE
Support kv quant for llama4 example

### DIFF
--- a/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/README.md
+++ b/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/README.md
@@ -32,6 +32,7 @@ hf download meta-llama/Llama-4-Scout-17B-16E-Instruct --local-dir Llama-4-Scout-
 CUDA_VISIBLE_DEVICES=0 bash run_quant.sh --topology=llama4_mxfp4 --input_model=Llama-4-Scout-17B-16E-Instruct/
 ```
 
+> Note: You can also enable static quantization for KV cache by adding `--static_kv_dtype fp8` argument to `main.py`， or `--static_kv_dtype=fp8` argument to `run_quant.sh` and `run_benchmark.sh`.
 
 ## 2. Benchmark
 

--- a/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/main.py
+++ b/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/main.py
@@ -25,36 +25,69 @@ from neural_compressor.torch.quantization import (
 )
 
 
-class BasicArgumentParser(argparse.ArgumentParser):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.add_argument("--model", "--model_name", "--model_name_or_path",
-                          help="model name or path")
-
-        self.add_argument('--scheme', default="MXFP4", type=str,
-                          help="quantizaion scheme.")
-
-        self.add_argument("--device", "--devices", default="auto", type=str,
-                          help="the device to be used for tuning. The default is set to auto,"
-                               "allowing for automatic detection."
-                               "Currently, device settings support CPU, GPU, and HPU.")
-
-        self.add_argument("--export_format", default="llm_compressor", type=str,
-                          help="the format to save the model"
-                          )
-
-        self.add_argument("--output_dir", default="./tmp_autoround", type=str,
-                          help="the directory to save quantized model")
-
-        self.add_argument("--fp_layers", default="", type=str,
-                          help="layers to maintain original data type")
-
-
 def setup_parser():
-    parser = BasicArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Llama4 quantization.", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--model",
+        "--model_name",
+        "--model_name_or_path",
+        help="model name or path"
+    )
 
-    parser.add_argument("--iters", "--iter", default=0, type=int,
-                        help=" iters")
+    parser.add_argument(
+        "--scheme",
+        default="MXFP4",
+        type=str,
+        help="quantizaion scheme."
+    )
+
+    parser.add_argument(
+        "--device",
+        "--devices",
+        default="auto",
+        type=str,
+        help="the device to be used for tuning. The default is set to auto,"
+             "allowing for automatic detection."
+             "Currently, device settings support CPU, GPU, and HPU."
+    )
+
+    parser.add_argument(
+        "--export_format",
+        default="llm_compressor",
+        type=str,
+        help="the format to save the model"
+    )
+
+    parser.add_argument(
+        "--output_dir",
+        default="./tmp_autoround",
+        type=str,
+        help="the directory to save quantized model"
+    )
+
+    parser.add_argument(
+        "--fp_layers",
+        default="",
+        type=str,
+        help="layers to maintain original data type"
+    )
+    parser.add_argument(
+        "--static_kv_dtype",
+        default=None,
+        type=str,
+        choices=["fp8", "float8_e4m3fn"],
+        help="Data type for static quantize key and value."
+    )
+
+    parser.add_argument(
+        "--iters",
+        "--iter",
+        default=0,
+        type=int,
+        help=" iters"
+    )
 
     args = parser.parse_args()
     return args
@@ -88,6 +121,8 @@ def tune(args):
         export_format=args.export_format,
         output_dir=args.output_dir,
         processor=processor,
+        static_kv_dtype=args.static_kv_dtype,
+        reloading=False,
     )
     model = prepare(model, qconfig)
     model = convert(model, qconfig)

--- a/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/run_benchmark.sh
+++ b/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/run_benchmark.sh
@@ -27,6 +27,9 @@ function init_params {
       --batch_size=*)
           batch_size=$(echo $var |cut -f2 -d=)
       ;;
+      --static_kv_dtype=*)
+          kv_cache_dtype=$(echo $var |cut -f2 -d=)
+      ;;
     esac
   done
 
@@ -37,6 +40,7 @@ function run_benchmark {
 
     extra_model_args=""
     extra_cmd=""
+    kv_cache_dtype=${kv_cache_dtype:="auto"}
     batch_size=${batch_size:=1}
 
     if [ "${topology}" = "llama4_mxfp4" ]; then
@@ -46,7 +50,7 @@ function run_benchmark {
         export VLLM_ENABLE_STATIC_MOE=0
         export VLLM_USE_DEEP_GEMM=0
         export VLLM_ENABLE_AR_EXT=1
-        extra_model_args="max_model_len=8192,max_num_seqs=1024,max_gen_toks=2048,kv_cache_dtype=auto,gpu_memory_utilization=0.7"
+        extra_model_args="max_model_len=8192,max_num_seqs=1024,max_gen_toks=2048,gpu_memory_utilization=0.7"
         extra_cmd="--gen_kwargs max_gen_toks=2048"
     fi
 
@@ -57,9 +61,15 @@ function run_benchmark {
         model="vllm"
     fi
 
+    if [[ "${kv_cache_dtype}" == "fp8" ]]; then
+        export VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION=0
+        export VLLM_ATTENTION_BACKEND="FLASHINFER"
+        echo "Using FP8 for KV cache"
+    fi
+
     NCCL_NVLS_ENABLE=0 VLLM_USE_STANDALONE_COMPILE=0 VLLM_WORKER_MULTIPROC_METHOD=spawn \
     lm_eval --model ${model} \
-            --model_args pretrained=${input_model},tensor_parallel_size=${tp_size},${extra_model_args},enable_expert_parallel=True \
+            --model_args pretrained=${input_model},tensor_parallel_size=${tp_size},${extra_model_args},enable_expert_parallel=True,kv_cache_dtype=${kv_cache_dtype} \
             --tasks ${tasks} \
             --batch_size ${batch_size} \
             ${extra_cmd}

--- a/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/run_quant.sh
+++ b/examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/run_quant.sh
@@ -26,8 +26,11 @@ function init_params {
           input_model=$(echo $var |cut -f2 -d=)
       ;;
        --output_model=*)
-           tuned_checkpoint=$(echo $var |cut -f2 -d=)
-       ;;
+          tuned_checkpoint=$(echo $var |cut -f2 -d=)
+      ;;
+      --static_kv_dtype=*)
+          kv_cache_dtype=$(echo $var |cut -f2 -d=)
+      ;;
       *)
           echo "Error: No such parameter: ${var}"
           exit 1
@@ -42,16 +45,21 @@ function run_tuning {
     extra_cmd=""
     tuned_checkpoint=${tuned_checkpoint:="saved_results"}
     iters=${iters:=0}
+    kv_cache_dtype=${kv_cache_dtype:="auto"}
 
     if [ "${topology}" = "llama4_mxfp4" ]; then
         extra_cmd="--fp_layers lm-head,self_attn,router,vision_model,multi_modal_projector,shared_expert --scheme MXFP4 --export_format auto_round"
     fi
 
+    if [[ ! "${kv_cache_dtype}" = "auto" ]]; then
+        extra_cmd=${extra_cmd}" --static_kv_dtype ${kv_cache_dtype}"
+    fi
+
     python3 main.py \
-    	--model ${input_model} \
-		--iters ${iters} \
-		--output_dir ${tuned_checkpoint} \
-		${extra_cmd}
+        --model ${input_model} \
+        --iters ${iters} \
+        --output_dir ${tuned_checkpoint} \
+        ${extra_cmd}
 }
 
 main "$@"


### PR DESCRIPTION
### **User description**
## Type of Change

example update

## Description

kv cache quantization is supported


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for KV quantization in Llama4 example

- Introduced `static_kv_dtype` argument for key-value cache quantization

- Updated scripts to handle `static_kv_dtype` parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Update main.py"] -- "Add static_kv_dtype" --> B["Modify setup_parser"]
  B -- "Pass static_kv_dtype" --> C["Update tune function"]
  C -- "Add static_kv_dtype arg" --> D["Modify run_benchmark.sh"]
  D -- "Handle kv_cache_dtype" --> E["Modify run_quant.sh"]
  E -- "Pass kv_cache_dtype" --> F["Update README.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Enhance argument parsing and KV quantization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/main.py

<ul><li>Replaced <code>BasicArgumentParser</code> with standard <code>argparse.ArgumentParser</code><br> <li> Added <code>static_kv_dtype</code> argument for key-value cache quantization<br> <li> Passed <code>static_kv_dtype</code> to <code>tune</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2376/files#diff-4288a3a498c974dc23fe25febf4e974061bb7e4db407adb9e41bb2c2e155eae7">+59/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_benchmark.sh</strong><dd><code>Update benchmark script for KV quantization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/run_benchmark.sh

<ul><li>Added <code>--static_kv_dtype</code> parameter parsing<br> <li> Updated <code>extra_model_args</code> to include <code>kv_cache_dtype</code><br> <li> Added conditional logic for FP8 KV cache</ul>


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2376/files#diff-b68c43d67287a34640877d6d44e7441d0e4ca4c0dd5dafebc8c5671e12fc6b0b">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_quant.sh</strong><dd><code>Update quantization script for KV quantization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/run_quant.sh

<ul><li>Added <code>--static_kv_dtype</code> parameter parsing<br> <li> Conditionally added <code>static_kv_dtype</code> to <code>extra_cmd</code></ul>


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2376/files#diff-b4be1fe06b5f90d03d102df2e322a8ba3488f834f13d5f893ab0f115fd15079a">+14/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document KV quantization support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/pytorch/multimodal-modeling/quantization/auto_round/llama4/README.md

- Updated documentation to reflect KV quantization support


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2376/files#diff-8fc4279ed2f27d217e90b6e6c52541b70e1a0344fa7e72922e9d59bfd4ea1fc2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

