### PR TITLE
update flux example parameters

### DIFF
--- a/examples/pytorch/diffusion_model/diffusers/flux/main.py
+++ b/examples/pytorch/diffusion_model/diffusers/flux/main.py
@@ -47,7 +47,7 @@ parser.add_argument("--dataset", type=str, default="coco2014", help="the dataset
 parser.add_argument("--output_dir", "--quantized_model_path", default="./tmp_autoround", type=str, help="the directory to save quantized model")
 parser.add_argument("--eval_dataset", default="captions_source.tsv", type=str, help="eval datasets")
 parser.add_argument("--output_image_path", default="./tmp_imgs", type=str, help="the directory to save quantized model")
-parser.add_argument("--iters", "--iter", default=1000, type=int, help="tuning iters")
+parser.add_argument("--iters", "--iter", default=200, type=int, help="tuning iters")
 parser.add_argument("--limit", default=-1, type=int, help="limit the number of prompts for evaluation")
 
 args = parser.parse_args()
@@ -101,7 +101,7 @@ def tune(device):
         iters=args.iters,
         dataset=args.dataset,
         layer_config=layer_config,
-        num_inference_steps=3,
+        calib_num_inference_steps=8,
         export_format="fake",
         nsamples=128,
         batch_size=1,

--- a/examples/pytorch/diffusion_model/diffusers/flux/run_quant.sh
+++ b/examples/pytorch/diffusion_model/diffusers/flux/run_quant.sh
@@ -42,7 +42,7 @@ function run_tuning {
     if [ "${topology}" = "flux_fp8" ]; then
         extra_cmd="--scheme FP8 --iters 0 --dataset ${dataset_location} --quantize"
     elif [ "${topology}" = "flux_mxfp8" ]; then
-        extra_cmd="--scheme MXFP8 --iters 1000 --dataset ${dataset_location} --quantize"
+        extra_cmd="--scheme MXFP8 --iters 200 --dataset ${dataset_location} --quantize"
     fi
 
     python3 main.py \


### PR DESCRIPTION
## Type of Change

feature/bug fix/documentation/validation/others

Description
Update the Flux MXFP8 example to align with the new diffusion calibration API introduced by AutoRound PR [#2265](https://github.com/intel/auto-round/pull/2265)

Changes
Replace `num_inference_steps=3` with `calib_num_inference_steps=8`
Change the default tuning `iters` from 1000 to 200..

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
