### PR TITLE
Deprecate tensorflow examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -144,7 +144,7 @@ Intel® Neural Compressor validated examples with multiple compression technique
 </table>
 
 
-# TensorFlow Examples
+# TensorFlow Examples (Deprecated)
 
 ## Quantization
 

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm_qat/README.md
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm_qat/README.md
@@ -10,6 +10,7 @@ Install the requirements for the example:
 pip install -r requirements.txt
 ```
 
+
 ## Getting Started
 
 In QAT, a model quantized using `prepare_qat()` can be directly fine-tuned with the original training pipeline. During QAT, the scaling factors inside quantizers are frozen and the model weights are fine-tuned.

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm_qat/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/llm_qat/requirements.txt
@@ -1,9 +1,9 @@
-auto-round==0.8.0
-neural-compressor-pt==3.6
-transformers==4.53.0
+auto-round
+neural-compressor-pt
+transformers
 datasets
 sentencepiece>=0.2.0
 tensorboardX
 peft
-accelerate >= 0.12.0
-lm-eval==0.4.9.1
+accelerate>=0.12.0
+lm-eval

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/smooth_quant/requirements.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/smooth_quant/requirements.txt
@@ -2,7 +2,7 @@ accelerate
 protobuf
 sentencepiece != 0.1.92
 datasets >= 1.1.3
-torch == 2.8.0
+torch
 transformers
 pytest
 wandb
@@ -11,4 +11,4 @@ neural-compressor
 lm_eval <= 0.4.7
 peft <= 0.17.0
 optimum-intel
-intel_extension_for_pytorch == 2.8.0
+intel_extension_for_pytorch

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/README.md
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/README.md
@@ -10,9 +10,8 @@ python version requests equal or higher than 3.9 due to [text evaluation library
 
 ```bash
 pip install oneccl_bind_pt==2.4.0 --index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
-pip install -r requirements_cpu_woq.txt
+pip install -r requirements_cpu_woq.txt --extra-index-url https://download.pytorch.org/whl/cpu
 ```
-
 
 ### Run
 #### Performance

--- a/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/requirements_cpu_woq.txt
+++ b/examples/pytorch/nlp/huggingface_models/language-modeling/quantization/transformers/weight_only/text-generation/requirements_cpu_woq.txt
@@ -3,8 +3,7 @@ datasets >= 2.0
 peft
 protobuf
 sentencepiece != 0.1.92
---extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.8.0+cpu
+torch
 transformers
 bitsandbytes  #baichuan
 transformers_stream_generator
@@ -15,5 +14,4 @@ lm-eval>=0.4.2
 huggingface_hub
 numba
 tbb
---extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
-intel-extension-for-pytorch==2.4.0
+intel-extension-for-pytorch

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/README.md
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/README.md
@@ -1,4 +1,4 @@
-Step-by-Step
+Step-by-Step (Deprecated)
 ============
 
 This document is used to list steps of reproducing TensorFlow Intel® Neural Compressor quantization and smooth quantization of language models such as OPT and GPT2.

--- a/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
+++ b/examples/tensorflow/nlp/large_language_models/quantization/ptq/smoothquant/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow==2.15
+tensorflow
 datasets
-transformers==4.53.0
+transformers


### PR DESCRIPTION
1. Deprecate tensorflow examples
2. Remove pytorch example version limit 