### PR TITLE
[JAX] Clean prepare() and from_dict()

### DIFF
--- a/neural_compressor/jax/quantization/config.py
+++ b/neural_compressor/jax/quantization/config.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import json
 import re
 from collections import OrderedDict
-from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Callable, Dict, List, NamedTuple, Optional, Self, Tuple, Union
 
 import jax.numpy as jnp
 import keras
@@ -289,17 +289,37 @@ class JaxBaseConfig(BaseConfig):
         return filter_result
 
     @classmethod
-    def from_json_string(cls, json_string: str) -> "JaxBaseConfig":
+    def from_json_string(cls, json_string: str) -> Self:
         """Create a config from a JSON string.
 
         Args:
             json_string (str): JSON string describing the config.
 
         Returns:
-            JaxBaseConfig: Parsed configuration instance.
+            Self: Parsed configuration instance of the calling class.
         """
         cfg = json.loads(json_string)
         return cls.from_dict(cfg)
+
+    @classmethod
+    def from_dict(cls, config_dict: Dict) -> Self:
+        """Create a config from a dictionary.
+
+        Args:
+            config_dict (Dict): Configuration fields.
+
+        Returns:
+            Self: Parsed configuration instance of the calling class.
+        """
+        return cls(
+            weight_dtype=config_dict.get("weight_dtype", "fp8_e4m3"),
+            activation_dtype=config_dict.get("activation_dtype", "fp8_e4m3"),
+            const_scale=config_dict.get("const_scale", False),
+            const_weight=config_dict.get("const_weight", False),
+            weight_scale_granularity=config_dict.get("weight_scale_granularity", "per_tensor"),
+            white_list=config_dict.get("white_list", DEFAULT_WHITE_LIST),
+            exclude_list=config_dict.get("exclude_list", None),
+        )
 
 
 @register_config(framework_name=FRAMEWORK_NAME, algo_name=DYNAMIC_QUANT)
@@ -355,33 +375,6 @@ class DynamicQuantConfig(JaxBaseConfig):
             activation_dtype=["fp8", "fp8_e4m3", "fp8_e5m2", "int8"],
         )
 
-    @classmethod
-    def from_dict(cls, config_dict: Dict) -> "DynamicQuantConfig":
-        """Create a DynamicQuantConfig from a dictionary.
-
-        Args:
-            config_dict (Dict): Configuration fields.
-
-        Returns:
-            DynamicQuantConfig: Parsed configuration instance.
-        """
-        weight_dtype = config_dict.get("weight_dtype", "fp8_e4m3")
-        activation_dtype = config_dict.get("activation_dtype", "fp8_e4m3")
-        const_scale = config_dict.get("const_scale", False)
-        const_weight = config_dict.get("const_weight", False)
-        weight_scale_granularity = config_dict.get("weight_scale_granularity", "per_tensor")
-        white_list = config_dict.get("white_list", DEFAULT_WHITE_LIST)
-        exclude_list = config_dict.get("exclude_list", None)
-        return cls(
-            weight_dtype=weight_dtype,
-            activation_dtype=activation_dtype,
-            const_scale=const_scale,
-            const_weight=const_weight,
-            weight_scale_granularity=weight_scale_granularity,
-            white_list=white_list,
-            exclude_list=exclude_list,
-        )
-
 
 @register_config(framework_name=FRAMEWORK_NAME, algo_name=STATIC_QUANT)
 class StaticQuantConfig(JaxBaseConfig):
@@ -435,33 +428,6 @@ class StaticQuantConfig(JaxBaseConfig):
         return StaticQuantConfig(
             weight_dtype=["fp8_e4m3", "fp8_e5m2", "int8"],
             activation_dtype=["fp8_e4m3", "fp8_e5m2", "int8"],
-        )
-
-    @classmethod
-    def from_dict(cls, config_dict: Dict) -> "StaticQuantConfig":
-        """Create a StaticQuantConfig from a dictionary.
-
-        Args:
-            config_dict (Dict): Configuration fields.
-
-        Returns:
-            StaticQuantConfig: Parsed configuration instance.
-        """
-        weight_dtype = config_dict.get("weight_dtype", "fp8_e5m2")
-        activation_dtype = config_dict.get("activation_dtype", "fp8_e5m2")
-        const_scale = config_dict.get("const_scale", False)
-        const_weight = config_dict.get("const_weight", False)
-        weight_scale_granularity = config_dict.get("weight_scale_granularity", "per_tensor")
-        white_list = config_dict.get("white_list", DEFAULT_WHITE_LIST)
-        exclude_list = config_dict.get("exclude_list", None)
-        return cls(
-            weight_dtype=weight_dtype,
-            activation_dtype=activation_dtype,
-            const_scale=const_scale,
-            const_weight=const_weight,
-            weight_scale_granularity=weight_scale_granularity,
-            white_list=white_list,
-            exclude_list=exclude_list,
         )
 
 

--- a/neural_compressor/jax/quantization/layers_dynamic.py
+++ b/neural_compressor/jax/quantization/layers_dynamic.py
@@ -265,9 +265,9 @@ class QDynamicDenseMixin(SaveableLayerMixin):
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a dense-like layer instance for dynamic quantization.
 
@@ -461,9 +461,9 @@ class QDynamicMultiHeadAttention(SaveableLayerMixin, keras.layers.MultiHeadAtten
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a MultiHeadAttention instance for dynamic quantization.
 
@@ -665,9 +665,9 @@ class QDynamicCachedGemma3Attention(SaveableLayerMixin, CachedGemma3Attention):
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a CachedGemma3Attention instance for dynamic quantization.
 
@@ -818,9 +818,9 @@ class QDynamicGemma3VisionAttention(SaveableLayerMixin, Gemma3VisionAttention):
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a Gemma3VisionAttention instance for dynamic quantization.
 
@@ -930,9 +930,9 @@ class QDynamicReversibleEmbedding(SaveableLayerMixin, keras.layers.ReversibleEmb
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a ReversibleEmbedding instance for dynamic quantization.
 

--- a/neural_compressor/jax/quantization/layers_static.py
+++ b/neural_compressor/jax/quantization/layers_static.py
@@ -440,9 +440,9 @@ class QStaticDenseMixin(SaveableLayerMixin):
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a dense-like layer instance for static quantization.
 
@@ -796,9 +796,9 @@ class QStaticMultiHeadAttention(SaveableLayerMixin, keras.layers.MultiHeadAttent
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a MultiHeadAttention instance for static quantization.
 
@@ -1057,9 +1057,9 @@ class QStaticCachedGemma3Attention(SaveableLayerMixin, CachedGemma3Attention):
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a CachedGemma3Attention instance for static quantization.
 
@@ -1234,9 +1234,9 @@ class QStaticGemma3VisionAttention(SaveableLayerMixin, Gemma3VisionAttention):
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a Gemma3VisionAttention instance for static quantization.
 
@@ -1382,9 +1382,9 @@ class QStaticRotaryEmbedding(SaveableLayerMixin, keras_hub.layers.RotaryEmbeddin
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a RotaryEmbedding instance for static quantization.
 
@@ -1506,9 +1506,9 @@ class QStaticReversibleEmbedding(SaveableLayerMixin, keras.layers.ReversibleEmbe
         orig,
         weight_dtype,
         activation_dtype,
-        const_scale=False,
-        const_weight=False,
-        w_quant_granularity="per_tensor",
+        const_scale,
+        const_weight,
+        w_quant_granularity,
     ):
         """Convert a ReversibleEmbedding instance for static quantization.
 


### PR DESCRIPTION
## Type of Change

some cleanup

## Description
prepare()  functions is intend to be used only internally so not giving default values could catch potential
internal wrong usage and allows easier find where config parameters are really set.
Simplify configs by moving from_dict()  implementation to base config class (JaxBaseConfig).
