### PR TITLE
[JAX] Prepare QDQ for separate use quantization and dequantization

### DIFF
--- a/neural_compressor/jax/quantization/layers_dynamic.py
+++ b/neural_compressor/jax/quantization/layers_dynamic.py
@@ -68,23 +68,30 @@ def register_dynamic_quantized_layer(clso):
 class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
     """Layer that applies dynamic quantize-dequantize to activations."""
 
-    def __init__(self, name, activation_dtype, dtype="float32", asymmetric=False, fixed_range=None):
+    def __init__(
+        self, name, activation_dtype, dtype="float32", asymmetric=False, fixed_range=None, q_enable=True, dq_enable=True
+    ):
         """Initialize the dynamic QDQ helper layer.
 
         Args:
             name (str): Layer name.
             activation_dtype (jnp.dtype): Activation dtype used for quantization.
-            dtype (str): dtype for the layer - see keras.layers.Layer API for details.
+            dtype (str | keras.DTypePolicy): dtype for the layer - see keras.layers.Layer API for details.
             asymmetric (bool): Whether to use asymmetric quantization.
             fixed_range (Optional[Tuple[float, float]]): If provided, use this (min, max) range
                 instead of computing min/max dynamically per batch.
+            q_enable (bool): Whether to apply quantization. Default True.
+            dq_enable (bool): Whether to apply dequantization. Default True.
 
         Returns:
             None: Initializes the layer instance.
         """
+        assert q_enable or dq_enable, "At least one of q_enable or dq_enable must be True"
         super().__init__(name=name, dtype=dtype)
         self.activation_dtype = activation_dtype
         self._is_asymmetric = asymmetric
+        self._q_enable = q_enable
+        self._dq_enable = dq_enable
         self.supports_masking = True
         self.fixed_range = fixed_range
 
@@ -100,6 +107,8 @@ class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         self._tracker.unlock()
         self.aquantfun = get_quantize_fun(dtype=self.activation_dtype, asymmetric=self._is_asymmetric)
         self.adequantfun = get_dequantize_fun(dtype=self.compute_dtype, asymmetric=self._is_asymmetric)
+        self.quantize = self.aquantfun if self._q_enable else self._passthrough
+        self.dequantize = self.adequantfun if self._dq_enable else self._passthrough
         if self.fixed_range is not None:
             fixed_min_max = ops.array(self.fixed_range)
             a_scale, a_zero_point = get_q_params(
@@ -108,51 +117,54 @@ class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             self._fixed_a_scale = a_scale
             if self._is_asymmetric:
                 self._fixed_a_zero_point = a_zero_point
-            self.call = self.call_fixed_asymmetric if self._is_asymmetric else self.call_fixed_symmetric
+                self.take_scale = lambda inputs, mask=None: (self._fixed_a_scale, self._fixed_a_zero_point)
+            else:
+                self.take_scale = lambda inputs, mask=None: (self._fixed_a_scale,)
+        elif self._is_asymmetric:
+            self.take_scale = self._take_scale_dynamic_asymmetric
+        else:
+            self.take_scale = self._take_scale_dynamic_symmetric
+        self.call = self.call_quantized
         self._tracker.lock()
 
-    def call_symmetric(self, inputs, a_scale):
-        """Apply symmetric quantize-dequantize with given scale.
-
-        Args:
-            inputs (jnp.ndarray): Input tensor.
-            a_scale (jnp.ndarray): Quantization scale.
+    def post_quantization_cleanup(self):
+        """Finalize dynamic quantization with no extra cleanup.
 
         Returns:
-            jnp.ndarray: Quantized-dequantized tensor.
+            None: Keeps the layer ready for inference.
         """
-        x = self.aquantfun(inputs, a_scale)
-        x = self.adequantfun(x, a_scale)
-        return x
-
-    def call_asymmetric(self, inputs, a_scale, a_zero_point):
-        """Apply asymmetric quantize-dequantize with given scale and zero point.
-
-        Args:
-            inputs (jnp.ndarray): Input tensor.
-            a_scale (jnp.ndarray): Quantization scale.
-            a_zero_point (jnp.ndarray): Quantization zero point.
-
-        Returns:
-            jnp.ndarray: Quantized-dequantized tensor.
-        """
-        x = self.aquantfun(inputs, a_scale, a_zero_point)
-        x = self.adequantfun(x, a_scale, a_zero_point)
-        return x
+        pass
 
     def call(self, inputs, mask=None):
-        """Apply dynamic activation quantize-dequantize.
+        """Default call before add_variables is invoked.
+
+        Should not be reached after setup.
+        """
+        raise RuntimeError("DynamicQDQLayer.call: add_variables() must be called before use.")
+
+    def _passthrough(self, x, *args, **kwargs):
+        """No-op passthrough. Used when quantize or dequantize is disabled.
+
+        Args:
+            x (jnp.ndarray): Input tensor.
+            *args: Ignored positional params (e.g. scale, zero_point).
+            **kwargs: Ignored keyword params.
+
+        Returns:
+            jnp.ndarray: Unmodified input.
+        """
+        return x
+
+    def _compute_batch_min_max(self, inputs, mask=None):
+        """Compute batch min/max from inputs, respecting mask.
 
         Args:
             inputs (jnp.ndarray): Input tensor.
             mask (Optional[jnp.ndarray]): Optional mask tensor.
 
         Returns:
-            jnp.ndarray: Tensor with quantize-dequantize applied.
+            jnp.ndarray: Tensor of (min, max) values.
         """
-        if any([dim == 0 for dim in inputs.shape]):
-            # Skip quantization for zero-size inputs
-            return inputs
         if mask is not None:
             # Expand mask to match input dimensions if needed
             if len(mask.shape) < len(inputs.shape):
@@ -166,48 +178,52 @@ class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         else:
             batch_min = keras.ops.min(inputs)
             batch_max = keras.ops.max(inputs)
+        return keras.ops.array((batch_min, batch_max))
 
-        batch_min_max = keras.ops.array((batch_min, batch_max))
+    def _take_scale_dynamic_symmetric(self, inputs, mask=None):
+        """Compute symmetric scale dynamically from batch min/max.
 
-        if self._is_asymmetric:
-            a_scale, a_zero_point = get_q_params(
-                batch_min_max, self.activation_dtype, self.compute_dtype, asymmetric=True
-            )
-            return self.call_asymmetric(inputs, a_scale, a_zero_point)
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
+
+        Returns:
+            Tuple[jnp.ndarray]: Tuple containing (a_scale,).
+        """
+        batch_min_max = self._compute_batch_min_max(inputs, mask)
         a_scale, _ = get_q_params(batch_min_max, self.activation_dtype, self.compute_dtype, asymmetric=False)
-        return self.call_symmetric(inputs, a_scale)
+        return (a_scale,)
 
-    def call_fixed_symmetric(self, inputs, mask=None):
-        """Apply symmetric quantization using a pre-computed fixed scale.
-
-        Args:
-            inputs (jnp.ndarray): Input tensor.
-            mask (Optional[jnp.ndarray]): Optional mask tensor.
-
-        Returns:
-            jnp.ndarray: Quantized-dequantized tensor.
-        """
-        return self.call_symmetric(inputs, self._fixed_a_scale)
-
-    def call_fixed_asymmetric(self, inputs, mask=None):
-        """Apply asymmetric quantization using a pre-computed fixed scale.
+    def _take_scale_dynamic_asymmetric(self, inputs, mask=None):
+        """Compute asymmetric scale and zero point dynamically from batch min/max.
 
         Args:
             inputs (jnp.ndarray): Input tensor.
             mask (Optional[jnp.ndarray]): Optional mask tensor.
 
         Returns:
-            jnp.ndarray: Quantized-dequantized tensor.
+            Tuple[jnp.ndarray, jnp.ndarray]: Tuple containing (a_scale, a_zero_point).
         """
-        return self.call_asymmetric(inputs, self._fixed_a_scale, self._fixed_a_zero_point)
+        batch_min_max = self._compute_batch_min_max(inputs, mask)
+        a_scale, a_zero_point = get_q_params(batch_min_max, self.activation_dtype, self.compute_dtype, asymmetric=True)
+        return (a_scale, a_zero_point)
 
-    def post_quantization_cleanup(self):
-        """Finalize dynamic quantization with no extra cleanup.
+    def call_quantized(self, inputs, mask=None):
+        """Apply quantization pipeline to inputs.
+
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
 
         Returns:
-            None: Keeps the layer ready for inference.
+            jnp.ndarray: Processed tensor.
         """
-        pass
+        if any([dim == 0 for dim in inputs.shape]):
+            return inputs
+        params = self.take_scale(inputs, mask)
+        x = self.quantize(inputs, *params)
+        x = self.dequantize(x, *params)
+        return x
 
 
 class QDynamicDenseMixin(SaveableLayerMixin):

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -156,7 +156,17 @@ class MinMaxObserver(keras.layers.Layer):
 class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
     """Layer that applies static quantize-dequantize to activations."""
 
-    def __init__(self, name, activation_dtype, dtype="float32", asymmetric=False, const_scale=False, fixed_range=None):
+    def __init__(
+        self,
+        name,
+        activation_dtype,
+        dtype="float32",
+        asymmetric=False,
+        const_scale=False,
+        fixed_range=None,
+        q_enable=True,
+        dq_enable=True,
+    ):
         """Initialize the static QDQ helper layer.
 
         Args:
@@ -167,19 +177,24 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             const_scale (bool): Whether to use constant scales.
             fixed_range (Optional[Tuple[float, float]]): If provided, use this (min, max) range
                 instead of collecting calibration data via observers.
+            q_enable (bool): Whether to apply quantization. Default True.
+            dq_enable (bool): Whether to apply dequantization. Default True.
 
         Returns:
             None: Initializes the layer instance.
         """
+        assert q_enable or dq_enable, "At least one of q_enable or dq_enable must be True"
         super().__init__(name=name, dtype=dtype)
         self.activation_dtype = activation_dtype
         self._is_asymmetric = asymmetric
+        self._q_enable = q_enable
+        self._dq_enable = dq_enable
         self.supports_masking = True
         self._is_quantized = None
         self.const_scale = const_scale
         self.fixed_range = fixed_range
         if fixed_range is not None:
-            self.call = self.call_passthrough
+            self.call = self._passthrough
         if const_scale:
             self._const_variables = ["a_scale"]
             if asymmetric:
@@ -270,7 +285,8 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
 
         self._tracker.unlock()
         if self._is_quantized:
-            self.call = self.call_asymmetric if self._is_asymmetric else self.call_symmetric
+            self._setup_quantized_ops()
+            self.call = self.call_quantized
 
             model_is_during_load = self.a_scale == 0.0
             if not model_is_during_load:
@@ -281,7 +297,7 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
                     self._non_trainable_variables[:] = [v for v in self._non_trainable_variables if v is not var]
                     setattr(self, name, value)
         else:
-            self.call = self.call_passthrough
+            self.call = self._passthrough
             attrs_to_remove = [self.a_scale]
             if self._is_asymmetric:
                 attrs_to_remove.append(self.a_zero_point)
@@ -312,56 +328,50 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         x = self.input_observer(inputs, mask=mask)
         return x
 
-    def call_passthrough(self, inputs, mask=None):
-        """Pass inputs through without observation.
+    def _passthrough(self, x, *args, **kwargs):
+        """No-op passthrough. Used for disabled quantize/dequantize steps and as call_passthrough.
 
         Args:
-            inputs (jnp.ndarray): Input tensor.
-            mask (Optional[jnp.ndarray]): Optional mask tensor.
+            x (jnp.ndarray): Input tensor.
+            *args: Ignored positional params (e.g. scale, zero_point).
+            **kwargs: Ignored keyword params (e.g. mask).
 
         Returns:
-            jnp.ndarray: Unmodified inputs.
+            jnp.ndarray: Unmodified input.
         """
-        return inputs
-
-    def call_symmetric(self, inputs, mask=None):
-        """Apply symmetric quantize-dequantize to inputs.
-
-        Args:
-            inputs (jnp.ndarray): Input tensor.
-            mask (Optional[jnp.ndarray]): Optional mask tensor.
-
-        Returns:
-            jnp.ndarray: Quantized-dequantized tensor.
-        """
-
-        if self.const_scale:
-            a_scale = self.a_scale
-        else:
-            a_scale = self.a_scale.value
-
-        x = self.aquantfun(inputs, a_scale)
-        x = self.adequantfun(x, a_scale)
         return x
 
-    def call_asymmetric(self, inputs, mask=None):
-        """Apply asymmetric quantize-dequantize to inputs.
+    def _setup_quantized_ops(self):
+        """Assign take_scale, quantize, and dequantize methods for the quantized call.
+
+        Returns:
+            None: Sets self.take_scale, self.quantize, self.dequantize.
+        """
+        if self._is_asymmetric and self.const_scale:
+            self.take_scale = lambda: (self.a_scale, self.a_zero_point)
+        elif self._is_asymmetric:
+            self.take_scale = lambda: (self.a_scale.value, self.a_zero_point.value)
+        elif self.const_scale:
+            self.take_scale = lambda: (self.a_scale,)
+        else:
+            self.take_scale = lambda: (self.a_scale.value,)
+
+        self.quantize = self.aquantfun if self._q_enable else self._passthrough
+        self.dequantize = self.adequantfun if self._dq_enable else self._passthrough
+
+    def call_quantized(self, inputs, mask=None):
+        """Apply quantization pipeline to inputs.
 
         Args:
             inputs (jnp.ndarray): Input tensor.
             mask (Optional[jnp.ndarray]): Optional mask tensor.
 
         Returns:
-            jnp.ndarray: Quantized-dequantized tensor.
+            jnp.ndarray: Processed tensor.
         """
-        if self.const_scale:
-            a_scale = self.a_scale
-            a_zero_point = self.a_zero_point
-        else:
-            a_scale = self.a_scale.value
-            a_zero_point = self.a_zero_point.value
-        x = self.aquantfun(inputs, a_scale, a_zero_point)
-        x = self.adequantfun(x, a_scale, a_zero_point)
+        params = self.take_scale()
+        x = self.quantize(inputs, *params)
+        x = self.dequantize(x, *params)
         return x
 
 


### PR DESCRIPTION
## Type of Change

feature

## Description

Prepare QDQLayer's implementation to be used also as only quantization or dequantization
Align QDQLayer call_quantized implementation to always call 3 steps:
1. get scale function (get scale and zero if needed, const or variable)
2. quantize or nop
3. dequantize or nop

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
