### PR TITLE
[JAX] Enable dot_product_attention usage in MultiHeadAttention

### DIFF
--- a/neural_compressor/jax/quantization/layers_dynamic.py
+++ b/neural_compressor/jax/quantization/layers_dynamic.py
@@ -385,12 +385,11 @@ class QDynamicMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
             )
 
         # Determine whether to use dot-product attention
-        # use_dot_product_attention = not (
-        #     self._dropout > 0.0
-        #     or return_attention_scores
-        #     or (len(query.shape) != 4)
-        # )
-        use_dot_product_attention = False  # TODO Add dot_product_attention support
+        use_dot_product_attention = not (
+            self._dropout > 0.0
+            or return_attention_scores
+            or (len(query.shape) != 4)
+        )
 
         if use_dot_product_attention:
             if attention_mask is not None:
@@ -407,6 +406,9 @@ class QDynamicMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
                     )
                 attention_mask = ops.cast(attention_mask, dtype="bool")
             # Directly compute the attention output using dot-product attention
+            query = self.q_qdq(query)
+            key = self.k_qdq(key)
+            value = self.v_qdq(value)
             attention_output = ops.dot_product_attention(
                 query=query,
                 key=key,

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -167,6 +167,7 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         self.supports_masking = True
         self._is_quantized = False
         self.const_scale = const_scale
+        self.show_warning = True
         if const_scale:
             self._const_variables = ["a_scale"]
             if asymmetric:
@@ -224,10 +225,11 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             arange, self.activation_dtype, self.compute_dtype, asymmetric=self._is_asymmetric
         )
         if jnp.isinf(a_scale).any().item():
-            logger.warning(
-                f"Activation scale is inf for layer {self._path}. This may be caused by missing calibration data. "
-                "Please make sure to run calibration with representative dataset."
-            )
+            if self.show_warning:
+                logger.warning(
+                    f"Activation scale is inf for layer {self._path}. This may be caused by missing calibration data. "
+                    "Please make sure to run calibration with representative dataset."
+                )
             self._is_quantized = False
             self._tracker.lock()
             return
@@ -235,6 +237,20 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         if self._is_asymmetric:
             self.a_zero_point.assign(a_zero_point)
         self._tracker.lock()
+
+    def is_calibrated(self):
+        """Check if the layer has been properly calibrated.
+
+        Returns:
+            bool: True if scale are set to valid values, False otherwise.
+        """
+        # 0 scale value indicates that calibration not happen for given layer
+        # cause could be missing proper calibration data or particular instance is not used due to model dataflow
+        return not np.all(self.a_scale.value == 0)  # TODO here np instead of jnp
+
+    def switch_warning(self, param):
+        """Enable or disable warnings."""
+        self.show_warning = param
 
     def post_quantization_cleanup(self):
         """Remove observers and finalize quantized call path.
@@ -621,7 +637,11 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
             None: Updates QDQ helpers with calibrated values.
         """
         self.q_qdq.convert()
+        show_warning = not self.q_qdq.is_calibrated()
         self.k_qdq.convert()
+        # Disable warning for activation when query is calibrated,
+        # as when use_dot_product_attention path is used, activation is not used.
+        self.a_qdq.switch_warning(show_warning)
         self.a_qdq.convert()
         self.v_qdq.convert()
 
@@ -678,12 +698,11 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
             )
 
         # Determine whether to use dot-product attention
-        # use_dot_product_attention = not (
-        #     self._dropout > 0.0
-        #     or return_attention_scores
-        #     or (len(query.shape) != 4)
-        # )
-        use_dot_product_attention = False  # TODO Add dot_product_attention support
+        use_dot_product_attention = not (
+            self._dropout > 0.0
+            or return_attention_scores
+            or (len(query.shape) != 4)
+        )
 
         if use_dot_product_attention:
             if attention_mask is not None:
@@ -700,6 +719,9 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
                     )
                 attention_mask = ops.cast(attention_mask, dtype="bool")
             # Directly compute the attention output using dot-product attention
+            query = self.q_qdq(query)
+            key = self.k_qdq(key)
+            value = self.v_qdq(value)
             attention_output = ops.dot_product_attention(
                 query=query,
                 key=key,

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -167,7 +167,6 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         self.supports_masking = True
         self._is_quantized = False
         self.const_scale = const_scale
-        self.show_warning = True
         if const_scale:
             self._const_variables = ["a_scale"]
             if asymmetric:
@@ -225,11 +224,10 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             arange, self.activation_dtype, self.compute_dtype, asymmetric=self._is_asymmetric
         )
         if jnp.isinf(a_scale).any().item():
-            if self.show_warning:
-                logger.warning(
-                    f"Activation scale is inf for layer {self._path}. This may be caused by missing calibration data. "
-                    "Please make sure to run calibration with representative dataset."
-                )
+            logger.warning(
+                f"Activation scale is inf for layer {self._path}. This may be caused by missing calibration data. "
+                "Please make sure to run calibration with representative dataset."
+            )
             self._is_quantized = False
             self._tracker.lock()
             return
@@ -237,20 +235,6 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         if self._is_asymmetric:
             self.a_zero_point.assign(a_zero_point)
         self._tracker.lock()
-
-    def is_calibrated(self):
-        """Check if the layer has been properly calibrated.
-
-        Returns:
-            bool: True if scale are set to valid values, False otherwise.
-        """
-        # 0 scale value indicates that calibration not happen for given layer
-        # cause could be missing proper calibration data or particular instance is not used due to model dataflow
-        return not np.all(self.a_scale.value == 0)  # TODO here np instead of jnp
-
-    def switch_warning(self, param):
-        """Enable or disable warnings."""
-        self.show_warning = param
 
     def post_quantization_cleanup(self):
         """Remove observers and finalize quantized call path.
@@ -601,6 +585,8 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
         orig.__class__ = cls
         orig._is_int8 = jnp.issubdtype(activation_dtype, jnp.integer)
         orig.q_qdq = StaticQDQLayer("q_qdq", activation_dtype, orig.dtype_policy, orig._is_int8, const_scale)
+        # f_qdq is used for quantize/dequantize of query tensor on fallback path (without using dot_product_attention)
+        orig.f_qdq = StaticQDQLayer("f_qdq", activation_dtype, orig.dtype_policy, orig._is_int8, const_scale)
         orig.k_qdq = StaticQDQLayer("k_qdq", activation_dtype, orig.dtype_policy, orig._is_int8, const_scale)
         orig.a_qdq = StaticQDQLayer("a_qdq", activation_dtype, orig.dtype_policy, orig._is_int8, const_scale)
         orig.v_qdq = StaticQDQLayer("v_qdq", activation_dtype, orig.dtype_policy, orig._is_int8, const_scale)
@@ -615,6 +601,7 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
             None: Adds observer layers.
         """
         self.q_qdq.add_observers()
+        self.f_qdq.add_observers()
         self.k_qdq.add_observers()
         self.a_qdq.add_observers()
         self.v_qdq.add_observers()
@@ -626,6 +613,7 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
             None: Initializes QDQ helper variables.
         """
         self.q_qdq.add_variables()
+        self.f_qdq.add_variables()
         self.k_qdq.add_variables()
         self.a_qdq.add_variables()
         self.v_qdq.add_variables()
@@ -636,12 +624,13 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
         Returns:
             None: Updates QDQ helpers with calibrated values.
         """
-        self.q_qdq.convert()
-        show_warning = not self.q_qdq.is_calibrated()
+        self.f_qdq.convert()
+        # Calculate the scale for query for dot product attention path
+        # from the fallback path used in calibration
+        self.q_qdq.a_scale.assign(self.f_qdq.a_scale / self._inverse_sqrt_key_dim)
+        if self.q_qdq._is_asymmetric:
+            self.q_qdq.a_zero_point.assign(jnp.array(self.f_qdq.a_zero_point.value))
         self.k_qdq.convert()
-        # Disable warning for activation when query is calibrated,
-        # as when use_dot_product_attention path is used, activation is not used.
-        self.a_qdq.switch_warning(show_warning)
         self.a_qdq.convert()
         self.v_qdq.convert()
 
@@ -653,6 +642,7 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
         """
         self._tracker.unlock()
         self.q_qdq.post_quantization_cleanup()
+        self.f_qdq.post_quantization_cleanup()
         self.k_qdq.post_quantization_cleanup()
         self.a_qdq.post_quantization_cleanup()
         self.v_qdq.post_quantization_cleanup()
@@ -703,6 +693,8 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
             or return_attention_scores
             or (len(query.shape) != 4)
         )
+        # For calibration always use fallback path as it can collect data for both paths
+        use_dot_product_attention = use_dot_product_attention and self._is_quantized
 
         if use_dot_product_attention:
             if attention_mask is not None:
@@ -743,7 +735,7 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
         # Take the dot product between "query" and "key" to get the raw
         # attention scores.
         key = self.k_qdq(key)
-        query = self.q_qdq(query)
+        query = self.f_qdq(query)
         attention_scores = ops.einsum(self._dot_product_equation, key, query)
 
         # Apply the mask using the custom masked softmax


### PR DESCRIPTION
## Type of Change

feature

## Description

This PR enables the ops.dot_product_attention execution path in the JAX quantized MultiHeadAttention implementations (static and dynamic)

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
