### PR TITLE
Add test for VIT classification after quantization

### DIFF
--- a/test/jax/jax_test_utility.py
+++ b/test/jax/jax_test_utility.py
@@ -101,22 +101,22 @@ def compute_expected_qdq_dense_output(
     return current_input, all_a_scales, all_w_scales
 
 
-def load_image(image_path, target_size):
+def load_image(image_path, target_size, normalize):
     img = Image.open(image_path)
     if img.mode != "RGB":
         img = img.convert("RGB")
     img = img.resize(target_size, Image.BILINEAR)
-    normalized_pixels = jnp.array(img).astype(jnp.float32) / 255.0
-    normalized_pixels = jnp.expand_dims(normalized_pixels, 0)
-    return normalized_pixels
+    pixels = jnp.array(img)
+    if normalize:
+        normalized_pixels = pixels.astype(jnp.float32) / 255.0
+        return jnp.expand_dims(normalized_pixels, 0)
+    else:
+        return jnp.expand_dims(pixels, 0)
 
 
 def load_model_from_preset(model_type, preset, dtype="float32"):
-    datasets_path = os.environ.get("DATASETS_PATH")
-    if datasets_path is None:
-        datasets_path = "/models/"
-
-    model_path = f"{datasets_path}/{preset}"
+    root_models_path = os.environ.get("MODELS_PATH", "/models")
+    model_path = f"{root_models_path}/{preset}"
     if os.path.exists(model_path):
         return model_type.from_preset(model_path, dtype=dtype)
     else:

--- a/test/jax/jax_test_utility.py
+++ b/test/jax/jax_test_utility.py
@@ -3,8 +3,12 @@
 This file provides helper functions used by tests in test/jax/
 """
 
+import os
+
 import ml_dtypes
 import numpy as np
+from jax import numpy as jnp
+from PIL import Image
 
 
 def _dtype_min_max(dtype, out_dtype):
@@ -95,3 +99,25 @@ def compute_expected_qdq_dense_output(
         current_input = _matmul(qdq_input, qdq_weights)
 
     return current_input, all_a_scales, all_w_scales
+
+
+def load_image(image_path, target_size):
+    img = Image.open(image_path)
+    if img.mode != "RGB":
+        img = img.convert("RGB")
+    img = img.resize(target_size, Image.BILINEAR)
+    normalized_pixels = jnp.array(img).astype(jnp.float32) / 255.0
+    normalized_pixels = jnp.expand_dims(normalized_pixels, 0)
+    return normalized_pixels
+
+
+def load_model_from_preset(model_type, preset, dtype="float32"):
+    datasets_path = os.environ.get("DATASETS_PATH")
+    if datasets_path is None:
+        datasets_path = "/models/"
+
+    model_path = f"{datasets_path}/{preset}"
+    if os.path.exists(model_path):
+        return model_type.from_preset(model_path, dtype=dtype)
+    else:
+        raise Exception(f"Model path does not exist: {model_path}")

--- a/test/jax/test_vit_quantization.py
+++ b/test/jax/test_vit_quantization.py
@@ -6,23 +6,25 @@ import os
 
 os.environ["KERAS_BACKEND"] = "jax"
 
+import tempfile
+
 import jax.numpy as jnp
+import keras
 import pytest
-from jax import nn, random
+from jax import random
+from jax_test_utility import load_image, load_model_from_preset
 from keras.applications.imagenet_utils import decode_predictions
 from keras_hub.models import ViTImageClassifier
 
 from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig, quantize_model
 
-from ..jax_test_utility import load_image, load_model_from_preset
-
 
 @pytest.fixture(scope="module")
 def colva_beach_sq():
-    repo_root_path = f"{os.path.dirname(__file__)}/../../.."
+    repo_root_path = f"{os.path.dirname(__file__)}/../.."
     image_path = f"{repo_root_path}/examples/jax/keras/vit/colva_beach_sq.jpg"
     target_size = (224, 224)
-    return load_image(image_path, target_size)
+    return load_image(image_path, target_size, True)
 
 
 @pytest.fixture(scope="module")
@@ -34,8 +36,7 @@ def random_image():
 
 def classify_image(model, input, labels_n=1):
     out = model(input)
-    probs = nn.softmax(out, axis=-1)
-    labels = decode_predictions(jnp.array(probs), top=labels_n)[0]
+    labels = decode_predictions(jnp.array(out), top=labels_n)[0]
     return [class_name for (_, class_name, _) in labels]
 
 
@@ -53,8 +54,15 @@ def test_image_classification(dynamic, model_dtype, colva_beach_sq, random_image
         config = DynamicQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
         vit_q = quantize_model(vit, config, None)
     else:
-        config = StaticQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
+        config = StaticQuantConfig(
+            weight_dtype=quantization_dtype, activation_dtype=quantization_dtype, const_scale=True, const_weight=True
+        )
         vit_q = quantize_model(vit, config, calib_fn)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = os.path.join(tmpdir, "vit_quantized.keras")
+        keras.saving.save_model(vit_q, save_path)
+        vit_q = keras.saving.load_model(save_path)
 
     actual_labels = classify_image(vit_q, colva_beach_sq, len(expected_labels))
     assert expected_labels == actual_labels

--- a/test/jax/vit/test_model.py
+++ b/test/jax/vit/test_model.py
@@ -16,21 +16,12 @@ from PIL import Image
 from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig, quantize_model
 
 
-def load_model_from_preset(model_type, preset, allow_download=False, dtype="float32"):
-    datasets_path = "/models/"
-    model_path = datasets_path + preset
+@pytest.fixture(scope="module")
+def colva_beach_sq():
+    repo_root_path = f"{os.path.dirname(__file__)}/../../.."
+    image_path = f"{repo_root_path}/examples/jax/keras/vit/colva_beach_sq.jpg"
+    target_size = (224, 224)
 
-    if os.path.exists(model_path):
-        return model_type.from_preset(model_path, dtype=dtype)
-    elif allow_download:
-        model = model_type.from_preset(preset, dtype=dtype)
-        model.save_to_preset(model_path)
-        return model
-    else:
-        raise Exception(f"Model path does not exist: {model_path}")
-
-
-def load_image(image_path, target_size=(224, 224)):
     img = Image.open(image_path)
     if img.mode != "RGB":
         img = img.convert("RGB")
@@ -40,10 +31,23 @@ def load_image(image_path, target_size=(224, 224)):
     return normalized_pixels
 
 
-def create_random_image():
+@pytest.fixture(scope="module")
+def random_image():
     key = random.PRNGKey(0)
     img = random.uniform(key, shape=(1, 224, 224, 3), minval=0.0, maxval=1.0, dtype=jnp.float32)
     return img
+
+
+def load_model_from_preset(model_type, preset, dtype="float32"):
+    datasets_path = os.environ.get("DATASETS_PATH")
+    if datasets_path is None:
+        datasets_path = "/models/"
+
+    model_path = f"{datasets_path}/{preset}"
+    if os.path.exists(model_path):
+        return model_type.from_preset(model_path, dtype=dtype)
+    else:
+        raise Exception(f"Model path does not exist: {model_path}")
 
 
 def classify_image(model, input, labels_n=1):
@@ -55,17 +59,13 @@ def classify_image(model, input, labels_n=1):
 
 @pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
 @pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
-def test_image_classification(dynamic, model_dtype):
-    repo_root_path = f"{os.path.dirname(__file__)}/../../.."
-    image_path = f"{repo_root_path}/examples/jax/keras/vit/colva_beach_sq.jpg"
+def test_image_classification(dynamic, model_dtype, colva_beach_sq, random_image):
     expected_labels = ["seashore", "sandbar", "lakeside", "promontory", "beacon"]
     quantization_dtype = "fp8_e4m3"
-
-    vit = load_model_from_preset(ViTImageClassifier, "vit_base_patch16_224_imagenet", False, model_dtype)
-    image = load_image(image_path)
+    vit = load_model_from_preset(ViTImageClassifier, "vit_base_patch16_224_imagenet", model_dtype)
 
     def calib_fn(model):
-        _ = model(create_random_image())
+        _ = model(random_image)
 
     if dynamic:
         config = DynamicQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
@@ -74,5 +74,5 @@ def test_image_classification(dynamic, model_dtype):
         config = StaticQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
         vit_q = quantize_model(vit, config, calib_fn)
 
-    actual_labels = classify_image(vit_q, image, len(expected_labels))
+    actual_labels = classify_image(vit_q, colva_beach_sq, len(expected_labels))
     assert expected_labels == actual_labels

--- a/test/jax/vit/test_model.py
+++ b/test/jax/vit/test_model.py
@@ -8,7 +8,7 @@ os.environ["KERAS_BACKEND"] = "jax"
 
 import jax.numpy as jnp
 import pytest
-from jax import nn
+from jax import nn, random
 from keras.applications.imagenet_utils import decode_predictions
 from keras_hub.models import ViTImageClassifier
 from PIL import Image
@@ -40,6 +40,12 @@ def load_image(image_path, target_size=(224, 224)):
     return normalized_pixels
 
 
+def create_random_image():
+    key = random.PRNGKey(0)
+    img = random.uniform(key, shape=(1, 224, 224, 3), minval=0.0, maxval=1.0, dtype=jnp.float32)
+    return img
+
+
 def classify_image(model, input, labels_n=1):
     out = model(input)
     probs = nn.softmax(out, axis=-1)
@@ -59,7 +65,7 @@ def test_image_classification(dynamic, model_dtype):
     image = load_image(image_path)
 
     def calib_fn(model):
-        _ = model(image)
+        _ = model(create_random_image())
 
     if dynamic:
         config = DynamicQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)

--- a/test/jax/vit/test_model.py
+++ b/test/jax/vit/test_model.py
@@ -3,15 +3,18 @@
 """Tests for ViT model after quantization."""
 
 import os
+
 os.environ["KERAS_BACKEND"] = "jax"
 
-import pytest
 import jax.numpy as jnp
+import pytest
 from jax import nn
-from PIL import Image
 from keras.applications.imagenet_utils import decode_predictions
 from keras_hub.models import ViTImageClassifier
-from neural_compressor.jax import quantize_model, DynamicQuantConfig, StaticQuantConfig
+from PIL import Image
+
+from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig, quantize_model
+
 
 def load_model_from_preset(model_type, preset, allow_download=False, dtype="float32"):
     datasets_path = "/models/"
@@ -26,6 +29,7 @@ def load_model_from_preset(model_type, preset, allow_download=False, dtype="floa
     else:
         raise Exception(f"Model path does not exist: {model_path}")
 
+
 def load_image(image_path, target_size=(224, 224)):
     img = Image.open(image_path)
     if img.mode != "RGB":
@@ -35,22 +39,25 @@ def load_image(image_path, target_size=(224, 224)):
     normalized_pixels = jnp.expand_dims(normalized_pixels, 0)
     return normalized_pixels
 
+
 def classify_image(model, input, labels_n=1):
     out = model(input)
     probs = nn.softmax(out, axis=-1)
     labels = decode_predictions(jnp.array(probs), top=labels_n)[0]
     return [class_name for (_, class_name, _) in labels]
 
+
 @pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
 @pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
 def test_image_classification(dynamic, model_dtype):
-    image_path = "./examples/jax/keras/vit/colva_beach_sq.jpg"
-    expected_labels = ['seashore', 'sandbar', 'lakeside', 'promontory', 'beacon']
+    repo_root_path = f"{os.path.dirname(__file__)}/../../.."
+    image_path = f"{repo_root_path}/examples/jax/keras/vit/colva_beach_sq.jpg"
+    expected_labels = ["seashore", "sandbar", "lakeside", "promontory", "beacon"]
     quantization_dtype = "fp8_e4m3"
 
-    vit = load_model_from_preset(ViTImageClassifier, "vit_base_patch16_224_imagenet", True, model_dtype)
+    vit = load_model_from_preset(ViTImageClassifier, "vit_base_patch16_224_imagenet", False, model_dtype)
     image = load_image(image_path)
-    
+
     def calib_fn(model):
         _ = model(image)
 
@@ -60,6 +67,6 @@ def test_image_classification(dynamic, model_dtype):
     else:
         config = StaticQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
         vit_q = quantize_model(vit, config, calib_fn)
-    
+
     actual_labels = classify_image(vit_q, image, len(expected_labels))
     assert expected_labels == actual_labels

--- a/test/jax/vit/test_model.py
+++ b/test/jax/vit/test_model.py
@@ -13,14 +13,14 @@ from keras.applications.imagenet_utils import decode_predictions
 from keras_hub.models import ViTImageClassifier
 from neural_compressor.jax import quantize_model, DynamicQuantConfig, StaticQuantConfig
 
-def load_model_from_preset(modelType, preset, allow_download=False):
+def load_model_from_preset(modelType, preset, allow_download=False, dtype="float32"):
     datasets_path = "/models/"
     model_path = datasets_path + preset
 
     if os.path.exists(model_path):
-        return modelType.from_preset(model_path)
+        return modelType.from_preset(model_path, dtype=dtype)
     elif allow_download:
-        model = modelType.from_preset(preset)
+        model = modelType.from_preset(preset, dtype=dtype)
         model.save_to_preset(model_path)
         return model
     else:
@@ -31,9 +31,9 @@ def load_image(image_path, target_size=(224, 224)):
     if img.mode != "RGB":
         img = img.convert("RGB")
     img = img.resize(target_size, Image.BILINEAR)
-    arr = jnp.array(img).astype(jnp.float32) / 255.0
-    arr = jnp.expand_dims(arr, 0)
-    return arr
+    normalized_pixels = jnp.array(img).astype(jnp.float32) / 255.0
+    normalized_pixels = jnp.expand_dims(normalized_pixels, 0)
+    return normalized_pixels
 
 def classify_image(model, input, labels_n=1):
     out = model(input)
@@ -42,16 +42,17 @@ def classify_image(model, input, labels_n=1):
     return [class_name for (_, class_name, _) in labels]
 
 @pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
-def test_image_classification(dynamic):
+@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
+def test_image_classification(dynamic, model_dtype):
     image_path = "./examples/jax/keras/vit/colva_beach_sq.jpg"
     expected_labels = ['seashore', 'sandbar', 'lakeside', 'promontory', 'beacon']
     quantization_dtype = "fp8_e4m3"
 
-    vit = load_model_from_preset(ViTImageClassifier, "vit_base_patch16_224_imagenet", True)
-    input = load_image(image_path)
+    vit = load_model_from_preset(ViTImageClassifier, "vit_base_patch16_224_imagenet", True, model_dtype)
+    image = load_image(image_path)
     
     def calib_fn(model):
-        _ = model(input)
+        _ = model(image)
 
     if dynamic:
         config = DynamicQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
@@ -60,5 +61,5 @@ def test_image_classification(dynamic):
         config = StaticQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
         vit_q = quantize_model(vit, config, calib_fn)
     
-    actual_labels = classify_image(vit_q, input, len(expected_labels))
+    actual_labels = classify_image(vit_q, image, len(expected_labels))
     assert expected_labels == actual_labels

--- a/test/jax/vit/test_model.py
+++ b/test/jax/vit/test_model.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests for ViT model after quantization."""
+
+import os
+os.environ["KERAS_BACKEND"] = "jax"
+
+import pytest
+import jax.numpy as jnp
+from jax import nn
+from PIL import Image
+from keras.applications.imagenet_utils import decode_predictions
+from keras_hub.models import ViTImageClassifier
+from neural_compressor.jax import quantize_model, DynamicQuantConfig, StaticQuantConfig
+
+def load_model_from_preset(modelType, preset, allow_download=False):
+    datasets_path = "/models/"
+    model_path = datasets_path + preset
+
+    if os.path.exists(model_path):
+        return modelType.from_preset(model_path)
+    elif allow_download:
+        model = modelType.from_preset(preset)
+        model.save_to_preset(model_path)
+        return model
+    else:
+        raise Exception(f"Model path does not exist: {model_path}")
+
+def load_image(image_path, target_size=(224, 224)):
+    img = Image.open(image_path)
+    if img.mode != "RGB":
+        img = img.convert("RGB")
+    img = img.resize(target_size, Image.BILINEAR)
+    arr = jnp.array(img).astype(jnp.float32) / 255.0
+    arr = jnp.expand_dims(arr, 0)
+    return arr
+
+def classify_image(model, input, labels_n=1):
+    out = model(input)
+    probs = nn.softmax(out, axis=-1)
+    labels = decode_predictions(jnp.array(probs), top=labels_n)[0]
+    return [class_name for (_, class_name, _) in labels]
+
+@pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
+def test_image_classification(dynamic):
+    image_path = "./examples/jax/keras/vit/colva_beach_sq.jpg"
+    expected_labels = ['seashore', 'sandbar', 'lakeside', 'promontory', 'beacon']
+    quantization_dtype = "fp8_e4m3"
+
+    vit = load_model_from_preset(ViTImageClassifier, "vit_base_patch16_224_imagenet", True)
+    input = load_image(image_path)
+    
+    def calib_fn(model):
+        _ = model(input)
+
+    if dynamic:
+        config = DynamicQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
+        vit_q = quantize_model(vit, config, None)
+    else:
+        config = StaticQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
+        vit_q = quantize_model(vit, config, calib_fn)
+    
+    actual_labels = classify_image(vit_q, input, len(expected_labels))
+    assert expected_labels == actual_labels

--- a/test/jax/vit/test_model.py
+++ b/test/jax/vit/test_model.py
@@ -13,14 +13,14 @@ from keras.applications.imagenet_utils import decode_predictions
 from keras_hub.models import ViTImageClassifier
 from neural_compressor.jax import quantize_model, DynamicQuantConfig, StaticQuantConfig
 
-def load_model_from_preset(modelType, preset, allow_download=False, dtype="float32"):
+def load_model_from_preset(model_type, preset, allow_download=False, dtype="float32"):
     datasets_path = "/models/"
     model_path = datasets_path + preset
 
     if os.path.exists(model_path):
-        return modelType.from_preset(model_path, dtype=dtype)
+        return model_type.from_preset(model_path, dtype=dtype)
     elif allow_download:
-        model = modelType.from_preset(preset, dtype=dtype)
+        model = model_type.from_preset(preset, dtype=dtype)
         model.save_to_preset(model_path)
         return model
     else:

--- a/test/jax/vit/test_model.py
+++ b/test/jax/vit/test_model.py
@@ -11,9 +11,10 @@ import pytest
 from jax import nn, random
 from keras.applications.imagenet_utils import decode_predictions
 from keras_hub.models import ViTImageClassifier
-from PIL import Image
 
 from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig, quantize_model
+
+from ..jax_test_utility import load_image, load_model_from_preset
 
 
 @pytest.fixture(scope="module")
@@ -21,14 +22,7 @@ def colva_beach_sq():
     repo_root_path = f"{os.path.dirname(__file__)}/../../.."
     image_path = f"{repo_root_path}/examples/jax/keras/vit/colva_beach_sq.jpg"
     target_size = (224, 224)
-
-    img = Image.open(image_path)
-    if img.mode != "RGB":
-        img = img.convert("RGB")
-    img = img.resize(target_size, Image.BILINEAR)
-    normalized_pixels = jnp.array(img).astype(jnp.float32) / 255.0
-    normalized_pixels = jnp.expand_dims(normalized_pixels, 0)
-    return normalized_pixels
+    return load_image(image_path, target_size)
 
 
 @pytest.fixture(scope="module")
@@ -36,18 +30,6 @@ def random_image():
     key = random.PRNGKey(0)
     img = random.uniform(key, shape=(1, 224, 224, 3), minval=0.0, maxval=1.0, dtype=jnp.float32)
     return img
-
-
-def load_model_from_preset(model_type, preset, dtype="float32"):
-    datasets_path = os.environ.get("DATASETS_PATH")
-    if datasets_path is None:
-        datasets_path = "/models/"
-
-    model_path = f"{datasets_path}/{preset}"
-    if os.path.exists(model_path):
-        return model_type.from_preset(model_path, dtype=dtype)
-    else:
-        raise Exception(f"Model path does not exist: {model_path}")
 
 
 def classify_image(model, input, labels_n=1):


### PR DESCRIPTION
## Type of Change
Test

## Description
Adds a new test which quantizes small VIT model and runs image classification on colva_beach_sq.

## Expected Behavior & Potential Risk
E2E validation of VIT output in CI

## How has this PR been tested?
python -m pytest test/jax/vit/test_model.py

## Dependency Change?
No dependencies changed