### PR TITLE
[JAX] Fix reversible embedding

### DIFF
--- a/neural_compressor/jax/quantization/layers_dynamic.py
+++ b/neural_compressor/jax/quantization/layers_dynamic.py
@@ -20,11 +20,11 @@
 
 
 import keras
+import keras.layers
+import keras_hub.layers
 import numpy as np
 from jax import numpy as jnp
 from keras import ops
-from keras.layers import Conv2D, Dense, EinsumDense, MultiHeadAttention
-from keras_hub.layers import ReversibleEmbedding
 from keras_hub.src.models.gemma3.gemma3_attention import CachedGemma3Attention
 from keras_hub.src.models.gemma3.gemma3_vision_encoder import Gemma3VisionAttention
 
@@ -333,27 +333,27 @@ class QDynamicDenseMixin(SaveableLayerMixin):
         return x
 
 
-@register_dynamic_quantized_layer(Dense)
-class QDynamicDense(QDynamicDenseMixin, Dense):
+@register_dynamic_quantized_layer(keras.layers.Dense)
+class QDynamicDense(QDynamicDenseMixin, keras.layers.Dense):
     """Dynamically quantized Dense layer."""
 
     pass
 
 
-verify_api(Dense, QDynamicDense, "call")
+verify_api(keras.layers.Dense, QDynamicDense, "call")
 
 
-@register_dynamic_quantized_layer(EinsumDense)
-class QDynamicEinsumDense(QDynamicDenseMixin, EinsumDense):
+@register_dynamic_quantized_layer(keras.layers.EinsumDense)
+class QDynamicEinsumDense(QDynamicDenseMixin, keras.layers.EinsumDense):
     """Dynamically quantized EinsumDense layer."""
 
     pass
 
 
-verify_api(EinsumDense, QDynamicEinsumDense, "call")
+verify_api(keras.layers.EinsumDense, QDynamicEinsumDense, "call")
 
 
-class QDynamicConv2DMixin(QDynamicDenseMixin, Conv2D):
+class QDynamicConv2DMixin(QDynamicDenseMixin, keras.layers.Conv2D):
     """Mixin that adds dynamic quantization to Conv2D layers."""
 
     def call(self, inputs):
@@ -371,18 +371,18 @@ class QDynamicConv2DMixin(QDynamicDenseMixin, Conv2D):
         return x
 
 
-@register_dynamic_quantized_layer(Conv2D)
-class QDynamicConv2D(QDynamicConv2DMixin, Conv2D):
+@register_dynamic_quantized_layer(keras.layers.Conv2D)
+class QDynamicConv2D(QDynamicConv2DMixin, keras.layers.Conv2D):
     """Dynamically quantized Conv2D layer."""
 
     pass
 
 
-verify_api(Conv2D, QDynamicConv2D, "call")
+verify_api(keras.layers.Conv2D, QDynamicConv2D, "call")
 
 
-@register_dynamic_quantized_layer(MultiHeadAttention)
-class QDynamicMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
+@register_dynamic_quantized_layer(keras.layers.MultiHeadAttention)
+class QDynamicMultiHeadAttention(SaveableLayerMixin, keras.layers.MultiHeadAttention):
     """Dynamically quantized MultiHeadAttention layer."""
 
     @classmethod
@@ -536,7 +536,7 @@ class QDynamicMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
     # fmt on
 
 
-verify_api(MultiHeadAttention, QDynamicMultiHeadAttention, "_compute_attention")
+verify_api(keras.layers.MultiHeadAttention, QDynamicMultiHeadAttention, "_compute_attention")
 
 
 @register_dynamic_quantized_layer(CachedGemma3Attention)
@@ -758,8 +758,9 @@ class QDynamicGemma3VisionAttention(SaveableLayerMixin, Gemma3VisionAttention):
 verify_api(Gemma3VisionAttention, QDynamicGemma3VisionAttention, "call")
 
 
-@register_dynamic_quantized_layer(ReversibleEmbedding)
-class QDynamicReversibleEmbedding(SaveableLayerMixin, ReversibleEmbedding):
+@register_dynamic_quantized_layer(keras_hub.layers.ReversibleEmbedding)
+@register_dynamic_quantized_layer(keras.layers.ReversibleEmbedding)
+class QDynamicReversibleEmbedding(SaveableLayerMixin, keras.layers.ReversibleEmbedding):
     """Dynamically quantized ReversibleEmbedding layer."""
 
     @classmethod
@@ -830,7 +831,7 @@ class QDynamicReversibleEmbedding(SaveableLayerMixin, ReversibleEmbedding):
                 logits = ops.tanh(logits / soft_cap) * soft_cap
             return logits
 
-        return super(ReversibleEmbedding, self).call(inputs)
+        return super(keras.layers.ReversibleEmbedding, self).call(inputs)
 
 
-verify_api(ReversibleEmbedding, QDynamicReversibleEmbedding, "call")
+verify_api(keras.layers.ReversibleEmbedding, QDynamicReversibleEmbedding, "call")

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -1385,7 +1385,6 @@ class QStaticReversibleEmbedding(SaveableLayerMixin, keras.layers.ReversibleEmbe
         self._tracker.unlock()
         self.inputs_qdq.post_quantization_cleanup()
         self.kernel_qdq.post_quantization_cleanup()
-        self._is_quantized = True
         self._tracker.lock()
 
     def call(self, inputs, reverse=False):

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -1340,12 +1340,12 @@ class QStaticReversibleEmbedding(SaveableLayerMixin, keras.layers.ReversibleEmbe
         """Convert a ReversibleEmbedding instance for static quantization.
 
         Args:
-            orig (keras.layers.ReversibleEmbedding): Original layer instance.
+            orig (ReversibleEmbedding): Original layer instance.
             weight_dtype (jnp.dtype): Dtype for quantized weights.
             activation_dtype (jnp.dtype): Dtype for quantized activations.
 
         Returns:
-            keras.layers.ReversibleEmbedding: Updated layer instance.
+            ReversibleEmbedding: Updated layer instance.
         """
         orig._tracker.unlock()
         orig.__class__ = cls
@@ -1390,7 +1390,7 @@ class QStaticReversibleEmbedding(SaveableLayerMixin, keras.layers.ReversibleEmbe
         """Finalize static quantization and mark the layer as quantized.
 
         Returns:
-            None: Cleans up observers and marks quantized state.
+            None: Cleans up observers.
         """
         self._tracker.unlock()
         self.inputs_qdq.post_quantization_cleanup()

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -20,11 +20,11 @@
 
 
 import keras
+import keras.layers
+import keras_hub.layers
 import numpy as np
 from jax import numpy as jnp
 from keras import ops
-from keras.layers import Conv2D, Dense, EinsumDense, MultiHeadAttention
-from keras_hub.layers import ReversibleEmbedding, RotaryEmbedding
 from keras_hub.src.models.gemma3.gemma3_attention import CachedGemma3Attention
 from keras_hub.src.models.gemma3.gemma3_vision_encoder import Gemma3VisionAttention
 
@@ -612,27 +612,27 @@ class QStaticDenseMixin(SaveableLayerMixin):
         return x
 
 
-@register_static_quantized_layer(Dense)
-class QStaticDense(QStaticDenseMixin, Dense):
+@register_static_quantized_layer(keras.layers.Dense)
+class QStaticDense(QStaticDenseMixin, keras.layers.Dense):
     """Statically quantized Dense layer."""
 
     pass
 
 
-verify_api(Dense, QStaticDense, "call")
+verify_api(keras.layers.Dense, QStaticDense, "call")
 
 
-@register_static_quantized_layer(EinsumDense)
-class QStaticEinsumDense(QStaticDenseMixin, EinsumDense):
+@register_static_quantized_layer(keras.layers.EinsumDense)
+class QStaticEinsumDense(QStaticDenseMixin, keras.layers.EinsumDense):
     """Statically quantized EinsumDense layer."""
 
     pass
 
 
-verify_api(EinsumDense, QStaticEinsumDense, "call")
+verify_api(keras.layers.EinsumDense, QStaticEinsumDense, "call")
 
 
-class QStaticConv2DMixin(QStaticDenseMixin, Conv2D):
+class QStaticConv2DMixin(QStaticDenseMixin, keras.layers.Conv2D):
     """Mixin that adds static quantization to Conv2D layers."""
 
     def call(self, inputs):
@@ -690,18 +690,18 @@ class QStaticConv2DMixin(QStaticDenseMixin, Conv2D):
         return x
 
 
-@register_static_quantized_layer(Conv2D)
-class QStaticConv2d(QStaticConv2DMixin, Conv2D):
+@register_static_quantized_layer(keras.layers.Conv2D)
+class QStaticConv2d(QStaticConv2DMixin, keras.layers.Conv2D):
     """Statically quantized Conv2D layer."""
 
     pass
 
 
-verify_api(Conv2D, QStaticConv2d, "call")
+verify_api(keras.layers.Conv2D, QStaticConv2d, "call")
 
 
-@register_static_quantized_layer(MultiHeadAttention)
-class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
+@register_static_quantized_layer(keras.layers.MultiHeadAttention)
+class QStaticMultiHeadAttention(SaveableLayerMixin, keras.layers.MultiHeadAttention):
     """Statically quantized MultiHeadAttention layer."""
 
     @classmethod
@@ -912,7 +912,7 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, MultiHeadAttention):
     # fmt on
 
 
-verify_api(MultiHeadAttention, QStaticMultiHeadAttention, "_compute_attention")
+verify_api(keras.layers.MultiHeadAttention, QStaticMultiHeadAttention, "_compute_attention")
 
 
 @register_static_quantized_layer(CachedGemma3Attention)
@@ -1206,8 +1206,8 @@ class QStaticGemma3VisionAttention(SaveableLayerMixin, Gemma3VisionAttention):
 verify_api(Gemma3VisionAttention, QStaticGemma3VisionAttention, "call")
 
 
-# @register_static_quantized_layer(RotaryEmbedding)
-class QStaticRotaryEmbedding(SaveableLayerMixin, RotaryEmbedding):
+# @register_static_quantized_layer(keras_hub.layers.RotaryEmbedding)
+class QStaticRotaryEmbedding(SaveableLayerMixin, keras_hub.layers.RotaryEmbedding):
     """Statically quantized RotaryEmbedding layer."""
 
     @classmethod
@@ -1317,11 +1317,12 @@ class QStaticRotaryEmbedding(SaveableLayerMixin, RotaryEmbedding):
         return cos_emb, sin_emb
 
 
-# verify_api(RotaryEmbedding, QStaticRotaryEmbedding, "_compute_cos_sin_embedding")
+# verify_api(keras_hub.layers.RotaryEmbedding, QStaticRotaryEmbedding, "_compute_cos_sin_embedding")
 
 
-@register_static_quantized_layer(ReversibleEmbedding)
-class QStaticReversibleEmbedding(SaveableLayerMixin, ReversibleEmbedding):
+@register_static_quantized_layer(keras.layers.ReversibleEmbedding)
+@register_static_quantized_layer(keras_hub.layers.ReversibleEmbedding)
+class QStaticReversibleEmbedding(SaveableLayerMixin, keras.layers.ReversibleEmbedding):
     """Statically quantized ReversibleEmbedding layer."""
 
     @classmethod
@@ -1329,12 +1330,12 @@ class QStaticReversibleEmbedding(SaveableLayerMixin, ReversibleEmbedding):
         """Convert a ReversibleEmbedding instance for static quantization.
 
         Args:
-            orig (ReversibleEmbedding): Original layer instance.
+            orig (keras.layers.ReversibleEmbedding): Original layer instance.
             weight_dtype (jnp.dtype): Dtype for quantized weights.
             activation_dtype (jnp.dtype): Dtype for quantized activations.
 
         Returns:
-            ReversibleEmbedding: Updated layer instance.
+            keras.layers.ReversibleEmbedding: Updated layer instance.
         """
         orig._tracker.unlock()
         orig.__class__ = cls
@@ -1414,7 +1415,7 @@ class QStaticReversibleEmbedding(SaveableLayerMixin, ReversibleEmbedding):
                 logits = ops.tanh(logits / soft_cap) * soft_cap
             return logits
 
-        return super(ReversibleEmbedding, self).call(inputs)
+        return super(keras.layers.ReversibleEmbedding, self).call(inputs)
 
 
-verify_api(ReversibleEmbedding, QStaticReversibleEmbedding, "call")
+verify_api(keras.layers.ReversibleEmbedding, QStaticReversibleEmbedding, "call")


### PR DESCRIPTION
This PR adds missing registrations for ReversibleEmbedding, which caused this layer not to be quantized. 
This also revealed an issue with weights loading for QStaticReversibleEmbedding, which this PR also fixes.