### PR TITLE
[JAX] Use XLA_FLAGS by default in all tests

### DIFF
--- a/test/jax/conftest.py
+++ b/test/jax/conftest.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def setup_before_all_tests():
+    if os.getenv("XLA_FLAGS") is None:
+        xla_flags = [
+            "--xla_cpu_experimental_onednn_custom_call=true",
+            "--xla_cpu_use_onednn=false",
+            "--xla_cpu_experimental_ynn_fusion_type=invalid",
+            "--xla_cpu_use_xnnpack=false",
+            "--xla_backend_extra_options=xla_cpu_disable_new_fusion_emitter",
+        ]
+        os.environ["XLA_FLAGS"] = " ".join(xla_flags)

--- a/test/jax/conftest.py
+++ b/test/jax/conftest.py
@@ -1,10 +1,8 @@
 import os
 
-import pytest
 
-
-@pytest.fixture(autouse=True, scope="session")
-def setup_before_all_tests():
+def pytest_sessionstart(session):
+    os.environ["KERAS_BACKEND"] = "jax"
     if os.getenv("XLA_FLAGS") is None:
         xla_flags = [
             "--xla_cpu_experimental_onednn_custom_call=true",
@@ -14,3 +12,6 @@ def setup_before_all_tests():
             "--xla_backend_extra_options=xla_cpu_disable_new_fusion_emitter",
         ]
         os.environ["XLA_FLAGS"] = " ".join(xla_flags)
+
+    print("KERAS_BACKEND =", os.environ.get("KERAS_BACKEND"))
+    print("XLA_FLAGS =", os.environ.get("XLA_FLAGS"))

--- a/test/jax/test_accuracy.py
+++ b/test/jax/test_accuracy.py
@@ -10,18 +10,13 @@ Key FP8 quantization insights:
 - Scale factors determine the range mapping to FP8's limited precision
 """
 
-import os
-
-import pytest
-from jax_test_utility import compute_expected_qdq_dense_output
-
-os.environ["KERAS_BACKEND"] = "jax"
 from functools import reduce
 
 import jax
 import keras
-import ml_dtypes
+import pytest
 from jax import numpy as jnp
+from jax_test_utility import compute_expected_qdq_dense_output
 
 from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig, quantize_model
 from neural_compressor.jax.utils.utility import dtype_mapping

--- a/test/jax/test_gemma3.py
+++ b/test/jax/test_gemma3.py
@@ -16,13 +16,9 @@
 """Tests for Gemma model after quantization."""
 
 import os
-
-os.environ["KERAS_BACKEND"] = "jax"
-
 import random
 import string
 import tempfile
-from pathlib import Path
 
 import keras
 import pytest

--- a/test/jax/test_save_load.py
+++ b/test/jax/test_save_load.py
@@ -9,11 +9,8 @@ preserving both the quantization configuration and the quantized behavior.
 import os
 import tempfile
 
-import pytest
-
-os.environ["KERAS_BACKEND"] = "jax"
-
 import keras
+import pytest
 from jax import numpy as jnp
 
 from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig, quantize_model

--- a/test/jax/test_vit_quantization.py
+++ b/test/jax/test_vit_quantization.py
@@ -3,9 +3,6 @@
 """Tests for ViT model after quantization."""
 
 import os
-
-os.environ["KERAS_BACKEND"] = "jax"
-
 import tempfile
 
 import jax


### PR DESCRIPTION
## Type of Change

feature

## Description

Set XLA_FLAGS before running tests, if they were not set already

## Expected Behavior & Potential Risk

Hardware acceleration will be used by default locally and in CI

## How has this PR been tested?

run any existing test

## Dependency Change?

no library dependencies introduced or removed
