### PR TITLE
[JAX] Add possibility to call quantization to and dequantization only

### DIFF
--- a/neural_compressor/jax/quantization/layers_dynamic.py
+++ b/neural_compressor/jax/quantization/layers_dynamic.py
@@ -68,9 +68,7 @@ def register_dynamic_quantized_layer(clso):
 class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
     """Layer that applies dynamic quantize-dequantize to activations."""
 
-    def __init__(
-        self, name, activation_dtype, dtype="float32", asymmetric=False, fixed_range=None, q_enable=True, dq_enable=True
-    ):
+    def __init__(self, name, activation_dtype, dtype="float32", asymmetric=False, fixed_range=None):
         """Initialize the dynamic QDQ helper layer.
 
         Args:
@@ -80,18 +78,13 @@ class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             asymmetric (bool): Whether to use asymmetric quantization.
             fixed_range (Optional[Tuple[float, float]]): If provided, use this (min, max) range
                 instead of computing min/max dynamically per batch.
-            q_enable (bool): Whether to apply quantization. Default True.
-            dq_enable (bool): Whether to apply dequantization. Default True.
 
         Returns:
             None: Initializes the layer instance.
         """
-        assert q_enable or dq_enable, "At least one of q_enable or dq_enable must be True"
         super().__init__(name=name, dtype=dtype)
         self.activation_dtype = activation_dtype
         self._is_asymmetric = asymmetric
-        self._q_enable = q_enable
-        self._dq_enable = dq_enable
         self.supports_masking = True
         self.fixed_range = fixed_range
 
@@ -105,10 +98,8 @@ class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             None: Initializes quantization functions.
         """
         self._tracker.unlock()
-        self.aquantfun = get_quantize_fun(dtype=self.activation_dtype, asymmetric=self._is_asymmetric)
-        self.adequantfun = get_dequantize_fun(dtype=self.compute_dtype, asymmetric=self._is_asymmetric)
-        self.quantize = self.aquantfun if self._q_enable else self._passthrough
-        self.dequantize = self.adequantfun if self._dq_enable else self._passthrough
+        self.quantize = get_quantize_fun(dtype=self.activation_dtype, asymmetric=self._is_asymmetric)
+        self.dequantize = get_dequantize_fun(dtype=self.compute_dtype, asymmetric=self._is_asymmetric)
         if self.fixed_range is not None:
             fixed_min_max = ops.array(self.fixed_range)
             a_scale, a_zero_point = get_q_params(
@@ -224,6 +215,41 @@ class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         x = self.quantize(inputs, *params)
         x = self.dequantize(x, *params)
         return x
+
+    def call_q(self, inputs, mask=None):
+        """Q-side of split QDQ: compute scale and quantize.
+
+        Computes scale from inputs (or uses fixed scale), quantizes,
+        and stores the scale params for a subsequent call_dq.
+
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
+
+        Returns:
+            jnp.ndarray: Quantized tensor.
+        """
+        if any([dim == 0 for dim in inputs.shape]):
+            return inputs
+        params = self.take_scale(inputs, mask)
+        self._last_params = params
+        return self.quantize(inputs, *params)
+
+    def call_dq(self, inputs, mask=None):
+        """DQ-side of split QDQ: dequantize using scale from prior call_q.
+
+        Uses the scale params stored by the most recent call_q invocation.
+
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
+
+        Returns:
+            jnp.ndarray: Dequantized tensor.
+        """
+        if any([dim == 0 for dim in inputs.shape]):
+            return inputs
+        return self.dequantize(inputs, *self._last_params)
 
 
 class QDynamicDenseMixin(SaveableLayerMixin):

--- a/neural_compressor/jax/quantization/layers_dynamic.py
+++ b/neural_compressor/jax/quantization/layers_dynamic.py
@@ -238,7 +238,11 @@ class DynamicQDQLayer(SaveableLayerMixin, keras.layers.Layer):
     def call_dq(self, inputs, mask=None):
         """DQ-side of split QDQ: dequantize using scale from prior call_q.
 
-        Uses the scale params stored by the most recent call_q invocation.
+        Uses the scale params stored by the most recent ``call_q`` invocation.
+
+        Note:
+            ``call_q`` must be called first, as it computes and stores
+            the scale parameters (``_last_params``) required by this method.
 
         Args:
             inputs (jnp.ndarray): Input tensor.

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -164,8 +164,6 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         asymmetric=False,
         const_scale=False,
         fixed_range=None,
-        q_enable=True,
-        dq_enable=True,
     ):
         """Initialize the static QDQ helper layer.
 
@@ -177,24 +175,21 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             const_scale (bool): Whether to use constant scales.
             fixed_range (Optional[Tuple[float, float]]): If provided, use this (min, max) range
                 instead of collecting calibration data via observers.
-            q_enable (bool): Whether to apply quantization. Default True.
-            dq_enable (bool): Whether to apply dequantization. Default True.
 
         Returns:
             None: Initializes the layer instance.
         """
-        assert q_enable or dq_enable, "At least one of q_enable or dq_enable must be True"
         super().__init__(name=name, dtype=dtype)
         self.activation_dtype = activation_dtype
         self._is_asymmetric = asymmetric
-        self._q_enable = q_enable
-        self._dq_enable = dq_enable
         self.supports_masking = True
         self._is_quantized = None
         self.const_scale = const_scale
         self.fixed_range = fixed_range
         if fixed_range is not None:
             self.call = self._passthrough
+            self.call_q = self._passthrough
+            self.call_dq = self._passthrough
         if const_scale:
             self._const_variables = ["a_scale"]
             if asymmetric:
@@ -240,8 +235,8 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             autocast=False,
             dtype=self.compute_dtype,
         )
-        self.aquantfun = get_quantize_fun(dtype=self.activation_dtype, asymmetric=self._is_asymmetric)
-        self.adequantfun = get_dequantize_fun(dtype=self.compute_dtype, asymmetric=self._is_asymmetric)
+        self.quantize = get_quantize_fun(dtype=self.activation_dtype, asymmetric=self._is_asymmetric)
+        self.dequantize = get_dequantize_fun(dtype=self.compute_dtype, asymmetric=self._is_asymmetric)
         self._tracker.lock()
 
     def convert(self):
@@ -286,8 +281,6 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         self._tracker.unlock()
         if self._is_quantized:
             self._setup_quantized_ops()
-            self.call = self.call_quantized
-
             model_is_during_load = self.a_scale == 0.0
             if not model_is_during_load:
                 # convert variables to attributes (const) if needed
@@ -298,6 +291,8 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
                     setattr(self, name, value)
         else:
             self.call = self._passthrough
+            self.call_q = self._passthrough
+            self.call_dq = self._passthrough
             attrs_to_remove = [self.a_scale]
             if self._is_asymmetric:
                 attrs_to_remove.append(self.a_zero_point)
@@ -328,6 +323,63 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         x = self.input_observer(inputs, mask=mask)
         return x
 
+    def call_q(self, inputs, mask=None):
+        """Q-side of split QDQ: observe inputs during calibration.
+
+        During calibration, runs the observer on inputs.
+        After post_quantization_cleanup, this is reassigned to quantize-only.
+
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
+
+        Returns:
+            jnp.ndarray: Observed inputs (unchanged values during calibration).
+        """
+        x = self.input_observer(inputs, mask=mask)
+        return x
+
+    def call_dq(self, inputs, mask=None):
+        """DQ-side of split QDQ: passthrough during calibration.
+
+        During calibration, passes inputs through unchanged.
+        After post_quantization_cleanup, this is reassigned to dequantize-only.
+
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
+
+        Returns:
+            jnp.ndarray: Unmodified inputs.
+        """
+        return inputs
+
+    def _call_q_quantized(self, inputs, mask=None):
+        """Quantize-only using pre-computed scale (inference path).
+
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
+
+        Returns:
+            jnp.ndarray: Quantized tensor.
+        """
+        params = self.take_scale()
+        return self.quantize(inputs, *params)
+
+    def _call_dq_quantized(self, inputs, mask=None):
+        """Dequantize-only using pre-computed scale (inference path).
+
+        Args:
+            inputs (jnp.ndarray): Input tensor.
+            mask (Optional[jnp.ndarray]): Optional mask tensor.
+
+        Returns:
+            jnp.ndarray: Dequantized tensor.
+        """
+        params = self.take_scale()
+        return self.dequantize(inputs, *params)
+
     def _passthrough(self, x, *args, **kwargs):
         """No-op passthrough. Used for disabled quantize/dequantize steps and as call_passthrough.
 
@@ -342,10 +394,10 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
         return x
 
     def _setup_quantized_ops(self):
-        """Assign take_scale, quantize, and dequantize methods for the quantized call.
+        """Set up take_scale and reassign call, call_q, call_dq for inference.
 
         Returns:
-            None: Sets self.take_scale, self.quantize, self.dequantize.
+            None: Sets self.take_scale, self.call, self.call_q, self.call_dq.
         """
         if self._is_asymmetric and self.const_scale:
             self.take_scale = lambda: (self.a_scale, self.a_zero_point)
@@ -355,9 +407,9 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
             self.take_scale = lambda: (self.a_scale,)
         else:
             self.take_scale = lambda: (self.a_scale.value,)
-
-        self.quantize = self.aquantfun if self._q_enable else self._passthrough
-        self.dequantize = self.adequantfun if self._dq_enable else self._passthrough
+        self.call = self.call_quantized
+        self.call_q = self._call_q_quantized
+        self.call_dq = self._call_dq_quantized
 
     def call_quantized(self, inputs, mask=None):
         """Apply quantization pipeline to inputs.

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -370,6 +370,10 @@ class StaticQDQLayer(SaveableLayerMixin, keras.layers.Layer):
     def _call_dq_quantized(self, inputs, mask=None):
         """Dequantize-only using pre-computed scale (inference path).
 
+        Note:
+            ``call_q`` must be called first, as it performs calibration
+            and computes the scale required by this method.
+
         Args:
             inputs (jnp.ndarray): Input tensor.
             mask (Optional[jnp.ndarray]): Optional mask tensor.

--- a/test/jax/test_qdq_split.py
+++ b/test/jax/test_qdq_split.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for split quantize/dequantize QDQ layer functionality.
+
+Verifies that running layer.call_dq(layer.call_q(x)) on a single QDQLayer instance
+produces the same result as the combined layer(x) path.
+"""
+
+import pytest
+from jax import numpy as jnp
+
+from neural_compressor.jax.quantization.layers_dynamic import DynamicQDQLayer
+from neural_compressor.jax.quantization.layers_static import StaticQDQLayer
+
+_fp8_dtypes = ["float8_e4m3fn", "float8_e5m2"]
+_int_dtypes = ["int8"]
+_all_dtypes = _fp8_dtypes + _int_dtypes
+
+
+def _make_test_inputs(model_dtype):
+    """Create representative test inputs."""
+    return [
+        jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype=model_dtype).reshape(1, 8),
+        jnp.linspace(-50000.0, 50000.0, 16, dtype=model_dtype).reshape(2, 8),
+        jnp.array([0.01, -0.01, 0.005, -0.005, 0.001, -0.001, 0.02, -0.02], dtype=model_dtype).reshape(1, 8),
+    ]
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
+@pytest.mark.smoke_test_if("model_dtype=bfloat16-activation_dtype=float8_e4m3fn")
+def test_dynamic_qdq_split_equivalence(model_dtype, activation_dtype):
+    """Test that layer.call_dq(layer.call_q(x)) == layer(x) on a single DynamicQDQLayer."""
+
+    test_inputs = _make_test_inputs(model_dtype)
+
+    layer = DynamicQDQLayer(name="dynamic_split", activation_dtype=jnp.dtype(activation_dtype), dtype=model_dtype)
+    layer.add_variables()
+
+    for test_input in test_inputs:
+        combined_output = layer(test_input)
+
+        quantized = layer.call_q(test_input)
+        split_output = layer.call_dq(quantized)
+
+        assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
+            f"Dynamic QDQ split mismatch for dtype={activation_dtype}:\n"
+            f"  combined: {combined_output}\n"
+            f"  split:    {split_output}"
+        )
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
+def test_dynamic_qdq_split_fixed_range(model_dtype, activation_dtype):
+    """Test split QDQ equivalence with fixed_range for dynamic layers."""
+    fixed_range = (-3.0, 3.0)
+    test_inputs = _make_test_inputs(model_dtype)
+
+    layer = DynamicQDQLayer(
+        name="dynamic_split_fixed",
+        activation_dtype=jnp.dtype(activation_dtype),
+        dtype=model_dtype,
+        fixed_range=fixed_range,
+    )
+    layer.add_variables()
+
+    for test_input in test_inputs:
+        combined_output = layer(test_input)
+
+        quantized = layer.call_q(test_input)
+        split_output = layer.call_dq(quantized)
+
+        assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
+            f"Dynamic QDQ split (fixed_range) mismatch for dtype={activation_dtype}:\n"
+            f"  combined: {combined_output}\n"
+            f"  split:    {split_output}"
+        )
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+def test_dynamic_call_q_output_dtype(activation_dtype):
+    """Test that call_q outputs quantized dtype."""
+    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
+
+    layer = DynamicQDQLayer(name="q_dtype_check", activation_dtype=jnp.dtype(activation_dtype), dtype="float32")
+    layer.add_variables()
+
+    output = layer.call_q(test_input)
+    assert output.dtype == jnp.dtype(
+        activation_dtype
+    ), f"Expected call_q output dtype {activation_dtype}, got {output.dtype}"
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+def test_dynamic_call_dq_output_dtype(activation_dtype):
+    """Test that call_dq outputs compute dtype (float32)."""
+    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
+
+    layer = DynamicQDQLayer(name="dq_dtype_check", activation_dtype=jnp.dtype(activation_dtype), dtype="float32")
+    layer.add_variables()
+
+    quantized = layer.call_q(test_input)
+    output = layer.call_dq(quantized)
+
+    assert output.dtype == jnp.float32, f"Expected call_dq output dtype float32, got {output.dtype}"
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
+@pytest.mark.parametrize("const_scale", [False, True], ids=["const_scale=False", "const_scale=True"])
+def test_static_single_instance_split_call(model_dtype, activation_dtype, const_scale):
+    """Test that layer.call_dq(layer.call_q(x)) == layer(x) on a single StaticQDQLayer instance."""
+    fixed_range = (-4.0, 4.0)
+    test_inputs = _make_test_inputs(model_dtype)
+
+    layer = StaticQDQLayer(
+        name="single_instance_split",
+        activation_dtype=jnp.dtype(activation_dtype),
+        dtype=model_dtype,
+        const_scale=const_scale,
+        fixed_range=fixed_range,
+    )
+    layer.add_observers()
+    layer.add_variables()
+    layer.convert()
+    layer.post_quantization_cleanup()
+
+    for test_input in test_inputs:
+        # Combined QDQ path
+        combined_output = layer(test_input)
+
+        # Split path: quantize then dequantize using same instance
+        quantized = layer.call_q(test_input)
+        split_output = layer.call_dq(quantized)
+
+        assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
+            f"Single-instance split mismatch for dtype={activation_dtype}, "
+            f"const_scale={const_scale}:\n"
+            f"  combined: {combined_output}\n"
+            f"  split:    {split_output}"
+        )
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
+@pytest.mark.parametrize("const_scale", [False, True], ids=["const_scale=False", "const_scale=True"])
+@pytest.mark.smoke_test_if("const_scale=True-model_dtype=bfloat16-activation_dtype=float8_e5m2")
+def test_static_single_instance_split_with_calibration(model_dtype, activation_dtype, const_scale):
+    """Test single-instance split with actual calibration (no fixed_range)."""
+
+    test_inputs = _make_test_inputs(model_dtype)
+
+    layer = StaticQDQLayer(
+        name="split_with_calib",
+        activation_dtype=jnp.dtype(activation_dtype),
+        dtype=model_dtype,
+        const_scale=const_scale,
+    )
+    layer.add_observers()
+    layer.add_variables()
+
+    # Calibration: use call_q to observe inputs (call_dq is passthrough during calibration)
+    for test_input in test_inputs:
+        layer.call_q(test_input)
+
+    layer.convert()
+    layer.post_quantization_cleanup()
+
+    for test_input in test_inputs:
+        # Combined QDQ path
+        combined_output = layer(test_input)
+
+        # Split path: quantize then dequantize using same instance
+        quantized = layer.call_q(test_input)
+        split_output = layer.call_dq(quantized)
+
+        assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
+            f"Single-instance split (calibrated) mismatch for dtype={activation_dtype}, "
+            f"const_scale={const_scale}:\n"
+            f"  combined: {combined_output}\n"
+            f"  split:    {split_output}"
+        )
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+@pytest.mark.smoke_test
+def test_static_split_call_q_output_dtype(activation_dtype):
+    """Test that call_q outputs the quantized dtype after post_quantization_cleanup."""
+    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
+
+    layer = StaticQDQLayer(
+        name="split_q_dtype",
+        activation_dtype=jnp.dtype(activation_dtype),
+        dtype="float32",
+        const_scale=True,
+        fixed_range=(-4.0, 4.0),
+    )
+    layer.add_observers()
+    layer.add_variables()
+    layer.convert()
+    layer.post_quantization_cleanup()
+
+    output = layer.call_q(test_input)
+    assert output.dtype == jnp.dtype(
+        activation_dtype
+    ), f"Expected call_q output dtype {activation_dtype}, got {output.dtype}"
+
+
+@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
+@pytest.mark.smoke_test
+def test_static_split_call_dq_output_dtype(activation_dtype):
+    """Test that call_dq outputs the compute dtype after post_quantization_cleanup."""
+    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
+
+    layer = StaticQDQLayer(
+        name="split_dq_dtype",
+        activation_dtype=jnp.dtype(activation_dtype),
+        dtype="float32",
+        const_scale=True,
+        fixed_range=(-4.0, 4.0),
+    )
+    layer.add_observers()
+    layer.add_variables()
+    layer.convert()
+    layer.post_quantization_cleanup()
+
+    # First quantize, then dequantize
+    quantized = layer.call_q(test_input)
+    output = layer.call_dq(quantized)
+    assert output.dtype == jnp.float32, f"Expected call_dq output dtype float32, got {output.dtype}"

--- a/test/jax/test_qdq_split.py
+++ b/test/jax/test_qdq_split.py
@@ -39,22 +39,33 @@ def _make_test_inputs(model_dtype):
     ]
 
 
+@pytest.mark.parametrize("fixed_range", [True, False], ids=["fixed_range=True", "fixed_range=False"])
 @pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
 @pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
-@pytest.mark.smoke_test_if("model_dtype=bfloat16-activation_dtype=float8_e4m3fn")
-def test_dynamic_qdq_split_equivalence(model_dtype, activation_dtype):
+@pytest.mark.smoke_test_if("model_dtype=bfloat16-activation_dtype=float8_e5m2")
+def test_dynamic_qdq_split_equivalence(model_dtype, activation_dtype, fixed_range):
     """Test that layer.call_dq(layer.call_q(x)) == layer(x) on a single DynamicQDQLayer."""
 
     test_inputs = _make_test_inputs(model_dtype)
+    if fixed_range:
+        fixed_range = (-3.0, 3.0)
+    else:
+        fixed_range = None
 
-    layer = DynamicQDQLayer(name="dynamic_split", activation_dtype=jnp.dtype(activation_dtype), dtype=model_dtype)
-    layer.add_variables()
+    layer_qdq = DynamicQDQLayer(
+        name="dynamic_qdq", activation_dtype=jnp.dtype(activation_dtype), dtype=model_dtype, fixed_range=fixed_range
+    )
+    layer_splitted = DynamicQDQLayer(
+        name="dynamic_split", activation_dtype=jnp.dtype(activation_dtype), dtype=model_dtype, fixed_range=fixed_range
+    )
+    layer_qdq.add_variables()
+    layer_splitted.add_variables()
 
     for test_input in test_inputs:
-        combined_output = layer(test_input)
+        combined_output = layer_qdq(test_input)
 
-        quantized = layer.call_q(test_input)
-        split_output = layer.call_dq(quantized)
+        quantized = layer_splitted.call_q(test_input)
+        split_output = layer_splitted.call_dq(quantized)
 
         assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
             f"Dynamic QDQ split mismatch for dtype={activation_dtype}:\n"
@@ -62,183 +73,73 @@ def test_dynamic_qdq_split_equivalence(model_dtype, activation_dtype):
             f"  split:    {split_output}"
         )
 
-
-@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
-@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
-def test_dynamic_qdq_split_fixed_range(model_dtype, activation_dtype):
-    """Test split QDQ equivalence with fixed_range for dynamic layers."""
-    fixed_range = (-3.0, 3.0)
-    test_inputs = _make_test_inputs(model_dtype)
-
-    layer = DynamicQDQLayer(
-        name="dynamic_split_fixed",
-        activation_dtype=jnp.dtype(activation_dtype),
-        dtype=model_dtype,
-        fixed_range=fixed_range,
-    )
-    layer.add_variables()
-
-    for test_input in test_inputs:
-        combined_output = layer(test_input)
-
-        quantized = layer.call_q(test_input)
-        split_output = layer.call_dq(quantized)
-
-        assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
-            f"Dynamic QDQ split (fixed_range) mismatch for dtype={activation_dtype}:\n"
-            f"  combined: {combined_output}\n"
-            f"  split:    {split_output}"
-        )
-
-
-@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
-def test_dynamic_call_q_output_dtype(activation_dtype):
-    """Test that call_q outputs quantized dtype."""
-    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
-
-    layer = DynamicQDQLayer(name="q_dtype_check", activation_dtype=jnp.dtype(activation_dtype), dtype="float32")
-    layer.add_variables()
-
-    output = layer.call_q(test_input)
-    assert output.dtype == jnp.dtype(
+    assert quantized.dtype == jnp.dtype(
         activation_dtype
-    ), f"Expected call_q output dtype {activation_dtype}, got {output.dtype}"
+    ), f"Expected call_q output dtype {activation_dtype}, got {quantized.dtype}"
+
+    assert split_output.dtype == model_dtype, f"Expected call_dq output dtype {model_dtype}, got {split_output.dtype}"
 
 
-@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
-def test_dynamic_call_dq_output_dtype(activation_dtype):
-    """Test that call_dq outputs compute dtype (float32)."""
-    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
-
-    layer = DynamicQDQLayer(name="dq_dtype_check", activation_dtype=jnp.dtype(activation_dtype), dtype="float32")
-    layer.add_variables()
-
-    quantized = layer.call_q(test_input)
-    output = layer.call_dq(quantized)
-
-    assert output.dtype == jnp.float32, f"Expected call_dq output dtype float32, got {output.dtype}"
-
-
+@pytest.mark.parametrize("fixed_range", [True, False], ids=["fixed_range=True", "fixed_range=False"])
 @pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
 @pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
 @pytest.mark.parametrize("const_scale", [False, True], ids=["const_scale=False", "const_scale=True"])
-def test_static_single_instance_split_call(model_dtype, activation_dtype, const_scale):
-    """Test that layer.call_dq(layer.call_q(x)) == layer(x) on a single StaticQDQLayer instance."""
-    fixed_range = (-4.0, 4.0)
-    test_inputs = _make_test_inputs(model_dtype)
+@pytest.mark.smoke_test_if("const_scale=True-model_dtype=float32-activation_dtype=float8_e4m3fn")
+def test_static_qdq_split_equivalence(model_dtype, activation_dtype, const_scale, fixed_range):
+    """Test that layer.call_dq(layer.call_q(x)) == layer(x) on a single StaticQDQLayer."""
 
-    layer = StaticQDQLayer(
-        name="single_instance_split",
+    test_inputs = _make_test_inputs(model_dtype)
+    if fixed_range:
+        fixed_range = (-4.0, 4.0)
+    else:
+        fixed_range = None
+
+    layer_qdq = StaticQDQLayer(
+        name="static_qdq",
         activation_dtype=jnp.dtype(activation_dtype),
         dtype=model_dtype,
         const_scale=const_scale,
         fixed_range=fixed_range,
     )
-    layer.add_observers()
-    layer.add_variables()
-    layer.convert()
-    layer.post_quantization_cleanup()
-
-    for test_input in test_inputs:
-        # Combined QDQ path
-        combined_output = layer(test_input)
-
-        # Split path: quantize then dequantize using same instance
-        quantized = layer.call_q(test_input)
-        split_output = layer.call_dq(quantized)
-
-        assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
-            f"Single-instance split mismatch for dtype={activation_dtype}, "
-            f"const_scale={const_scale}:\n"
-            f"  combined: {combined_output}\n"
-            f"  split:    {split_output}"
-        )
-
-
-@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
-@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
-@pytest.mark.parametrize("const_scale", [False, True], ids=["const_scale=False", "const_scale=True"])
-@pytest.mark.smoke_test_if("const_scale=True-model_dtype=bfloat16-activation_dtype=float8_e5m2")
-def test_static_single_instance_split_with_calibration(model_dtype, activation_dtype, const_scale):
-    """Test single-instance split with actual calibration (no fixed_range)."""
-
-    test_inputs = _make_test_inputs(model_dtype)
-
-    layer = StaticQDQLayer(
-        name="split_with_calib",
+    layer_splitted = StaticQDQLayer(
+        name="static_split",
         activation_dtype=jnp.dtype(activation_dtype),
         dtype=model_dtype,
         const_scale=const_scale,
+        fixed_range=fixed_range,
     )
-    layer.add_observers()
-    layer.add_variables()
 
-    # Calibration: use call_q to observe inputs (call_dq is passthrough during calibration)
+    layer_qdq.add_observers()
+    layer_qdq.add_variables()
+    layer_splitted.add_observers()
+    layer_splitted.add_variables()
+
+    if fixed_range is None:
+        # Calibration: run inputs through observers
+        for test_input in test_inputs:
+            layer_qdq(test_input)
+            layer_splitted.call_q(test_input)
+
+    layer_qdq.convert()
+    layer_qdq.post_quantization_cleanup()
+    layer_splitted.convert()
+    layer_splitted.post_quantization_cleanup()
+
     for test_input in test_inputs:
-        layer.call_q(test_input)
+        combined_output = layer_qdq(test_input)
 
-    layer.convert()
-    layer.post_quantization_cleanup()
-
-    for test_input in test_inputs:
-        # Combined QDQ path
-        combined_output = layer(test_input)
-
-        # Split path: quantize then dequantize using same instance
-        quantized = layer.call_q(test_input)
-        split_output = layer.call_dq(quantized)
+        quantized = layer_splitted.call_q(test_input)
+        split_output = layer_splitted.call_dq(quantized)
 
         assert jnp.allclose(combined_output, split_output, rtol=1e-5), (
-            f"Single-instance split (calibrated) mismatch for dtype={activation_dtype}, "
+            f"Static QDQ split mismatch for dtype={activation_dtype}, "
             f"const_scale={const_scale}:\n"
             f"  combined: {combined_output}\n"
             f"  split:    {split_output}"
         )
 
-
-@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
-@pytest.mark.smoke_test
-def test_static_split_call_q_output_dtype(activation_dtype):
-    """Test that call_q outputs the quantized dtype after post_quantization_cleanup."""
-    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
-
-    layer = StaticQDQLayer(
-        name="split_q_dtype",
-        activation_dtype=jnp.dtype(activation_dtype),
-        dtype="float32",
-        const_scale=True,
-        fixed_range=(-4.0, 4.0),
-    )
-    layer.add_observers()
-    layer.add_variables()
-    layer.convert()
-    layer.post_quantization_cleanup()
-
-    output = layer.call_q(test_input)
-    assert output.dtype == jnp.dtype(
+    assert quantized.dtype == jnp.dtype(
         activation_dtype
-    ), f"Expected call_q output dtype {activation_dtype}, got {output.dtype}"
+    ), f"Expected call_q output dtype {activation_dtype}, got {quantized.dtype}"
 
-
-@pytest.mark.parametrize("activation_dtype", _all_dtypes, ids=[f"activation_dtype={d}" for d in _all_dtypes])
-@pytest.mark.smoke_test
-def test_static_split_call_dq_output_dtype(activation_dtype):
-    """Test that call_dq outputs the compute dtype after post_quantization_cleanup."""
-    test_input = jnp.array([1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.5, -1.5], dtype="float32").reshape(1, 8)
-
-    layer = StaticQDQLayer(
-        name="split_dq_dtype",
-        activation_dtype=jnp.dtype(activation_dtype),
-        dtype="float32",
-        const_scale=True,
-        fixed_range=(-4.0, 4.0),
-    )
-    layer.add_observers()
-    layer.add_variables()
-    layer.convert()
-    layer.post_quantization_cleanup()
-
-    # First quantize, then dequantize
-    quantized = layer.call_q(test_input)
-    output = layer.call_dq(quantized)
-    assert output.dtype == jnp.float32, f"Expected call_dq output dtype float32, got {output.dtype}"
+    assert split_output.dtype == model_dtype, f"Expected call_dq output dtype {model_dtype}, got {split_output.dtype}"


### PR DESCRIPTION
## Type of Change

feature
## Description

After the change, QDQLayers allow using quantize and dequantize separately. The scale (and calibration) is calculated in call_q (the quantization part), and call_dq only dequantizes using the already-calculated scale from the quantization step.
Also test verifying it is added.