### PR TITLE
Remove skip once transformers fixed it

### DIFF
--- a/test/3x/torch/quantization/fp8_quant/test_layer_wise.py
+++ b/test/3x/torch/quantization/fp8_quant/test_layer_wise.py
@@ -7,7 +7,6 @@ from neural_compressor.torch.quantization import FP8Config, convert, prepare, fi
 from neural_compressor.torch.utils import get_used_cpu_mem_MB
 
 
-@pytest.mark.skip(reason="https://github.com/huggingface/transformers/issues/43159")
 def test_two_step_layer_wise():
     # layer-wise is based on memory mapping technique and https://github.com/huggingface/transformers/pull/31771
     # Workaround of [SW-208658]: torch.use_deterministic_algorithms(True) will break memory mapping


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed skip decorator due to transformers issue resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Skip decorator present"] -- "Transformers issue fixed" --> B["Skip decorator removed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_layer_wise.py</strong><dd><code>Removed skip decorator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/3x/torch/quantization/fp8_quant/test_layer_wise.py

- Removed skip decorator from test function


</details>


  </td>
  <td><a href="https://github.com/intel/neural-compressor/pull/2389/files#diff-8c7551f525c2f0a69ed09c91490ca2594feb14edda4fd951b298271105f5bcd8">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

