### PR TITLE
[JAX] Remove redundant tests

### DIFF
--- a/test/jax/test_composable_config.py
+++ b/test/jax/test_composable_config.py
@@ -11,10 +11,14 @@ The shared ``model`` / ``calibration_data`` / ``test_data`` fixtures (see
 conftest.py) supply a model with named Dense layers ``first``/``second``/``third``.
 """
 
+import pytest
 from jax import numpy as jnp
 
 from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig, quantize_model
 from neural_compressor.jax.quantization.config import JaxComposableConfig
+
+# Mark all tests in this file as smoke tests
+pytestmark = pytest.mark.smoke_test
 
 
 def _build_mapping(model, config):

--- a/test/jax/test_config_filtering.py
+++ b/test/jax/test_config_filtering.py
@@ -17,6 +17,9 @@ import pytest
 
 from neural_compressor.jax import DynamicQuantConfig, StaticQuantConfig
 
+# Mark all tests in this file as smoke tests
+pytestmark = pytest.mark.smoke_test
+
 
 @pytest.mark.parametrize("config_cls", [DynamicQuantConfig, StaticQuantConfig], ids=["dynamic_quant", "static_quant"])
 class TestLayerMatchesFilters:

--- a/test/jax/test_gemma3.py
+++ b/test/jax/test_gemma3.py
@@ -52,16 +52,15 @@ def random_string():
 
 @pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
 @pytest.mark.parametrize("const_vars", [False, True], ids=["const_vars=False", "const_vars=True"])
-@pytest.mark.parametrize("save_as_preset", [False, True], ids=["save_as_preset=False", "save_as_preset=True"])
-@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
 @pytest.mark.parametrize(
     "quantization_dtype", ["fp8_e4m3", "fp8_e5m2"], ids=["quantization_dtype=fp8_e4m3", "quantization_dtype=fp8_e5m2"]
 )
 @pytest.mark.smoke_test_if(
-    "quantization_dtype=fp8_e4m3-model_dtype=float32-save_as_preset=False-const_vars=False-dynamic=True",
-    "quantization_dtype=fp8_e4m3-model_dtype=bfloat16-save_as_preset=True-const_vars=True-dynamic=False",
+    "quantization_dtype=fp8_e4m3-const_vars=False-dynamic=True",
+    "quantization_dtype=fp8_e4m3-const_vars=True-dynamic=False",
 )
-def test_text_prompt(dynamic, const_vars, save_as_preset, model_dtype, quantization_dtype, random_string):
+def test_text_prompt(dynamic, const_vars, quantization_dtype, random_string):
+    model_dtype = "float32"
     gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_270m", model_dtype)
 
     def calib_fn(model):
@@ -86,12 +85,8 @@ def test_text_prompt(dynamic, const_vars, save_as_preset, model_dtype, quantizat
 
     with tempfile.TemporaryDirectory() as tmpdir:
         save_path = os.path.join(tmpdir, "gemma3_quantized.keras")
-        if save_as_preset:
-            gemma_q.save_to_preset(save_path)
-            gemma_q_loaded = Gemma3CausalLM.from_preset(save_path, dtype=model_dtype)
-        else:
-            keras.saving.save_model(gemma_q, save_path)
-            gemma_q_loaded = keras.saving.load_model(save_path)
+        gemma_q.save_to_preset(save_path)
+        gemma_q_loaded = Gemma3CausalLM.from_preset(save_path, dtype=model_dtype)
 
     answer = gemma_q_loaded.generate("Answer what is the capital city of England.", max_length=20, strip_prompt=True)
     print("Gemma answer: ", {answer})
@@ -100,17 +95,15 @@ def test_text_prompt(dynamic, const_vars, save_as_preset, model_dtype, quantizat
 
 @pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
 @pytest.mark.parametrize("const_vars", [False, True], ids=["const_vars=False", "const_vars=True"])
-@pytest.mark.parametrize("save_as_preset", [False, True], ids=["save_as_preset=False", "save_as_preset=True"])
-@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
 @pytest.mark.parametrize(
     "quantization_dtype", ["fp8_e4m3", "fp8_e5m2"], ids=["quantization_dtype=fp8_e4m3", "quantization_dtype=fp8_e5m2"]
 )
 @pytest.mark.smoke_test_if(
-    "quantization_dtype=fp8_e4m3-model_dtype=bfloat16-save_as_preset=True-const_vars=True-dynamic=True",
-    "quantization_dtype=fp8_e5m2-model_dtype=float32-save_as_preset=False-const_vars=False-dynamic=False",
+    "quantization_dtype=fp8_e4m3-const_vars=True-dynamic=True",
+    "quantization_dtype=fp8_e5m2-const_vars=False-dynamic=False",
 )
-def test_image_recognition(dynamic, const_vars, save_as_preset, model_dtype, quantization_dtype, colva_beach_sq):
-    gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_4b-v1", model_dtype)
+def test_image_recognition(dynamic, const_vars, quantization_dtype, colva_beach_sq):
+    gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_4b-v1", "bfloat16")
 
     def calib_fn(model):
         _ = model.generate(
@@ -140,12 +133,8 @@ def test_image_recognition(dynamic, const_vars, save_as_preset, model_dtype, qua
 
     with tempfile.TemporaryDirectory() as tmpdir:
         save_path = os.path.join(tmpdir, "gemma3_quantized.keras")
-        if save_as_preset:
-            gemma_q.save_to_preset(save_path)
-            gemma_q_loaded = Gemma3CausalLM.from_preset(save_path, dtype=model_dtype)
-        else:
-            keras.saving.save_model(gemma_q, save_path)
-            gemma_q_loaded = keras.saving.load_model(save_path)
+        keras.saving.save_model(gemma_q, save_path)
+        gemma_q_loaded = keras.saving.load_model(save_path)
 
     answer = gemma_q_loaded.generate(
         {
@@ -161,16 +150,10 @@ def test_image_recognition(dynamic, const_vars, save_as_preset, model_dtype, qua
     assert matches >= 3, f"Expected at least 3 elements from {elements_in_the_picture} in answer (found {matches})."
 
 
-@pytest.mark.parametrize("const_vars", [False, True], ids=["const_vars=False", "const_vars=True"])
-@pytest.mark.parametrize("save_as_preset", [False, True], ids=["save_as_preset=False", "save_as_preset=True"])
-@pytest.mark.parametrize("model_dtype", ["float32", "bfloat16"], ids=["model_dtype=float32", "model_dtype=bfloat16"])
-@pytest.mark.parametrize(
-    "quantization_dtype", ["fp8_e4m3", "fp8_e5m2"], ids=["quantization_dtype=fp8_e4m3", "quantization_dtype=fp8_e5m2"]
-)
-@pytest.mark.smoke_test_if("quantization_dtype=fp8_e4m3-model_dtype=bfloat16-save_as_preset=True-const_vars=False")
-def test_static_quantization_with_incomplete_calibration(
-    const_vars, save_as_preset, model_dtype, quantization_dtype, random_string, colva_beach_sq
-):
+@pytest.mark.smoke_test
+def test_static_quantization_with_incomplete_calibration(random_string, colva_beach_sq):
+    quantization_dtype = "fp8_e4m3"
+    model_dtype = "bfloat16"
     gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_4b-v1", model_dtype)
 
     # Run calibration without image in input, so vision layer won't activate during calibration
@@ -180,19 +163,15 @@ def test_static_quantization_with_incomplete_calibration(
     config = StaticQuantConfig(
         weight_dtype=quantization_dtype,
         activation_dtype=quantization_dtype,
-        const_scale=const_vars,
-        const_weight=const_vars,
+        const_scale=False,
+        const_weight=False,
     )
     gemma_q = quantize_model(gemma, config, calib_text_fn)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         save_path = os.path.join(tmpdir, "gemma3_quantized.keras")
-        if save_as_preset:
-            gemma_q.save_to_preset(save_path)
-            gemma_q_loaded = Gemma3CausalLM.from_preset(save_path, dtype=model_dtype)
-        else:
-            keras.saving.save_model(gemma_q, save_path)
-            gemma_q_loaded = keras.saving.load_model(save_path)
+        keras.saving.save_model(gemma_q, save_path)
+        gemma_q_loaded = keras.saving.load_model(save_path)
 
     answer = gemma_q_loaded.generate(
         {
@@ -210,28 +189,19 @@ def test_static_quantization_with_incomplete_calibration(
     assert matches >= 3, f"Expected at least 3 elements from {elements_in_the_picture} in answer (found {matches})."
 
 
-@pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
-def test_inplace_false(dynamic, random_string):
+@pytest.mark.smoke_test
+def test_inplace_false():
     quantization_dtype = "fp8_e4m3"
     model_dtype = "bfloat16"
     gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_270m", model_dtype)
-
-    def calib_fn(model):
-        _ = model.generate(random_string, max_length=100)
-
-    if dynamic:
-        config = DynamicQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
-        _calib_fn = None
-    else:
-        config = StaticQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
-        _calib_fn = calib_fn
+    config = DynamicQuantConfig(weight_dtype=quantization_dtype, activation_dtype=quantization_dtype)
 
     hash_before_quantization = compute_model_hash(gemma)
 
     # inplace=False, measure time
     jax.clear_caches()
     start = time.perf_counter()
-    gemma_q = quantize_model(gemma, config, _calib_fn, inplace=False)
+    gemma_q = quantize_model(gemma, config, None, inplace=False)
     duration_inplace_false = time.perf_counter() - start
 
     # Assert original model is untouched
@@ -246,7 +216,7 @@ def test_inplace_false(dynamic, random_string):
     # inplace=True, measure time
     jax.clear_caches()
     start = time.perf_counter()
-    gemma_q = quantize_model(gemma, config, _calib_fn, inplace=True)
+    gemma_q = quantize_model(gemma, config, None, inplace=True)
     duration_inplace_true = time.perf_counter() - start
 
     # Compare quantization performance

--- a/test/jax/test_gemma3.py
+++ b/test/jax/test_gemma3.py
@@ -52,15 +52,15 @@ def random_string():
 
 @pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
 @pytest.mark.parametrize("const_vars", [False, True], ids=["const_vars=False", "const_vars=True"])
+@pytest.mark.parametrize("model_dtype", ["float32"], ids=["model_dtype=float32"])
 @pytest.mark.parametrize(
     "quantization_dtype", ["fp8_e4m3", "fp8_e5m2"], ids=["quantization_dtype=fp8_e4m3", "quantization_dtype=fp8_e5m2"]
 )
 @pytest.mark.smoke_test_if(
-    "quantization_dtype=fp8_e4m3-const_vars=False-dynamic=True",
-    "quantization_dtype=fp8_e4m3-const_vars=True-dynamic=False",
+    "quantization_dtype=fp8_e4m3-model_dtype=float32-const_vars=False-dynamic=True",
+    "quantization_dtype=fp8_e4m3-model_dtype=float32-const_vars=True-dynamic=False",
 )
-def test_text_prompt(dynamic, const_vars, quantization_dtype, random_string):
-    model_dtype = "float32"
+def test_text_prompt(dynamic, const_vars, model_dtype, quantization_dtype, random_string):
     gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_270m", model_dtype)
 
     def calib_fn(model):
@@ -95,15 +95,16 @@ def test_text_prompt(dynamic, const_vars, quantization_dtype, random_string):
 
 @pytest.mark.parametrize("dynamic", [True, False], ids=["dynamic=True", "dynamic=False"])
 @pytest.mark.parametrize("const_vars", [False, True], ids=["const_vars=False", "const_vars=True"])
+@pytest.mark.parametrize("model_dtype", ["bfloat16"], ids=["model_dtype=bfloat16"])
 @pytest.mark.parametrize(
     "quantization_dtype", ["fp8_e4m3", "fp8_e5m2"], ids=["quantization_dtype=fp8_e4m3", "quantization_dtype=fp8_e5m2"]
 )
 @pytest.mark.smoke_test_if(
-    "quantization_dtype=fp8_e4m3-const_vars=True-dynamic=True",
-    "quantization_dtype=fp8_e5m2-const_vars=False-dynamic=False",
+    "quantization_dtype=fp8_e4m3-model_dtype=bfloat16-const_vars=True-dynamic=True",
+    "quantization_dtype=fp8_e5m2-model_dtype=bfloat16-const_vars=False-dynamic=False",
 )
-def test_image_recognition(dynamic, const_vars, quantization_dtype, colva_beach_sq):
-    gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_4b-v1", "bfloat16")
+def test_image_recognition(dynamic, const_vars, model_dtype, quantization_dtype, colva_beach_sq):
+    gemma = load_model_from_preset(Gemma3CausalLM, "gemma3_instruct_4b-v1", model_dtype)
 
     def calib_fn(model):
         _ = model.generate(

--- a/test/jax/test_qdq_split.py
+++ b/test/jax/test_qdq_split.py
@@ -25,6 +25,9 @@ from jax import numpy as jnp
 from neural_compressor.jax.quantization.layers_dynamic import DynamicQDQLayer
 from neural_compressor.jax.quantization.layers_static import StaticQDQLayer
 
+# Mark all tests in this file as smoke tests
+pytestmark = pytest.mark.smoke_test
+
 _fp8_dtypes = ["float8_e4m3fn", "float8_e5m2"]
 _int_dtypes = ["int8"]
 _all_dtypes = _fp8_dtypes + _int_dtypes


### PR DESCRIPTION
## Type of Change

Tests

## Description

Removes redundant gemma tests cases to shorten execution time of Pytest Other. Additionally marks config related tests as smoke tests since they execute almost immediately

## Expected Behavior & Potential Risk

Bigger coverage by smoke tests and quicker execution of non-smoke tests

## How has this PR been tested?

N/A

## Dependency Change?

No changes
