### PR TITLE
Fix activation scale inf issue for const_weight and const_scale

### DIFF
--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -243,6 +243,18 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             None: Cleans up observers and sets quantized call.
         """
         self._tracker.unlock()
+        if not self._is_quantized:
+            # Clean up observer only if it exists
+            if hasattr(self, "input_observer"):
+                if hasattr(self, "_layers") and self.input_observer in self._layers:
+                    self._layers.remove(self.input_observer)
+            # Set call to pass-through/original
+            if hasattr(self, 'call'):
+                # pass through
+                pass
+            self._const_variables = []
+            self._tracker.lock()
+            return        
         if hasattr(self, "_layers") and hasattr(self, "input_observer"):
             if self.input_observer in self._layers:
                 self._layers.remove(self.input_observer)
@@ -447,6 +459,16 @@ class QStaticDenseMixin(SaveableLayerMixin):
             None: Cleans up observers and original weights.
         """
         self._tracker.unlock()
+        if not self._is_quantized:
+            if hasattr(self, "input_observer"):
+                if hasattr(self, "_layers") and self.input_observer in self._layers:
+                    self._layers.remove(self.input_observer)
+            # Set call to pass-through/original
+            if hasattr(self, 'call'):
+                pass
+            self._const_variables = []
+            self._tracker.lock()
+            return
         if hasattr(self, "_kernel") and self._kernel in self._trainable_variables:
             self._trainable_variables.remove(self._kernel)
             del self._kernel

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -249,12 +249,12 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
                 if hasattr(self, "_layers") and self.input_observer in self._layers:
                     self._layers.remove(self.input_observer)
             # Set call to pass-through/original
-            if hasattr(self, 'call'):
+            if hasattr(self, "call"):
                 # pass through
                 pass
             self._const_variables = []
             self._tracker.lock()
-            return        
+            return
         if hasattr(self, "_layers") and hasattr(self, "input_observer"):
             if self.input_observer in self._layers:
                 self._layers.remove(self.input_observer)
@@ -464,7 +464,7 @@ class QStaticDenseMixin(SaveableLayerMixin):
                 if hasattr(self, "_layers") and self.input_observer in self._layers:
                     self._layers.remove(self.input_observer)
             # Set call to pass-through/original
-            if hasattr(self, 'call'):
+            if hasattr(self, "call"):
                 pass
             self._const_variables = []
             self._tracker.lock()


### PR DESCRIPTION
## Type of Change

bug fix

## Description

A lot of activation scale of inf when using one sample for calibration. For such layer, we should skip when it's marked _not_quantized, but it actually store value, due to constant weight initialization. 

## Expected Behavior & Potential Risk

resolved constant weight giberrish output issue. No foreseeable risk. 

## How has this PR been tested?

It has been tested using example_old.py file. 

## Dependency Change?

No dependency change. 
