### PR TITLE
use safe weights-only loading and add deserialization security validation

### DIFF
--- a/neural_compressor/torch/algorithms/layer_wise/modified_pickle.py
+++ b/neural_compressor/torch/algorithms/layer_wise/modified_pickle.py
@@ -1617,6 +1617,8 @@ class _Unpickler:  # pragma: no cover
         # Security: Block dangerous modules and functions to prevent RCE via deserialization (CWE-502)
         DANGEROUS_MODULES = {
             "os",
+            "posix",
+            "nt",
             "subprocess",
             "sys",
             "socket",
@@ -1637,6 +1639,8 @@ class _Unpickler:  # pragma: no cover
             "exec",
             "compile",
             "open",
+            "system",
+            "popen",
             "__import__",
             "breakpoint",
             "input",

--- a/neural_compressor/torch/algorithms/layer_wise/modified_pickle.py
+++ b/neural_compressor/torch/algorithms/layer_wise/modified_pickle.py
@@ -1614,6 +1614,29 @@ class _Unpickler:  # pragma: no cover
 
     def find_class(self, module, name):
         # Subclasses may override this.
+        # Security: Block dangerous modules and functions to prevent RCE via deserialization (CWE-502)
+        DANGEROUS_MODULES = {
+            'os', 'subprocess', 'sys', 'socket', 'urllib', 'requests',
+            'tempfile', 'shutil', 'glob', 'importlib', '__main__',
+            'builtins', '__builtins__', 'code', 'codeop',
+        }
+        DANGEROUS_NAMES = {
+            'eval', 'exec', 'compile', 'open', '__import__',
+            'breakpoint', 'input', 'help', 'dir',
+        }
+
+        # Check for dangerous modules
+        if module in DANGEROUS_MODULES:
+            raise UnpicklingError(
+                f"Unpickling forbidden module '{module}'"
+            )
+
+        # Check for dangerous names in any module
+        if name in DANGEROUS_NAMES:
+            raise UnpicklingError(
+                f"Unpickling forbidden function '{module}.{name}'"
+            )
+
         sys.audit("pickle.find_class", module, name)
         if self.proto < 3 and self.fix_imports:
             if (module, name) in _compat_pickle.NAME_MAPPING:

--- a/neural_compressor/torch/algorithms/layer_wise/modified_pickle.py
+++ b/neural_compressor/torch/algorithms/layer_wise/modified_pickle.py
@@ -1616,26 +1616,41 @@ class _Unpickler:  # pragma: no cover
         # Subclasses may override this.
         # Security: Block dangerous modules and functions to prevent RCE via deserialization (CWE-502)
         DANGEROUS_MODULES = {
-            'os', 'subprocess', 'sys', 'socket', 'urllib', 'requests',
-            'tempfile', 'shutil', 'glob', 'importlib', '__main__',
-            'builtins', '__builtins__', 'code', 'codeop',
+            "os",
+            "subprocess",
+            "sys",
+            "socket",
+            "urllib",
+            "requests",
+            "tempfile",
+            "shutil",
+            "glob",
+            "importlib",
+            "__main__",
+            "builtins",
+            "__builtins__",
+            "code",
+            "codeop",
         }
         DANGEROUS_NAMES = {
-            'eval', 'exec', 'compile', 'open', '__import__',
-            'breakpoint', 'input', 'help', 'dir',
+            "eval",
+            "exec",
+            "compile",
+            "open",
+            "__import__",
+            "breakpoint",
+            "input",
+            "help",
+            "dir",
         }
 
         # Check for dangerous modules
         if module in DANGEROUS_MODULES:
-            raise UnpicklingError(
-                f"Unpickling forbidden module '{module}'"
-            )
+            raise UnpicklingError(f"Unpickling forbidden module '{module}'")
 
         # Check for dangerous names in any module
         if name in DANGEROUS_NAMES:
-            raise UnpicklingError(
-                f"Unpickling forbidden function '{module}.{name}'"
-            )
+            raise UnpicklingError(f"Unpickling forbidden function '{module}.{name}'")
 
         sys.audit("pickle.find_class", module, name)
         if self.proto < 3 and self.fix_imports:

--- a/neural_compressor/torch/algorithms/weight_only/save_load.py
+++ b/neural_compressor/torch/algorithms/weight_only/save_load.py
@@ -292,15 +292,11 @@ class WOQModelLoader:
         """
         try:
             return torch.load(weight_file_path, weights_only=True)
-        except TypeError:
-            # Backward compatibility for old PyTorch versions that do not support
-            # the `weights_only` argument.
-            logger.warning(
-                "Current PyTorch does not support `weights_only` in torch.load. "
-                "Falling back to legacy loading behavior for %s.",
-                weight_file_path,
-            )
-            return torch.load(weight_file_path)
+        except TypeError as exc:
+            raise RuntimeError(
+                "`weights_only` in torch.load requires torch>=2.0. "
+                "If your torch version is lower, please use an older Neural Compressor version."
+            ) from exc
         except Exception as exc:
             raise RuntimeError(
                 "Failed to load quantized weights with `weights_only=True`. "

--- a/neural_compressor/torch/algorithms/weight_only/save_load.py
+++ b/neural_compressor/torch/algorithms/weight_only/save_load.py
@@ -257,7 +257,7 @@ class WOQModelLoader:
                 bin_index_file = os.path.join(shard_dir, "model_bin_index.json")
                 self.loaded_state_dict = load_model_from_shards_with_safetensors(shard_dir, bin_index_file)
         else:
-            self.loaded_state_dict = torch.load(qmodel_weight_file_path)
+            self.loaded_state_dict = self._load_weight_file(qmodel_weight_file_path)
 
         self.loaded_state_dict_keys = list(set(self.loaded_state_dict.keys()))
 
@@ -283,6 +283,30 @@ class WOQModelLoader:
 
         model.eval()
         return model
+
+    def _load_weight_file(self, weight_file_path):
+        """Load weight file with safe defaults.
+
+        `weights_only=True` avoids unpickling arbitrary Python objects when loading
+        quantized checkpoints.
+        """
+        try:
+            return torch.load(weight_file_path, weights_only=True)
+        except TypeError:
+            # Backward compatibility for old PyTorch versions that do not support
+            # the `weights_only` argument.
+            logger.warning(
+                "Current PyTorch does not support `weights_only` in torch.load. "
+                "Falling back to legacy loading behavior for %s.",
+                weight_file_path,
+            )
+            return torch.load(weight_file_path)
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to load quantized weights with `weights_only=True`. "
+                "Please ensure the checkpoint only contains tensor weights and "
+                f"quantization config is saved in `{QCONFIG_NAME}`."
+            ) from exc
 
     def _is_w4a8_model_from_auto_round(self):
         if self.quantization_config.get("data_type", None) == "fp8_to_int_sym":

--- a/test/torch/quantization/weight_only/test_load.py
+++ b/test/torch/quantization/weight_only/test_load.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 import transformers
 
+from neural_compressor.torch.algorithms.weight_only.save_load import WOQModelLoader
 from neural_compressor.torch.quantization import load
 from neural_compressor.torch.utils import SaveLoadFormat, accelerator, is_hpu_available
 
@@ -99,3 +100,57 @@ class TestHFModelLoad:
             cache_dir=self.local_cache,
         )
         assert model is not None, "Model not loaded correctly"
+
+
+def test_load_weight_file_uses_weights_only(monkeypatch):
+    loader = WOQModelLoader(model_name_or_path="dummy", format=SaveLoadFormat.DEFAULT)
+    calls = []
+
+    def _fake_torch_load(path, **kwargs):
+        calls.append((path, kwargs))
+        return {"w": torch.tensor([1])}
+
+    monkeypatch.setattr(torch, "load", _fake_torch_load)
+
+    loaded = loader._load_weight_file("dummy.pt")
+
+    assert loaded["w"].item() == 1
+    assert len(calls) == 1
+    assert calls[0][0] == "dummy.pt"
+    assert calls[0][1].get("weights_only") is True
+
+
+def test_load_weight_file_fallback_for_legacy_torch(monkeypatch):
+    loader = WOQModelLoader(model_name_or_path="dummy", format=SaveLoadFormat.DEFAULT)
+    calls = []
+
+    def _fake_torch_load(path, **kwargs):
+        calls.append((path, kwargs))
+        if "weights_only" in kwargs:
+            raise TypeError("weights_only is unsupported")
+        return {"ok": torch.tensor([2])}
+
+    monkeypatch.setattr(torch, "load", _fake_torch_load)
+
+    loaded = loader._load_weight_file("legacy.pt")
+
+    assert loaded["ok"].item() == 2
+    assert len(calls) == 2
+    assert calls[0][0] == "legacy.pt"
+    assert calls[0][1].get("weights_only") is True
+    assert calls[1][0] == "legacy.pt"
+    assert calls[1][1] == {}
+
+
+def test_load_weight_file_raises_runtime_error_for_non_type_error(monkeypatch):
+    loader = WOQModelLoader(model_name_or_path="dummy", format=SaveLoadFormat.DEFAULT)
+
+    def _fake_torch_load(path, **kwargs):
+        raise RuntimeError("corrupted checkpoint")
+
+    monkeypatch.setattr(torch, "load", _fake_torch_load)
+
+    with pytest.raises(RuntimeError, match="weights_only=True") as exc_info:
+        loader._load_weight_file("broken.pt")
+
+    assert "qconfig.json" in str(exc_info.value)

--- a/test/torch/quantization/weight_only/test_load.py
+++ b/test/torch/quantization/weight_only/test_load.py
@@ -120,7 +120,7 @@ def test_load_weight_file_uses_weights_only(monkeypatch):
     assert calls[0][1].get("weights_only") is True
 
 
-def test_load_weight_file_fallback_for_legacy_torch(monkeypatch):
+def test_load_weight_file_raises_runtime_error_for_legacy_torch(monkeypatch):
     loader = WOQModelLoader(model_name_or_path="dummy", format=SaveLoadFormat.DEFAULT)
     calls = []
 
@@ -128,18 +128,15 @@ def test_load_weight_file_fallback_for_legacy_torch(monkeypatch):
         calls.append((path, kwargs))
         if "weights_only" in kwargs:
             raise TypeError("weights_only is unsupported")
-        return {"ok": torch.tensor([2])}
 
     monkeypatch.setattr(torch, "load", _fake_torch_load)
 
-    loaded = loader._load_weight_file("legacy.pt")
+    with pytest.raises(RuntimeError, match="requires torch>=2.0"):
+        loader._load_weight_file("legacy.pt")
 
-    assert loaded["ok"].item() == 2
-    assert len(calls) == 2
+    assert len(calls) == 1
     assert calls[0][0] == "legacy.pt"
     assert calls[0][1].get("weights_only") is True
-    assert calls[1][0] == "legacy.pt"
-    assert calls[1][1] == {}
 
 
 def test_load_weight_file_raises_runtime_error_for_non_type_error(monkeypatch):

--- a/test/torch/quantization/weight_only/test_rtn.py
+++ b/test/torch/quantization/weight_only/test_rtn.py
@@ -1,10 +1,16 @@
 import copy
+import io
+import os
+import pickle as python_pickle
 import shutil
+import sys
+import types
 
 import pytest
 import torch
 import transformers
 
+from neural_compressor.torch.algorithms.layer_wise import modified_pickle
 from neural_compressor.torch.quantization import (
     RTNConfig,
     convert,
@@ -16,6 +22,42 @@ from neural_compressor.torch.quantization import (
 from neural_compressor.torch.utils import accelerator, is_hpu_available
 
 device = accelerator.name()
+
+
+def test_modified_pickle_blocks_native_system_calls():
+    class MaliciousPayload:
+        def __reduce__(self):
+            return (os.system, ("echo blocked",))
+
+    payload = python_pickle.dumps(MaliciousPayload())
+
+    with pytest.raises(modified_pickle.UnpicklingError, match="forbidden"):
+        modified_pickle._Unpickler(io.BytesIO(payload)).load()
+
+
+def test_modified_pickle_blocks_dangerous_names(monkeypatch):
+    module_name = "nc_test_pickle_guard"
+    test_module = types.ModuleType(module_name)
+    exec(
+        "def eval(value):\n    return value\n",
+        test_module.__dict__,
+    )
+    monkeypatch.setitem(sys.modules, module_name, test_module)
+
+    class MaliciousPayload:
+        def __reduce__(self):
+            return (test_module.eval, ("payload",))
+
+    payload = python_pickle.dumps(MaliciousPayload())
+
+    with pytest.raises(modified_pickle.UnpicklingError, match="forbidden"):
+        modified_pickle._Unpickler(io.BytesIO(payload)).load()
+
+
+def test_modified_pickle_allows_safe_payload():
+    payload = python_pickle.dumps({"value": [1, 2, 3]})
+
+    assert modified_pickle._Unpickler(io.BytesIO(payload)).load() == {"value": [1, 2, 3]}
 
 
 class ModelConv1d(torch.nn.Module):


### PR DESCRIPTION
## Type of Change

others

## Description

Makes WOQ loading safer by using `weights_only=True` by default, with a fallback for older PyTorch versions. (https://jira.devtools.intel.com/browse/ILITV-4261)
Add deserialization security validation(by adding blacklist) to prevent pickle RCE attacks (https://jira.devtools.intel.com/browse/ILITV-4276)
## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
