### PR TITLE
fix: use context managers for file I/O to prevent resource leaks

### DIFF
--- a/neural_compressor/evaluation/lm_eval/accuracy.py
+++ b/neural_compressor/evaluation/lm_eval/accuracy.py
@@ -259,7 +259,8 @@ def cli_evaluate(args) -> None:
                 eval_logger.info(f"Logging to Weights and Biases failed due to {e}")
 
         if args.output_path:
-            output_path_file.open("w", encoding="utf-8").write(dumped)
+            with output_path_file.open("w", encoding="utf-8") as f:
+                f.write(dumped)
 
             if args.log_samples:
                 for task_name, config in results["configs"].items():

--- a/neural_compressor/tensorflow/utils/utility.py
+++ b/neural_compressor/tensorflow/utils/utility.py
@@ -308,6 +308,11 @@ class CaptureOutputToFile(object):
         os.close(self.orig_stream_dup)
         self.tmp_file.close()
 
+    def __del__(self):
+        """Ensure the file is closed if __exit__ was never called."""
+        if hasattr(self, "tmp_file") and not self.tmp_file.closed:
+            self.tmp_file.close()
+
 
 @singleton
 class TFSlimNetsFactory(object):  # pragma: no cover

--- a/neural_compressor/torch/algorithms/layer_wise/utils.py
+++ b/neural_compressor/torch/algorithms/layer_wise/utils.py
@@ -129,7 +129,8 @@ def load_layer_wise_quantized_model(path):  # pragma: no cover
 def load_tensor_from_shard(pretrained_model_name_or_path, tensor_name, prefix=None):  # pragma: no cover
     """Load tensor from shard."""
     path = _get_path(pretrained_model_name_or_path)
-    idx_dict = json.load(open(os.path.join(path, "pytorch_model.bin.index.json"), "r"))["weight_map"]
+    with open(os.path.join(path, "pytorch_model.bin.index.json"), "r") as f:
+        idx_dict = json.load(f)["weight_map"]
     if tensor_name not in idx_dict.keys():
         if tensor_name.replace(f"{prefix}.", "") in idx_dict.keys():
             tensor_name = tensor_name.replace(f"{prefix}.", "")
@@ -176,7 +177,8 @@ def load_tensor_from_safetensors_shard(
 ):  # pragma: no cover
     """Load tensor from shard."""
     path = _get_path(pretrained_model_name_or_path)
-    idx_dict = json.load(open(os.path.join(path, "model.safetensors.index.json"), "r"))["weight_map"]
+    with open(os.path.join(path, "model.safetensors.index.json"), "r") as f:
+        idx_dict = json.load(f)["weight_map"]
     if tensor_name not in idx_dict.keys():
         if tensor_name.replace(f"{prefix}.", "") in idx_dict.keys():
             tensor_name = tensor_name.replace(f"{prefix}.", "")


### PR DESCRIPTION
## Motivation

Several places in the codebase open files without using context managers (`with` statements), which can lead to resource leaks if exceptions occur or if the file handle is not explicitly closed. This is a common Python anti-pattern that can cause issues in long-running processes or when processing many files.

## Changes

- **`neural_compressor/torch/algorithms/layer_wise/utils.py`**: Replaced `json.load(open(...))` with `with open(...) as f: json.load(f)` in `load_tensor_from_shard` and `load_tensor_from_safetensors_shard` to ensure file handles are properly closed after reading.

- **`neural_compressor/tensorflow/utils/utility.py`**: Added `__del__` method to `CaptureOutputToFile` class to ensure the temporary file is closed even when the object is not used as a context manager (i.e., `__exit__` is never called).

- **`neural_compressor/evaluation/lm_eval/accuracy.py`**: Replaced `output_path_file.open("w", encoding="utf-8").write(dumped)` with a `with` statement to ensure the output file is properly closed after writing.

## Testing

These are defensive resource management improvements that do not change functional behavior. The existing test suite should continue to pass without modification.
