### PR TITLE
fix(fp8_quant test): pass htexp_device_type to the unexpected-device error message

### DIFF
--- a/test/torch/algorithms/fp8_quant/test_hpu_utils.py
+++ b/test/torch/algorithms/fp8_quant/test_hpu_utils.py
@@ -46,7 +46,7 @@ def htexp_device_type_to_inc_acclerator_type(htexp_device_type):
     elif htexp_device_type == get_gaudi3_type():
         return INCAcceleratorType.GAUDI3
     else:
-        raise ValueError("Unexpected htexp_device_type {} ".format())
+        raise ValueError("Unexpected htexp_device_type {} ".format(htexp_device_type))
 
 
 device_type = [GAUDI2, GAUDI3]


### PR DESCRIPTION
### Problem

`test/torch/algorithms/fp8_quant/test_hpu_utils.py:49` formats an error message with a `{}` placeholder but passes no argument:

```python
def htexp_device_type_to_inc_acclerator_type(htexp_device_type):
    if htexp_device_type == get_gaudi2_type():
        return INCAcceleratorType.GAUDI2
    elif htexp_device_type == get_gaudi3_type():
        return INCAcceleratorType.GAUDI3
    else:
        raise ValueError("Unexpected htexp_device_type {} ".format())   # <-- no argument
```

`str.format()` with a positional `{}` and no arguments raises before the `ValueError` is ever constructed:

```
IndexError: Replacement index 0 out of range for positional args tuple
```

So on an unrecognised Gaudi device the helper — used by `unit_tests/test_functions/test_config_json.py` via `device_type_id[device_type]` — fails with an unrelated `IndexError` and no indication of *which* device type was unexpected, which is exactly the information the message exists to provide.

### Fix

Pass the value the placeholder is for:

```python
        raise ValueError("Unexpected htexp_device_type {} ".format(htexp_device_type))
```

One line. The trailing space in the literal is left as-is to keep the diff to the argument only.

### Verification

I don't have Gaudi hardware, so `habana_frameworks` won't import here and the module can't be executed directly. The failure is in `str.format` itself and is independent of the HPU stack — the literal from the file, reproduced verbatim:

```
>>> "Unexpected htexp_device_type {} ".format()
Traceback (most recent call last):
IndexError: Replacement index 0 out of range for positional args tuple
>>> "Unexpected htexp_device_type {} ".format("synDeviceGaudi")
'Unexpected htexp_device_type synDeviceGaudi '
```

Formatting checked against the repo's pinned hook (`black==26.5.1`, `line-length = 120` from `pyproject.toml`): the patched file is left unchanged (the new line is 86 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
