### PR TITLE
[JAX] Fix model loading from preset

### DIFF
--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -160,7 +160,7 @@ class SaveableLayerMixin:
         # Since this function modifies weights and removes variables, this behaviour causes crashes during loading.
         # To prevent that we can check if _is_quantized is None, since this should be initial value and is
         # modified later in this function
-        if self._is_quantized is not None:
+        if hasattr(self, "_is_quantized") and self._is_quantized is not None:
             return
 
         if self.__class__.__name__.startswith("Dynamic") or self.__class__.__name__.startswith("QDynamic"):

--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -156,7 +156,7 @@ class SaveableLayerMixin:
             None: Loads variables into the layer.
         """
 
-        # In some cases load_own_variables() may be called multiple times on for the same layer.
+        # In some cases load_own_variables() may be called multiple times for the same layer.
         # Since this function modifies weights and removes variables, this behaviour causes crashes during loading.
         #
         # To prevent that we can check if _is_quantized is None, since this should be initial value and is

--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -158,7 +158,6 @@ class SaveableLayerMixin:
 
         # In some cases load_own_variables() may be called multiple times for the same layer.
         # Since this function modifies weights and removes variables, this behaviour causes crashes during loading.
-        #
         # To prevent that we can check if _is_quantized is None, since this should be initial value and is
         # modified later in this function
         if self._is_quantized is not None:

--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -155,6 +155,15 @@ class SaveableLayerMixin:
         Returns:
             None: Loads variables into the layer.
         """
+
+        # In some cases load_own_variables() may be called multiple times on for the same layer.
+        # Since this function modifies weights and removes variables, this behaviour causes crashes during loading.
+        #
+        # To prevent that we can check if _is_quantized is None, since this should be initial value and is
+        # modified later in this function
+        if self._is_quantized is not None:
+            return
+
         if self.__class__.__name__.startswith("Dynamic") or self.__class__.__name__.startswith("QDynamic"):
             # Dynamic layers are always quantized
             self._is_quantized = True

--- a/test/jax/test_vit_quantization.py
+++ b/test/jax/test_vit_quantization.py
@@ -67,10 +67,10 @@ def test_image_classification(dynamic, model_dtype, quantization_dtype, colva_be
 
     with tempfile.TemporaryDirectory() as tmpdir:
         save_path = os.path.join(tmpdir, "vit_quantized.keras")
-        keras.saving.save_model(vit_q, save_path)
-        vit_q = keras.saving.load_model(save_path)
+        vit_q.save_to_preset(save_path)
+        vit_q_loaded = ViTImageClassifier.from_preset(save_path, dtype=model_dtype)
 
-    actual_labels = classify_image(vit_q, colva_beach_sq)
+    actual_labels = classify_image(vit_q_loaded, colva_beach_sq)
     assert (
         actual_labels[0][0] == expected_labels[0][0]
     ), f"Expected top-1 label '{expected_labels[0][0]}', but got '{actual_labels[0][0]}'"


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

Fixes error during model loading from preset.

When model is loaded using from_preset(), load_own_variables() is being called multiple times, so during second call cleanup is trying to remove already deletes variables. This PR adds a guard to load_own_variables() to return early if the layer was already loaded

## Expected Behavior & Potential Risk

Loading quantized presets works correctly

## How has this PR been tested?

call keras_hub.models.ImageClassifier.from_preset() on quantized model

## Dependency Change?

no dependency changes
