### PR TITLE
fix(example): preserve samples when splitting Flux dataset

### DIFF
--- a/examples/pytorch/diffusion_model/diffusers/flux/dataset_split.py
+++ b/examples/pytorch/diffusion_model/diffusers/flux/dataset_split.py
@@ -2,7 +2,7 @@ import argparse
 import pandas as pd
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--split_num', type=int)
+parser.add_argument('--split_num', type=int, required=True)
 parser.add_argument('--limit', default=-1, type=int)
 parser.add_argument('--input_file', type=str)
 parser.add_argument('--output_file', default="subset", type=str)
@@ -14,9 +14,12 @@ df = pd.read_csv(args.input_file, sep='\t')
 if args.limit > 0:
     df = df.iloc[0:args.limit]
 
-num = round(len(df) / args.split_num)
+if args.split_num <= 0:
+    parser.error("--split_num must be greater than 0")
+
+subset_size, remainder = divmod(len(df), args.split_num)
 for i in range(args.split_num):
-    start = i * num
-    end = min((i + 1) * num, len(df))
+    start = i * subset_size + min(i, remainder)
+    end = start + subset_size + (1 if i < remainder else 0)
     df_subset = df.iloc[start:end]
     df_subset.to_csv(f"{args.output_file}_{i}.tsv", sep='\t', index=False)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Distribute the remainder across the first Flux evaluation subsets instead of using a rounded fixed subset size. This ensures every dataset row is assigned exactly once when the sample count is not divisible by the number of visible GPUs. Also validate that `--split_num` is provided and greater than zero.

eg:
origin code,
3 splits: 1,667 / 1,667 / 1,666 rows
6 splits: 833 / 833 / 833 / 833 / 833 / 833 rows (missing 2 rows)

## Expected Behavior & Potential Risk

All evaluation samples are preserved, subset sizes differ by at most one, and row order remains unchanged. The change is limited to the Flux example dataset splitting script and introduces minimal risk.

## How has this PR been tested?

Ran the splitter on a generated 5,000-row TSV:
- 3 splits: 1,667 / 1,667 / 1,666 rows
- 6 splits: 834 / 834 / 833 / 833 / 833 / 833 rows

Concatenating each set of outputs reproduced all 5,000 input rows in their original order. Also verified Python syntax and `git diff --check`. No GPU hardware is required for this splitter test.

## Dependency Change?

None.