### PR TITLE
feat(example): add SDXL MXFP8 RTN workflow

### DIFF
--- a/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/README.md
+++ b/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/README.md
@@ -1,0 +1,86 @@
+# Stable Diffusion XL MXFP8
+
+This example quantizes the UNet in
+[`stabilityai/stable-diffusion-xl-base-1.0`](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0)
+to MXFP8 with AutoRound and evaluates generated images on COCO2014 captions.
+
+MXFP8 uses a block size of 32 and E8M0 power-of-two scales. The exported directory is a complete Diffusers
+pipeline: the UNet weights are fake-quantized and UNet linear-layer activations are dynamically quantized during
+inference.
+
+## Prerequisites
+
+Install a CUDA-compatible PyTorch build first, then install the example dependencies, Neural Compressor, and
+AutoRound:
+
+```bash
+pip install -r requirements.txt
+pip install neural-compressor-pt
+pip install git+https://github.com/intel/auto-round.git@main
+```
+
+Download the COCO2014 caption file used by MLPerf Stable Diffusion evaluation:
+
+```bash
+wget https://github.com/mlcommons/inference/raw/refs/heads/master/text_to_image/coco2014/captions/captions_source.tsv
+```
+
+Access to the gated SDXL model on Hugging Face may require authentication.
+
+## Quantization
+
+Run calibration-free pure RTN quantization:
+
+```bash
+bash run_quant.sh \
+    --input_model=stabilityai/stable-diffusion-xl-base-1.0 \
+    --output_model=./saved_results
+```
+
+The recipe fixes `iters=0` and `disable_opt_rtn=True`, so it does not require calibration samples or tuning.
+The equivalent Python command is:
+
+```bash
+python main.py \
+    --model stabilityai/stable-diffusion-xl-base-1.0 \
+    --output_dir ./saved_results \
+    --scheme MXFP8 \
+    --disable_opt_rtn \
+    --quantize
+```
+
+## Evaluation
+
+Generate the BF16 baseline on all visible GPUs and calculate CLIP, CLIP-IQA, and ImageReward:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 bash run_benchmark.sh \
+    --input_model=stabilityai/stable-diffusion-xl-base-1.0 \
+    --dataset_location=captions_source.tsv \
+    --output_image_path=./tmp_imgs_bf16
+```
+
+Evaluate the MXFP8 pipeline:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 bash run_benchmark.sh \
+    --input_model=stabilityai/stable-diffusion-xl-base-1.0 \
+    --quantized_model=./saved_results \
+    --dataset_location=captions_source.tsv \
+    --output_image_path=./tmp_imgs_mxfp8
+```
+
+When multiple GPUs are listed, the script partitions the TSV into balanced subsets. Every sample is assigned
+exactly once, even when the sample count is not divisible by the GPU count. Use `--limit=10` for a short smoke
+test.
+
+## Results
+
+The following results were measured on 5,000 COCO2014 validation prompts. Higher is better for every metric.
+
+| Format | CLIP ↑ | CLIP-IQA ↑ | ImageReward ↑ |
+|---|---:|---:|---:|
+| BF16 | 26.8583 | 0.929027 | 0.812544 |
+| MXFP8 (RTN) | 26.8491 | 0.930057 | 0.814659 |
+
+Compared with BF16, MXFP8 retains an average of 100.11% across the three metrics.

--- a/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/dataset_split.py
+++ b/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/dataset_split.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+import pandas as pd
+
+
+def split_dataset(input_file, output_prefix, split_num, limit=-1):
+    if split_num <= 0:
+        raise ValueError("split_num must be greater than zero")
+
+    dataframe = pd.read_csv(input_file, sep="\t")
+    if limit > 0:
+        dataframe = dataframe.iloc[:limit]
+
+    subset_size, remainder = divmod(len(dataframe), split_num)
+    for index in range(split_num):
+        start = index * subset_size + min(index, remainder)
+        end = start + subset_size + (1 if index < remainder else 0)
+        dataframe.iloc[start:end].to_csv(f"{output_prefix}_{index}.tsv", sep="\t", index=False)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Split a TSV dataset into balanced subsets.")
+    parser.add_argument("--split_num", type=int, required=True)
+    parser.add_argument("--limit", default=-1, type=int)
+    parser.add_argument("--input_file", required=True)
+    parser.add_argument("--output_file", default="subset")
+    args = parser.parse_args()
+    split_dataset(args.input_file, args.output_file, args.split_num, args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/main.py
+++ b/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/main.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+from functools import partial
+
+import pandas as pd
+import tabulate
+import torch
+from diffusers import StableDiffusionXLPipeline, UNet2DConditionModel
+
+from auto_round.compressors.diffusion.dataset import get_diffusion_dataloader
+from auto_round.compressors.diffusion.eval import metric_map
+from auto_round.data_type.mxfp import quant_mx_rceil
+from auto_round.utils import get_block_names, get_module
+from neural_compressor.torch.quantization import AutoRoundConfig, convert, prepare
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Quantize and evaluate Stable Diffusion XL with MXFP8.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--model",
+        "--model_name_or_path",
+        default="stabilityai/stable-diffusion-xl-base-1.0",
+        help="SDXL model name or local path",
+    )
+    parser.add_argument("--scheme", default="MXFP8", choices=["BF16", "MXFP8"])
+    parser.add_argument("--quantize", action="store_true")
+    parser.add_argument("--inference", action="store_true")
+    parser.add_argument("--accuracy", action="store_true")
+    parser.add_argument(
+        "--disable_opt_rtn",
+        action="store_true",
+        help="use calibration-free pure RTN instead of optimized RTN",
+    )
+    parser.add_argument(
+        "--output_dir",
+        "--quantized_model_path",
+        default="./saved_results",
+        help="directory used to save or load the quantized pipeline",
+    )
+    parser.add_argument("--eval_dataset", default="captions_source.tsv", help="evaluation TSV file")
+    parser.add_argument("--output_image_path", default="./tmp_imgs", help="generated image directory")
+    parser.add_argument("--num_inference_steps", default=50, type=int, help="denoising steps during evaluation")
+    parser.add_argument("--guidance_scale", default=7.5, type=float)
+    parser.add_argument("--seed", default=42, type=int)
+    parser.add_argument("--limit", default=-1, type=int, help="maximum number of evaluation prompts")
+    return parser.parse_args()
+
+
+def quantize(args, device):
+    if args.scheme != "MXFP8":
+        raise ValueError("Only MXFP8 requires quantization; use BF16 directly for the baseline.")
+    if not args.disable_opt_rtn:
+        raise ValueError("This MXFP8 example uses pure RTN; specify --disable_opt_rtn.")
+
+    pipe = StableDiffusionXLPipeline.from_pretrained(args.model, torch_dtype=torch.bfloat16).to(device)
+    quant_config = AutoRoundConfig(
+        scheme="MXFP8",
+        iters=0,
+        disable_opt_rtn=args.disable_opt_rtn,
+        export_format="fake",
+        output_dir=args.output_dir,
+    )
+    prepared_unet = prepare(pipe.unet, quant_config)
+    convert(prepared_unet, quant_config, pipeline=pipe)
+
+
+def enable_mxfp8_activation_qdq(unet):
+    def act_qdq_forward(module, inputs, *forward_args, **forward_kwargs):
+        qdq_inputs, _, _ = quant_mx_rceil(inputs, bits=8, group_size=32, data_type="mx_fp_rceil")
+        return module.orig_forward(qdq_inputs, *forward_args, **forward_kwargs)
+
+    for block_names in get_block_names(unet):
+        for block_name in block_names:
+            block = get_module(unet, block_name)
+            for module in block.modules():
+                if module.__class__.__name__ == "Linear" and not hasattr(module, "orig_forward"):
+                    module.orig_forward = module.forward
+                    module.forward = partial(act_qdq_forward, module)
+
+
+def load_pipeline(args, device):
+    if args.scheme == "BF16":
+        print("Loading the BF16 baseline pipeline.")
+        return StableDiffusionXLPipeline.from_pretrained(args.model, torch_dtype=torch.bfloat16).to(device)
+
+    if not os.path.isdir(args.output_dir):
+        raise ValueError(f"Quantized model directory does not exist: {args.output_dir}")
+
+    if os.path.isfile(os.path.join(args.output_dir, "model_index.json")):
+        print(f"Loading the quantized pipeline from {args.output_dir}.")
+        pipe = StableDiffusionXLPipeline.from_pretrained(args.output_dir, torch_dtype=torch.bfloat16)
+    else:
+        print(f"Loading the quantized UNet from {args.output_dir}.")
+        pipe = StableDiffusionXLPipeline.from_pretrained(args.model, torch_dtype=torch.bfloat16)
+        pipe.unet = UNet2DConditionModel.from_pretrained(args.output_dir, torch_dtype=torch.bfloat16)
+
+    enable_mxfp8_activation_qdq(pipe.unet)
+    return pipe.to(device)
+
+
+def generate_images(args, pipe, device):
+    os.makedirs(args.output_image_path, exist_ok=True)
+    dataloader, _ = get_diffusion_dataloader(args.eval_dataset, nsamples=args.limit, bs=1, seed=args.seed)
+
+    for image_ids, prompts in dataloader:
+        image_id = image_ids[0].item()
+        image_path = os.path.join(args.output_image_path, f"{image_id}.png")
+        if os.path.exists(image_path):
+            continue
+
+        generator = torch.Generator(device=device).manual_seed(args.seed + int(image_id))
+        output = pipe(
+            prompt=[prompts[0]],
+            guidance_scale=args.guidance_scale,
+            num_inference_steps=args.num_inference_steps,
+            generator=generator,
+        )
+        output.images[0].save(image_path)
+
+
+def evaluate_accuracy(args, device):
+    dataframe = pd.read_csv(args.eval_dataset, sep="\t")
+    if not {"id", "caption"}.issubset(dataframe.columns):
+        raise ValueError("The evaluation TSV must contain 'id' and 'caption' columns.")
+
+    if args.limit > 0:
+        dataframe = dataframe.iloc[: args.limit]
+
+    prompts = []
+    images = []
+    for row in dataframe.itertuples(index=False):
+        image_path = os.path.join(args.output_image_path, f"{row.id}.png")
+        if os.path.exists(image_path):
+            prompts.append(row.caption)
+            images.append(image_path)
+
+    if not images:
+        raise ValueError(f"No generated images found in {args.output_image_path}.")
+
+    results = {}
+    for metric in ("clip", "clip-iqa", "imagereward"):
+        results.update(metric_map[metric](prompts, images, device))
+    print(tabulate.tabulate(results.items(), headers=("Metric", "Score"), tablefmt="grid"))
+
+
+def main():
+    args = parse_args()
+    if not any((args.quantize, args.inference, args.accuracy)):
+        raise ValueError("Specify at least one of --quantize, --inference, or --accuracy.")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if args.quantize:
+        print(f"Quantizing {args.model} to MXFP8.")
+        quantize(args, device)
+    if args.inference:
+        generate_images(args, load_pipeline(args, device), device)
+    if args.accuracy:
+        evaluate_accuracy(args, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/requirements.txt
+++ b/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/requirements.txt
@@ -1,0 +1,11 @@
+accelerate
+clip==0.2.0
+diffusers>=0.38.0
+pandas
+protobuf
+sentencepiece
+safetensors
+tabulate
+torchmetrics
+transformers
+git+https://github.com/zai-org/ImageReward.git@78f8051059b34fef8e0032ccb40561c23a2ddbbb

--- a/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/run_benchmark.sh
+++ b/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/run_benchmark.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+input_model="stabilityai/stable-diffusion-xl-base-1.0"
+quantized_model=""
+dataset_location="captions_source.tsv"
+output_image_path="./tmp_imgs"
+limit=-1
+num_inference_steps=50
+guidance_scale=7.5
+seed=42
+
+for var in "$@"; do
+    case "${var}" in
+        --input_model=*) input_model="${var#*=}" ;;
+        --quantized_model=*) quantized_model="${var#*=}" ;;
+        --dataset_location=*) dataset_location="${var#*=}" ;;
+        --output_image_path=*) output_image_path="${var#*=}" ;;
+        --limit=*) limit="${var#*=}" ;;
+        --num_inference_steps=*) num_inference_steps="${var#*=}" ;;
+        --guidance_scale=*) guidance_scale="${var#*=}" ;;
+        --seed=*) seed="${var#*=}" ;;
+        *) echo "Error: No such parameter: ${var}"; exit 1 ;;
+    esac
+done
+
+scheme="BF16"
+model_args=()
+if [[ -n "${quantized_model}" ]]; then
+    scheme="MXFP8"
+    model_args=(--quantized_model_path "${quantized_model}")
+fi
+
+common_args=(
+    --model "${input_model}"
+    --scheme "${scheme}"
+    --output_image_path "${output_image_path}"
+    --num_inference_steps "${num_inference_steps}"
+    --guidance_scale "${guidance_scale}"
+    --seed "${seed}"
+    --limit "${limit}"
+)
+
+if [[ -n "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+    IFS=',' read -ra gpu_ids <<< "${CUDA_VISIBLE_DEVICES}"
+    visible_gpus=${#gpu_ids[@]}
+    subset_dir=$(mktemp -d)
+    trap 'rm -rf "${subset_dir}"' EXIT
+
+    python3 dataset_split.py \
+        --split_num "${visible_gpus}" \
+        --input_file "${dataset_location}" \
+        --output_file "${subset_dir}/subset" \
+        --limit "${limit}"
+
+    pids=()
+    for ((index=0; index<visible_gpus; index++)); do
+        CUDA_VISIBLE_DEVICES="${gpu_ids[index]}" python3 main.py \
+            "${common_args[@]}" \
+            "${model_args[@]}" \
+            --eval_dataset "${subset_dir}/subset_${index}.tsv" \
+            --inference &
+        pids+=("$!")
+    done
+
+    status=0
+    for pid in "${pids[@]}"; do
+        wait "${pid}" || status=1
+    done
+    [[ "${status}" -eq 0 ]] || exit "${status}"
+else
+    python3 main.py \
+        "${common_args[@]}" \
+        "${model_args[@]}" \
+        --eval_dataset "${dataset_location}" \
+        --inference
+fi
+
+python3 main.py \
+    --eval_dataset "${dataset_location}" \
+    --output_image_path "${output_image_path}" \
+    --limit "${limit}" \
+    --accuracy

--- a/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/run_quant.sh
+++ b/examples/pytorch/diffusion_model/diffusers/stable_diffusion/mxfp8/run_quant.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+input_model="stabilityai/stable-diffusion-xl-base-1.0"
+output_model="./saved_results"
+
+for var in "$@"; do
+    case "${var}" in
+        --input_model=*) input_model="${var#*=}" ;;
+        --output_model=*) output_model="${var#*=}" ;;
+        *) echo "Error: No such parameter: ${var}"; exit 1 ;;
+    esac
+done
+
+python3 main.py \
+    --model "${input_model}" \
+    --output_dir "${output_model}" \
+    --scheme MXFP8 \
+    --disable_opt_rtn \
+    --quantize


### PR DESCRIPTION
## Type of Change

feature

## Description

Add a standalone Stable Diffusion XL MXFP8 example under `stable_diffusion/mxfp8`. The example provides:

- calibration-free pure RTN quantization with `iters=0` and `disable_opt_rtn=True`
- BF16 and MXFP8 image generation
- balanced multi-GPU COCO2014 dataset splitting without dropping samples
- CLIP, CLIP-IQA, and ImageReward evaluation
- documented SDXL COCO2014 BF16 and MXFP8 RTN results

The workflow targets `stabilityai/stable-diffusion-xl-base-1.0` and keeps the existing Flux example unchanged.

## Expected Behavior & Potential Risk

Users can produce a complete fake-quantized Diffusers SDXL pipeline with MXFP8 pure RTN, then run single- or multi-GPU evaluation. No calibration dataset or tuning samples are required for quantization.

The change only adds a new example directory and does not modify library code or existing examples. Full model quantization is GPU- and resource-intensive.

## How has this PR been tested?

- Python syntax compilation for `main.py` and `dataset_split.py`
- Ruff checks for both Python files
- Bash syntax checks for `run_quant.sh` and `run_benchmark.sh`
- Balanced dataset split smoke test preserving every input row
- `AutoRoundConfig` verification confirming `scheme=MXFP8`, `iters=0`, and `disable_opt_rtn=True`
- `git diff --check`

## Dependency Change?

No library dependency changes. The new example includes its own `requirements.txt`.