### PR TITLE
Fix PT2E OPT export with recent transformers

### DIFF
--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/static_quant/pt2e/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/static_quant/pt2e/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.57.6
+transformers>=5.0
 torch
 sentencepiece
 neural-compressor

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/static_quant/pt2e/run_clm_no_trainer.py
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/static_quant/pt2e/run_clm_no_trainer.py
@@ -43,15 +43,15 @@ args = parser.parse_args()
 
 def get_user_model():
     torchscript = False
-    # Note: return_dict=False works with transformers 4.x because the
-    # @can_return_tuple decorator allows internal attribute access (e.g. .last_hidden_state)
-    # while converting the final output to a tuple for torch.export compatibility.
     user_model = AutoModelForCausalLM.from_pretrained(
         args.model,
         trust_remote_code=args.trust_remote_code,
         revision=args.revision,
         use_cache=False,  # avoid potential cache issues when loading the same model with different configs
-        return_dict=False,  # force the model to return tuple for better compatibility with torch.export
+        # Keep structured outputs enabled. Recent transformers versions still
+        # access attributes such as `last_hidden_state` inside forward(), so
+        # forcing tuple outputs breaks torch.export for OPT models.
+        return_dict=True,
     )
     tokenizer = AutoTokenizer.from_pretrained(args.model)
 


### PR DESCRIPTION
## Summary
- keep `return_dict` enabled when loading OPT causal LM models in the PT2E static quant example
- avoid the transformers 5.x export failure where `forward()` still expects `outputs.last_hidden_state`
- retain the existing quantization flow while restoring successful model export

## Testing
- `python -u examples/pytorch/nlp/huggingface_models/language-modeling/quantization/static_quant/pt2e/run_clm_no_trainer.py --model facebook/opt-125m --quantize --output_dir /tmp/qmodel_save_path_2`
