### PR TITLE
Enhance SWE-bench Verified with Mini, retries, and image retention

### DIFF
--- a/benchmark/agent_benchmarks/README.md
+++ b/benchmark/agent_benchmarks/README.md
@@ -66,7 +66,7 @@ The stop command uses `logs/vllm_<PORT>.pid` by default. Set the same
 `VLLM_LOG_DIR` used to start the server, or set `VLLM_PID_FILE` to the exact PID
 file, when using a custom location.
 
-## SWE-Verified
+## SWE-Verified and SWE-Verified Mini
 
 ### SWE-Verified environment setup
 
@@ -78,7 +78,7 @@ The setup script:
 
 1. Clones mini-SWE-agent v2.4.6 into `mini-swe-agent/`.
 2. Applies `patches/swebench_verified_per_instance_cleanup.patch` so each instance reliably removes its Docker container during cleanup.
-3. Installs mini-SWE-agent to generate predictions and the official SWE-bench harness to evaluate those predictions locally. It also installs datasets for loading SWE-bench Verified.
+3. Installs mini-SWE-agent to generate predictions, the pinned SWE-bench 4.1.0 harness for local evaluation, and datasets for loading SWE-bench Verified and Verified Mini.
 
 
 ### Run SWE-Verified
@@ -89,6 +89,24 @@ bash run_swe_verified.sh \
   --step-limit 250 \
   --tag qwen36_27b_full
 ```
+
+To run the 50-instance
+[SWE-bench Verified Mini](https://evalscope.readthedocs.io/zh-cn/latest/benchmarks/swe_bench_verified_mini.html)
+dataset instead, select it through the same runner:
+
+```bash
+bash run_swe_verified.sh \
+  --dataset verified-mini \
+  --port 8888 \
+  --step-limit 250 \
+  --tag qwen36_27b_mini
+```
+
+Generation loads the original Hugging Face dataset
+`MariusHobbhahn/swe-bench-verified-mini`, which is mirrored by EvalScope as
+`evalscope/swe-bench-verified-mini`. Evaluation uses the canonical Verified
+dataset plus the selected Mini instance IDs, so it remains compatible with the
+official SWE-bench harness and prebuilt images.
 
 The runner connects to the existing shared vLLM server and leaves it running
 when the benchmark exits, whether the benchmark succeeds or fails. Generation
@@ -136,6 +154,7 @@ The runner stops early when both categories are empty.
 
 | Option | Default | Description |
 | --- | --- | --- |
+| `--dataset NAME` | `verified` | Dataset selection: `verified` (500 instances) or `verified-mini` (50 instances) |
 | `--host HOST` | `127.0.0.1` | vLLM host |
 | `--port PORT` | `8888` | vLLM port |
 | `--served-name NAME` | discovered | Model ID exposed by vLLM |
@@ -165,6 +184,9 @@ Outputs:
 - Local evaluation report with resolved counts and accuracy:
   `mini-swe-agent/results/swe_verified_<TAG>/report.json`
 - Log: `logs/swe_verified_<TAG>.log`
+
+For Verified Mini, the same layout uses the `swe_verified_mini_<TAG>` prefix
+for the result directory and log file.
 
 
 ## SWE-bench Pro

--- a/benchmark/agent_benchmarks/run_swe_verified.sh
+++ b/benchmark/agent_benchmarks/run_swe_verified.sh
@@ -12,8 +12,9 @@ usage() {
 Usage:
 	bash run_swe_verified.sh [OPTIONS]
 
-Run mini-SWE-agent on SWE-bench Verified using an already-running vLLM server,
-then evaluate the generated predictions with the local SWE-bench harness.
+Run mini-SWE-agent on SWE-bench Verified or Verified Mini using an
+already-running vLLM server, then evaluate the generated predictions with the
+local SWE-bench harness.
 
 Generation runs as a single continuous process across the whole selection so
 the vLLM server always has work queued. Finished instances are evaluated in
@@ -22,6 +23,7 @@ with the next instances being generated on the GPU instead of alternating
 between the two phases.
 
 Options:
+	--dataset NAME       Dataset: verified or verified-mini (default: verified)
 	--host HOST          vLLM host (default: 127.0.0.1)
 	--port PORT          vLLM port (default: 8888)
 	--served-name NAME   Served model ID (default: discover from /v1/models)
@@ -68,9 +70,9 @@ remove_chunk_images() {
 		images+=("$(verified_image_name "${instance_id}")")
 	done <"${ids_file}"
 	[[ ${#images[@]} -gt 0 ]] || return
-	log "Removing ${#images[@]} SWE-bench Verified images"
+	log "Removing ${#images[@]} ${BENCHMARK_LABEL} images"
 	docker image rm -f "${images[@]}" >/dev/null 2>&1 || \
-		warn "Some SWE-bench Verified images could not be removed"
+		warn "Some ${BENCHMARK_LABEL} images could not be removed"
 }
 
 readonly RUNNER_PID=$$
@@ -88,7 +90,7 @@ cleanup() {
 }
 
 termination_requested() {
-	warn "SWE-bench Verified run was interrupted"
+	warn "${BENCHMARK_LABEL:-SWE-bench Verified} run was interrupted"
 	exit 1
 }
 
@@ -117,9 +119,15 @@ RETRY_ERRORS=false
 RETRY_EMPTY_PATCHES=false
 RETRY_ATTEMPTS=1
 RETRY_ATTEMPTS_SPECIFIED=false
+DATASET="verified"
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
+		--dataset)
+			[[ $# -ge 2 ]] || die "$1 requires a value"
+			DATASET="$2"
+			shift 2
+			;;
 		--host)
 			[[ $# -ge 2 ]] || die "$1 requires a value"
 			VLLM_HOST="$2"
@@ -249,12 +257,37 @@ require_positive_integer "--retry-attempts" "${RETRY_ATTEMPTS}"
 [[ -z "${SLICE_ARG}" || "${SLICE_ARG}" =~ ^[0-9]*:[0-9]*$ ]] || \
 	die "--slice must use START:END format: ${SLICE_ARG}"
 
+case "${DATASET}" in
+	verified | swe_bench_verified)
+		readonly BENCHMARK_LABEL="SWE-bench Verified"
+		readonly BENCHMARK_TOTAL=500
+		readonly GENERATION_DATASET="verified"
+		readonly EVALUATION_DATASET="princeton-nlp/SWE-bench_Verified"
+		readonly OUTPUT_PREFIX="swe_verified"
+		;;
+	verified-mini | swe_bench_verified_mini)
+		readonly BENCHMARK_LABEL="SWE-bench Verified Mini"
+		readonly BENCHMARK_TOTAL=50
+		# This is the Hugging Face mirror of EvalScope's
+		# evalscope/swe-bench-verified-mini ModelScope dataset. mini-SWE-agent
+		# loads custom datasets through Hugging Face datasets.load_dataset().
+		readonly GENERATION_DATASET="MariusHobbhahn/swe-bench-verified-mini"
+		# Every Mini instance belongs to the official Verified dataset, so using
+		# the canonical source keeps the SWE-bench harness fully compatible.
+		readonly EVALUATION_DATASET="princeton-nlp/SWE-bench_Verified"
+		readonly OUTPUT_PREFIX="swe_verified_mini"
+		;;
+	*)
+		die "Unsupported --dataset '${DATASET}'; expected verified or verified-mini"
+		;;
+esac
+
 init_benchmark_paths
 init_vllm_endpoint
 trap cleanup EXIT
 trap termination_requested INT TERM
 RUN_TAG="$(sanitize_run_tag "${RUN_TAG}")"
-readonly OUT_DIR="${AGENT_DIR_VERIFIED}/results/swe_verified_${RUN_TAG}"
+readonly OUT_DIR="${AGENT_DIR_VERIFIED}/results/${OUTPUT_PREFIX}_${RUN_TAG}"
 readonly GEN_DIR="${OUT_DIR}/generation"
 readonly EVAL_ROOT="${OUT_DIR}/eval_chunks"
 readonly CLAIMED_FILE="${OUT_DIR}/claimed_ids.txt"
@@ -262,7 +295,7 @@ readonly EVAL_REPORT_LIST="${OUT_DIR}/eval_report_list.txt"
 readonly PREDS_JSON="${OUT_DIR}/preds.json"
 readonly PREDS_JSONL="${OUT_DIR}/preds.jsonl"
 readonly GEN_LOG="${OUT_DIR}/generation.log"
-readonly LOG_FILE="${LOG_DIR}/swe_verified_${RUN_TAG}.log"
+readonly LOG_FILE="${LOG_DIR}/${OUTPUT_PREFIX}_${RUN_TAG}.log"
 readonly REPORT_FILE="${OUT_DIR}/report.json"
 
 [[ -d "${AGENT_DIR_VERIFIED}/.git" ]] || \
@@ -331,17 +364,17 @@ fi
 wait_for_vllm "${VLLM_WAIT_TIMEOUT:-300}"
 SERVED_MODEL_NAME="$(discover_vllm_model "${SERVED_MODEL_NAME}")"
 EVAL_WORKERS="${EVAL_WORKERS:-${WORKERS}}"
-full_slice_plan="$(plan_batch_slices 500 "${NUM_TASKS}" "${SLICE_ARG}" 500)"
+full_slice_plan="$(plan_batch_slices "${BENCHMARK_TOTAL}" "${NUM_TASKS}" "${SLICE_ARG}" "${BENCHMARK_TOTAL}")"
 mapfile -t FULL_SLICE_LINES <<<"${full_slice_plan}"
-[[ ${#FULL_SLICE_LINES[@]} -eq 1 ]] || die "Unexpected slice plan for SWE-bench Verified selection"
+[[ ${#FULL_SLICE_LINES[@]} -eq 1 ]] || die "Unexpected slice plan for ${BENCHMARK_LABEL} selection"
 readonly FULL_SLICE="${FULL_SLICE_LINES[0]}"
 
-log "Generating SWE-bench Verified selection ${FULL_SLICE} with model ${SERVED_MODEL_NAME}"
+log "Generating ${BENCHMARK_LABEL} selection ${FULL_SLICE} with model ${SERVED_MODEL_NAME}"
 (
 	cd "${AGENT_DIR_VERIFIED}"
 	exec env MSWEA_COST_TRACKING=ignore_errors mini-extra swebench \
 		--model "${SERVED_MODEL_NAME}" \
-		--subset verified \
+		--subset "${GENERATION_DATASET}" \
 		--split test \
 		--workers "${WORKERS}" \
 		--output "${GEN_DIR}" \
@@ -368,7 +401,7 @@ monitor_vllm() {
 		failures=$((failures + 1))
 		warn "vLLM health check failed (${failures}/${HEALTH_FAILURES}): ${VLLM_ORIGIN}/health"
 		if ((failures >= HEALTH_FAILURES)); then
-			warn "vLLM is unavailable; stopping SWE-bench Verified"
+			warn "vLLM is unavailable; stopping ${BENCHMARK_LABEL}"
 			kill -TERM "${GEN_PID}" 2>/dev/null || true
 			kill -TERM "${RUNNER_PID}" 2>/dev/null || true
 			return
@@ -406,12 +439,12 @@ process_pending_chunk() {
 			--source "${GEN_DIR}/preds.json" --output "${chunk_preds_jsonl}" \
 			--ids "${chunk_ids_file}"
 
-		log "Evaluating $# SWE-bench Verified instances with ${EVAL_WORKERS} workers"
+		log "Evaluating $# ${BENCHMARK_LABEL} instances with ${EVAL_WORKERS} workers"
 		rm -f -- "${harness_report}"
 		(
 			cd "${BENCHMARK_DIR}"
 			exec python -m swebench.harness.run_evaluation \
-				--dataset_name princeton-nlp/SWE-bench_Verified \
+				--dataset_name "${EVALUATION_DATASET}" \
 				--split test \
 				--predictions_path "${chunk_preds_jsonl}" \
 				--instance_ids "$@" \

--- a/benchmark/agent_benchmarks/setup_swe_verified.sh
+++ b/benchmark/agent_benchmarks/setup_swe_verified.sh
@@ -57,6 +57,6 @@ else
 fi
 
 log "Installing mini-SWE-agent for inference and SWE-bench for local evaluation"
-uv pip install "${AGENT_DIR_VERIFIED}" swebench "datasets>=3.0.0"
+uv pip install "${AGENT_DIR_VERIFIED}" "swebench==${SWEBENCH_VERSION}" "datasets>=3.0.0"
 
 log "SWE-bench Verified setup complete"

--- a/benchmark/agent_benchmarks/versions.env
+++ b/benchmark/agent_benchmarks/versions.env
@@ -6,6 +6,7 @@ VLLM_VERSION="${VLLM_VERSION:-0.26.0}"
 
 # mini-SWE-agent release used by SWE-bench Verified.
 MINI_SWE_AGENT_VERSION="${MINI_SWE_AGENT_VERSION:-2.4.6}"
+SWEBENCH_VERSION="${SWEBENCH_VERSION:-4.1.0}"
 
 # SWE-bench Pro repository and its mini-SWE-agent submodule.
 SWEBENCH_PRO_COMMIT="${SWEBENCH_PRO_COMMIT:-ca10a60a5fcae51e6948ffe1485d4153d421e6c5}"


### PR DESCRIPTION
## Type of Change

enhancement

## Description

This PR extends the existing SWE-bench Verified workflow with SWE-bench Verified Mini support and adds controls for repeated retries and Docker image retention.

### SWE-bench Verified Mini

- Adds `--dataset verified-mini` for the 50-instance Verified Mini dataset.
- Uses `MariusHobbhahn/swe-bench-verified-mini` for generation and the canonical `princeton-nlp/SWE-bench_Verified` dataset for local evaluation.
- Keeps the existing generation/evaluation pipeline and output layout.
- Automatically retains benchmark Docker images for Verified Mini runs.

Example:

```bash
bash run_swe_verified.sh \
  --dataset verified-mini \
  --port 8888 \
  --step-limit 250 \
  --tag qwen36_27b_mini
```

### Retry attempts

- Adds `--retry-attempts N`, which enables retries for both error cases and empty patches.
- Runs at most `N` retry rounds.
- Stops early when no retryable cases remain.
- After each round, compares aggregate accuracy (`resolved_instances / submitted_instances`) with the preceding round and stops when accuracy is unchanged or lower.
- Continues only when accuracy strictly improves.

For example, with `--retry-attempts 10`, an accuracy sequence of `1/10 -> 2/10 -> 2/10` stops after the second retry round instead of running all 10 rounds.

### Docker image retention

- Verified Mini automatically retains benchmark Docker images after each chunk.
- Full Verified runs continue to remove images by default.
- `--keep-images` can be used to retain images for a full Verified run.
- Image-cleanup no-op paths return success so they do not terminate the runner under `set -e`.

## Expected Behavior & Potential Risk

Expected behavior:

- `--dataset verified-mini` runs the Verified Mini selection and retains its Docker images automatically.
- `--retry-attempts N` retries until accuracy no longer improves, retry categories become empty, or the configured limit is reached.
- `--keep-images` prevents image removal for a full Verified run.

Potential risks:

- Retaining images can consume significant disk space.
- Retry stopping depends on the aggregate report's `resolved_instances` and `submitted_instances` values.
- The vLLM served model name must be compatible with the mini-SWE-agent/LiteLLM model configuration.

## How has this PR been tested?

Test environment:

- Python 3.13.13 from `/data3/changwa1/.venv`
- Local vLLM OpenAI-compatible server on GPU 0, port 8000
- Served model: `Qwen3.6-27B`

Validation performed:

- Shell syntax and Python compilation checks
- CLI help checks for the new options
- Fixture tests for retryable-ID deduplication and retry state output
- Simulated `--retry-attempts 10` loop: `1/10 -> 2/10 -> 2/10`, confirming it stopped after two rounds
- Verified that Verified Mini enables image retention automatically while full Verified still removes images by default
- Verified that retained-image and empty-ID cleanup paths return success without invoking `docker image rm`
- Verified the vLLM `/v1/models` and `/v1/chat/completions` endpoints; the model returned `OK`

A real one-instance Verified Mini generation smoke also loaded the dataset, started and cleaned up the SWE-bench container, called the existing `Qwen3.6-27B` vLLM endpoint through LiteLLM, and wrote `preds.json`. It used a two-step limit and therefore ended with the expected `LimitsExceeded` status. The existing vLLM process was not restarted or modified. Its tool-call endpoint is not enabled with `--enable-auto-tool-choice` and a tool-call parser, so the smoke used mini-SWE-agent text mode; the standard tool-call runner still requires those server options.

## Dependency Change?

No new library dependency is introduced or removed.