### PR TITLE
Fix example: remove torchscript to adapt transformers 5.x

### DIFF
--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/weight_only/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/weight_only/requirements.txt
@@ -3,7 +3,7 @@ protobuf
 sentencepiece != 0.1.92
 datasets >= 1.1.3
 torch >= 1.10
-transformers < 5.0.0
+transformers > 5.0.0
 pytest
 wandb
 einops

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/weight_only/run_clm_no_trainer.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/weight_only/run_clm_no_trainer.py
@@ -284,9 +284,6 @@ class Evaluator:
 
 
 def get_user_model(empty_model=False):
-    torchscript = False
-    if args.woq_algo in ["AWQ", "TEQ"]:
-        torchscript = True
     if args.woq_algo == "AutoRound" and is_habana_framework_installed():
         print("Quantizing model with AutoRound on HPU")
         if args.quantize:
@@ -317,7 +314,6 @@ def get_user_model(empty_model=False):
         elif not empty_model:
             user_model = AutoModelForCausalLM.from_pretrained(
                 args.model,
-                torchscript=torchscript,  # torchscript will force `return_dict=False` to avoid jit errors
                 trust_remote_code=args.trust_remote_code,
                 revision=args.revision,
                 torch_dtype=config.torch_dtype if args.use_mmap else torch.float32


### PR DESCRIPTION
## Type of Change

feature/bug fix/documentation/validation/others

## Description

In transformers 5.x, the `torchscript` parameter was completely removed in PR #41688—the PyTorch team has deprecated TorchScript, officially shifting focus to the supported paths of Dynamo and `torch.export`.

support GPTQ
```
 CUDA_VISIBLE_DEVICES=0 python -u run_clm_no_trainer.py  --model ./opt-125m --dataset NeelNanda/pile-10k  --quantize --output_dir saved_results --tasks lambda_openai --batch_size 8 --woq_algo GPTQ --woq_bits 4 --woq_group_size 128 --woq_scheme asym  --woq_use_mse_search  --gptq_use_max_length

2026-08-17 14:44:19 [INFO][gptq.py:1084] Quantization done
2026-08-17 14:44:20 [INFO][gptq.py:1715] GPTQ quantizing done.
2026-08-17 14:44:20 [INFO][utility.py:430] |******Mixed Precision Statistics******|
2026-08-17 14:44:20 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 14:44:20 [INFO][utility.py:432] | Op Type | Total | A32W4G128 |  FP32  |
2026-08-17 14:44:20 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 14:44:20 [INFO][utility.py:432] |  Linear |   73  |     72    |   1    |
2026-08-17 14:44:20 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 14:44:20 [INFO][run_clm_no_trainer.py:490] Conversion end.
```
support AWQ (cpu)
```
CUDA_VISIBLE_DEVICES=-1 python -u run_clm_no_trainer.py  --model ./opt-125m --dataset NeelNanda/pile-10k  --quantize --output_dir saved_results --tasks lambda_openai --batch_size 8 --woq_algo AWQ --woq_bits 4 --woq_group_size 128 --woq_scheme asym  --woq_use_mse_search
2026-08-17 17:48:22 [INFO][awq.py:493] AWQ quantization is done.
2026-08-17 17:48:22 [INFO][utility.py:430] |******Mixed Precision Statistics******|
2026-08-17 17:48:22 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 17:48:22 [INFO][utility.py:432] | Op Type | Total | A32W4G128 |  FP32  |
2026-08-17 17:48:22 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 17:48:22 [INFO][utility.py:432] |  Linear |   73  |     72    |   1    |
2026-08-17 17:48:22 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 17:48:22 [INFO][run_clm_no_trainer.py:504] Conversion end.
```

support TEQ (cpu）
```
CUDA_VISIBLE_DEVICES=-1 python -u run_clm_no_trainer.py  --model ./opt-125m --dataset NeelNanda/pile-10k  --quantize --output_dir saved_results --tasks lambda_openai --batch_size 8 --woq_algo TEQ --woq_bits 4 --woq_group_size 128 --woq_scheme asym  --woq_use_mse_search
2026-08-17 17:45:30 [INFO][teq.py:413] TEQ quantizing done.
2026-08-17 17:45:30 [INFO][utility.py:430] |******Mixed Precision Statistics******|
2026-08-17 17:45:30 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 17:45:30 [INFO][utility.py:432] | Op Type | Total | A32W4G128 |  FP32  |
2026-08-17 17:45:30 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 17:45:30 [INFO][utility.py:432] |  Linear |   73  |     72    |   1    |
2026-08-17 17:45:30 [INFO][utility.py:432] +---------+-------+-----------+--------+
2026-08-17 17:45:30 [INFO][run_clm_no_trainer.py:519] Conversion end.

```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
