### PR TITLE
[JAX] Update requirements to the working properly JAX version

### DIFF
--- a/requirements_jax.txt
+++ b/requirements_jax.txt
@@ -1,5 +1,5 @@
 deprecated>=1.2.13
-jax==0.10.0
+jax>=0.10.0
 keras>=3.14.1
 keras-hub>=0.29.1
 numpy


### PR DESCRIPTION
fix requirements to use newest fixed JAX version 0.10.2 (version 0.10.1 give wrong results) 
