### PR TITLE
Revert "Fix JAX install method (#2485)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ pip install neural-compressor-pt
 # Framework extension API + TensorFlow dependency
 pip install neural-compressor-tf
 # Framework extension API + JAX dependency, available since v3.8
-# JAX only support build from source installation method before [PyPI support](https://github.com/pypi/support/issues/10012) is available
-INC_JAX_ONLY=1 pip install . 
+pip install neural-compressor-jax
 ```    
 **Note**: Further installation methods can be found under [Installation Guide](./docs/source/installation_guide.md). check out our [FAQ](./docs/source/faq.md) for more details.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Intel Neural Compressor supports PyTorch with CPU, GPU and HPU. Please install t
 pip install neural-compressor-pt
 # Framework extension API + TensorFlow dependency
 pip install neural-compressor-tf
-# Framework extension API + JAX dependency, available since v3.8
+# Framework extension API + JAX dependency
 pip install neural-compressor-jax
 ```    
 **Note**: Further installation methods can be found under [Installation Guide](./docs/source/installation_guide.md). check out our [FAQ](./docs/source/faq.md) for more details.

--- a/docs/source/installation_guide.md
+++ b/docs/source/installation_guide.md
@@ -47,7 +47,7 @@ pip install neural-compressor
 # Framework extension API + corresponding framework dependency
 pip install neural-compressor[pt]
 pip install neural-compressor[tf]
-pip install neural-compressor[jax]
+pip install neural-compressor[jax] # JAX support is available since v3.8
 ```
 ```Shell
 # Framework extension API + PyTorch dependency
@@ -56,6 +56,10 @@ pip install neural-compressor-pt
 ```Shell
 # Framework extension API + TensorFlow dependency
 pip install neural-compressor-tf
+```
+```Shell
+# Framework extension API + JAX dependency, available since v3.8
+pip install neural-compressor-jax
 ```
 
 ### Install from Source

--- a/docs/source/installation_guide.md
+++ b/docs/source/installation_guide.md
@@ -47,7 +47,7 @@ pip install neural-compressor
 # Framework extension API + corresponding framework dependency
 pip install neural-compressor[pt]
 pip install neural-compressor[tf]
-pip install neural-compressor[jax] # JAX support is available since v3.8
+pip install neural-compressor[jax]
 ```
 ```Shell
 # Framework extension API + PyTorch dependency
@@ -58,7 +58,7 @@ pip install neural-compressor-pt
 pip install neural-compressor-tf
 ```
 ```Shell
-# Framework extension API + JAX dependency, available since v3.8
+# Framework extension API + JAX dependency, available since v3.9
 pip install neural-compressor-jax
 ```
 

--- a/examples/jax/keras/gemma/README.md
+++ b/examples/jax/keras/gemma/README.md
@@ -9,7 +9,12 @@ This document describes quantization of Keras Gemma models using Neural Compress
 It is worth conducting experiments in a separate environment. For example, you can use the conda environment from [conda-forge](https://github.com/conda-forge/miniforge). The binary for your environment could be found here: [miniforge](https://github.com/conda-forge/miniforge/releases/latest)  
 
 ## 2. Install modules
-Install Neural Compressor from the source code:
+
+After the Neural Compressor v3.8 release you can install required binaries:
+```bash
+pip install -r requirements.txt
+```
+Alternatively, you can always install Neural Compressor from the source code:
 ```bash
 pushd ../../../..  # go to the root directory of the Neural Compressor source code
 INC_JAX_ONLY=1 pip install .

--- a/examples/jax/keras/gemma/README.md
+++ b/examples/jax/keras/gemma/README.md
@@ -10,7 +10,7 @@ It is worth conducting experiments in a separate environment. For example, you c
 
 ## 2. Install modules
 
-After the Neural Compressor v3.8 release you can install required binaries:
+Since Neural Compressor v3.9, you can install the required binaries from PyPI:
 ```bash
 pip install -r requirements.txt
 ```

--- a/examples/jax/keras/gemma/requirements.txt
+++ b/examples/jax/keras/gemma/requirements.txt
@@ -1,2 +1,1 @@
 neural-compressor-jax
-tensorflow

--- a/examples/jax/keras/vit/README.md
+++ b/examples/jax/keras/vit/README.md
@@ -10,7 +10,7 @@ It is worth conducting experiments in a separate environment. For example, you c
 
 ## 2. Install modules
 
-After the Neural Compressor v3.8 release you can install required binaries:
+Since Neural Compressor v3.9, you can install the required binaries from PyPI:
 ```bash
 pip install -r requirements.txt
 ```

--- a/examples/jax/keras/vit/README.md
+++ b/examples/jax/keras/vit/README.md
@@ -10,11 +10,11 @@ It is worth conducting experiments in a separate environment. For example, you c
 
 ## 2. Install modules
 
-Install requirements:
+After the Neural Compressor v3.8 release you can install required binaries:
 ```bash
 pip install -r requirements.txt
 ```
-Install Neural Compressor from the source code:
+Alternatively, you can always install Neural Compressor from the source code:
 ```bash
 pushd ../../../..  # go to the root directory of the Neural Compressor source code
 INC_JAX_ONLY=1 pip install .


### PR DESCRIPTION
This reverts commit 484d75d0004ccdc5d6a84e6cdcb68d50a8ef21bd.

Since we've managed to publish neural-compressor-jax on PyPI, we no longer need the workaround for installing INC for JAX in the documentation.