### PR TITLE
[JAX] Use proper package name for Save/Load functionality 

### DIFF
--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -92,6 +92,8 @@ class VersionManager:
                 # If neural_compressor_jax is not found, try neural_compressor
                 if package == "neural_compressor_jax":
                     config["_versions"][package] = importlib_metadata.version("neural_compressor")
+                else:
+                    raise
 
     @classmethod
     def check_versions_mismatch(cls, config):
@@ -116,6 +118,8 @@ class VersionManager:
                 # If neural_compressor_jax is not found, try neural_compressor
                 if package == "neural_compressor_jax":
                     current_version = importlib_metadata.version("neural_compressor")
+                else:
+                    raise
 
             if version_in_config != current_version:
                 logger.warning(

--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -75,6 +75,18 @@ class VersionManager:
     _MODULES = ["neural_compressor_jax", "keras", "keras_hub"]
 
     @classmethod
+    def get_installed_inc_package_name(cls):
+        possible_names = ["neural_compressor", "neural_compressor_jax"]
+        for name in possible_names:
+            try:
+                importlib_metadata.version(name)
+                return name
+            except importlib_metadata.PackageNotFoundError:
+                continue
+
+        raise ModuleNotFoundError(f"Package of given name not found. Tried: {possible_names}")
+
+    @classmethod
     def add_versions(cls, config):
         """Insert package versions into the serialized config.
 
@@ -86,12 +98,12 @@ class VersionManager:
         """
         config["_versions"] = {}
         for package in cls._MODULES:
-            try:
+            if "neural_compressor" in package:
+                config["_versions"][package] = importlib_metadata.version(
+                    VersionManager.get_installed_inc_package_name()
+                )
+            else:
                 config["_versions"][package] = importlib_metadata.version(package)
-            except importlib_metadata.PackageNotFoundError:
-                # If neural_compressor_jax is not found, try neural_compressor
-                if package == "neural_compressor_jax":
-                    config["_versions"][package] = importlib_metadata.version("neural_compressor")
 
     @classmethod
     def check_versions_mismatch(cls, config):
@@ -110,12 +122,10 @@ class VersionManager:
             )
             return
         for package, version_in_config in versions.items():
-            try:
+            if "neural_compressor" in package:
+                current_version = importlib_metadata.version(VersionManager.get_installed_inc_package_name())
+            else:
                 current_version = importlib_metadata.version(package)
-            except importlib_metadata.PackageNotFoundError:
-                # If neural_compressor_jax is not found, try neural_compressor
-                if package == "neural_compressor_jax":
-                    current_version = importlib_metadata.version("neural_compressor")
 
             if version_in_config != current_version:
                 logger.warning(

--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -86,7 +86,12 @@ class VersionManager:
         """
         config["_versions"] = {}
         for package in cls._MODULES:
-            config["_versions"][package] = importlib_metadata.version(package)
+            try:
+                config["_versions"][package] = importlib_metadata.version(package)
+            except importlib_metadata.PackageNotFoundError:
+                # If neural_compressor_jax is not found, try neural_compressor
+                if package == "neural_compressor_jax":
+                    config["_versions"][package] = importlib_metadata.version("neural_compressor")
 
     @classmethod
     def check_versions_mismatch(cls, config):
@@ -105,7 +110,13 @@ class VersionManager:
             )
             return
         for package, version_in_config in versions.items():
-            current_version = importlib_metadata.version(package)
+            try:
+                current_version = importlib_metadata.version(package)
+            except importlib_metadata.PackageNotFoundError:
+                # If neural_compressor_jax is not found, try neural_compressor
+                if package == "neural_compressor_jax":
+                    current_version = importlib_metadata.version("neural_compressor")
+
             if version_in_config != current_version:
                 logger.warning(
                     f"{package}: version mismatch. Saved model: {version_in_config}, current version: {current_version}. "

--- a/neural_compressor/jax/quantization/saving.py
+++ b/neural_compressor/jax/quantization/saving.py
@@ -72,15 +72,14 @@ def quant_config_from_json_object(json_obj: dict) -> BaseConfig:
 class VersionManager:
     """Handle version metadata for serialized quantized models."""
 
-    _MODULES = ["neural_compressor_jax", "keras", "keras_hub"]
+    _MODULES = ["neural_compressor", "keras", "keras_hub"]
 
     @classmethod
-    def get_installed_inc_package_name(cls):
+    def get_installed_neural_compressor_version(cls):
         possible_names = ["neural_compressor", "neural_compressor_jax"]
         for name in possible_names:
             try:
-                importlib_metadata.version(name)
-                return name
+                return importlib_metadata.version(name)
             except importlib_metadata.PackageNotFoundError:
                 continue
 
@@ -99,9 +98,7 @@ class VersionManager:
         config["_versions"] = {}
         for package in cls._MODULES:
             if "neural_compressor" in package:
-                config["_versions"][package] = importlib_metadata.version(
-                    VersionManager.get_installed_inc_package_name()
-                )
+                config["_versions"][package] = VersionManager.get_installed_neural_compressor_version()
             else:
                 config["_versions"][package] = importlib_metadata.version(package)
 
@@ -123,7 +120,7 @@ class VersionManager:
             return
         for package, version_in_config in versions.items():
             if "neural_compressor" in package:
-                current_version = importlib_metadata.version(VersionManager.get_installed_inc_package_name())
+                current_version = VersionManager.get_installed_neural_compressor_version()
             else:
                 current_version = importlib_metadata.version(package)
 


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

Save/Load functionality tries to read INC version from the package, but expects the name to be "neural_compressor_jax". This PR adds fallback to "neural_compressor"

## Expected Behavior & Potential Risk

Save and load works even when INC was installed without INC_JAX_ONLY=1 flag

## How has this PR been tested?

pytest test/jax/test_save_load.py

## Dependency Change?

No changes
