### PR TITLE
Implement skip rope scaling for Qwen3-235B-A22B models

### DIFF
--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/auto_round/qwen/run_evaluation.sh
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/auto_round/qwen/run_evaluation.sh
@@ -233,7 +233,14 @@ start_vllm_server() {
         ROPE_FLAG="--rope-scaling"
         ROPE_VALUE="${ROPE_SCALING_JSON}"
     fi
-    echo "vLLM version: ${VLLM_VERSION}, using: ${ROPE_FLAG} '${ROPE_VALUE}'"
+
+    # Skip rope scaling for Qwen3-235B-A22B* models
+    ROPE_ARGS=("${ROPE_FLAG}" "${ROPE_VALUE}")
+    if [[ "$MODEL_NAME" == *"Qwen3-235B-A22B"* ]]; then
+        ROPE_ARGS=()
+        echo "Skipping rope scaling for model: ${MODEL_NAME}"
+    fi
+    echo "vLLM version: ${VLLM_VERSION}, using: ${ROPE_ARGS[*]}"
 
     vllm serve ${MODEL_PATH} \
         --port ${SERVER_PORT} \
@@ -242,7 +249,7 @@ start_vllm_server() {
         --gpu-memory-utilization 0.8 \
         --dtype bfloat16 \
         --kv-cache-dtype ${KV_CACHE_DTYPE} \
-        ${ROPE_FLAG} "${ROPE_VALUE}" \
+        "${ROPE_ARGS[@]}" \
         ${EXTRA_ARGS} \
         > ${OUTPUT_DIR}/vllm_server.log 2>&1 &
     

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/auto_round/qwen/run_evaluation.sh
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/auto_round/qwen/run_evaluation.sh
@@ -204,6 +204,8 @@ export VLLM_QDQ=1
 export VLLM_MXFP4_USE_MARLIN=1
 # A100 need to close torch compile
 # export TORCH_COMPILE_DISABLE=1
+# B200 special env
+export NLTK_ALLOW_PROXIED_URLOPEN=1
 
 # Function to run standard lm-eval tasks
 run_standard_eval() {


### PR DESCRIPTION
This pull request introduces environment configuration and logic updates to the `run_evaluation.sh` script for HuggingFace Qwen model evaluation. The main changes improve environment compatibility and add model-specific handling for rope scaling arguments.

**Environment and Compatibility Updates:**

* Added `export NLTK_ALLOW_PROXIED_URLOPEN=1` to support proxied URL access for NLTK, addressing B200-specific environment needs.

**Model-Specific Argument Handling:**

* Updated the `start_vllm_server` function to skip rope scaling arguments when the model name contains `Qwen3-235B-A22B`, ensuring compatibility with these models. This includes:
  * Initializing `ROPE_ARGS` and conditionally leaving it empty for matching models, with a log message for clarity.
  * Passing `"${ROPE_ARGS[@]}"` instead of static rope scaling flags to the `vllm serve` command, making the argument list dynamic.