### PR TITLE
feat: enhance QDQ tracing with backend and format details, update rel…

### DIFF
--- a/benchmark/vllm-qdq-plugin/README.md
+++ b/benchmark/vllm-qdq-plugin/README.md
@@ -60,11 +60,18 @@ The plugin registers as a `vllm.general_plugins` entry point. vLLM loads it in a
 | Variable | Default | Description |
 | --- | --- | --- |
 | `VLLM_QDQ` | `0` | Set to `1` to enable QDQ. |
-| `VLLM_QDQ_TRACE` | `0` | Set to `1` to print up to 200 QDQ shape and dtype trace lines. |
+| `VLLM_QDQ_TRACE` | `0` | Set to `1` to print backend, format, operation, shape, and dtype for the first 200 QDQ calls in each process （Eager mode only). |
 | `VLLM_QDQ_CUTE` | automatic | CuTe is selected automatically for MXFP4, MXFP8, and NVFP4_E5M3 when the input is on an NVIDIA CUDA GPU with SM80+, NVIDIA CUTLASS DSL is installed, and the format-specific shape requirements are met. In automatic mode, a missing CUTLASS DSL installation warns with an install command before falling back to the reference implementation. Set to `0` to force the reference implementation or `1` to explicitly require CuTe; an explicit request raises an error when CUTLASS DSL is missing. Other unsupported CuTe conditions warn before using the slower reference implementation. |
 | `VLLM_MARLIN_MOE_QDQ_MODE` | `0` | Set to `FORCE_MXFP4` to apply MXFP4 QDQ in `moe_wna16_marlin_gemm` when dtype-based routing is not sufficient. Matching is case-insensitive. |
 
-For diagnostics, add `VLLM_QDQ_TRACE=1` to print up to 200 QDQ shape and dtype trace lines. To force MXFP4 QDQ for Marlin MoE when dtype detection is insufficient, add `VLLM_MARLIN_MOE_QDQ_MODE=FORCE_MXFP4`.
+For diagnostics, add `VLLM_QDQ_TRACE=1` and start vLLM with `--enforce-eager` so QDQ calls execute eagerly and produce runtime trace output. The 200 limit counts QDQ calls independently in each process; it is not a request or token limit. A trace line looks like `[QDQ] backend=CuTe format=MXFP8 op=marlin_gemm shape=... dtype=...`. A fallback is reported as `backend=Reference`, and formats include `MXFP4`, `MXFP8`, and `NVFP4_E5M3`.
+
+```bash
+VLLM_QDQ=1 VLLM_QDQ_TRACE=1 VLLM_QDQ_CUTE=1 \
+  vllm serve /path/to/model --enforce-eager
+```
+
+To force MXFP4 QDQ for Marlin MoE when dtype detection is insufficient, add `VLLM_MARLIN_MOE_QDQ_MODE=FORCE_MXFP4`.
 
 ### Supported Formats
 

--- a/benchmark/vllm-qdq-plugin/src/nvfp4_hw/fused_moe_ue5m3.py
+++ b/benchmark/vllm-qdq-plugin/src/nvfp4_hw/fused_moe_ue5m3.py
@@ -238,7 +238,11 @@ def fused_moe_ue5m3(
     )
     num_assignments = num_tokens * top_k
     gate_up = torch.zeros((num_assignments, w13.shape[1]), dtype=x.dtype, device=x.device)
-    quantized_x = nvfp4_e5m3_qdq(x, group_size)
+    quantized_x = nvfp4_e5m3_qdq(
+        x,
+        group_size,
+        trace_op_name="nvfp4_e5m3_moe_input",
+    )
     _invoke_fused_moe_ue5m3(
         quantized_x,
         w13,
@@ -255,7 +259,11 @@ def fused_moe_ue5m3(
     )
     activated = torch.empty((num_assignments, w13.shape[1] // 2), dtype=x.dtype, device=x.device)
     apply_moe_activation(activation, activated, gate_up, activation_config=activation_config)
-    activated = nvfp4_e5m3_qdq(activated, group_size)
+    activated = nvfp4_e5m3_qdq(
+        activated,
+        group_size,
+        trace_op_name="nvfp4_e5m3_moe_activation",
+    )
     expert_output = torch.zeros((num_assignments, hidden_size), dtype=x.dtype, device=x.device)
     _invoke_fused_moe_ue5m3(
         activated,

--- a/benchmark/vllm-qdq-plugin/src/nvfp4_hw/inc_nvfp4_ue5m3_moe.py
+++ b/benchmark/vllm-qdq-plugin/src/nvfp4_hw/inc_nvfp4_ue5m3_moe.py
@@ -150,9 +150,19 @@ class INCNvfp4UE5M3MoEMethod(FusedMoEMethodBase):
                 topk_ids=topk_ids,
                 expert_map=expert_map,
             )
-            output.copy_(nvfp4_e5m3_qdq(output.contiguous(), self.group_size))
+            output.copy_(
+                nvfp4_e5m3_qdq(
+                    output.contiguous(),
+                    self.group_size,
+                    trace_op_name="nvfp4_e5m3_moe_activation",
+                )
+            )
 
-        quantized_x = nvfp4_e5m3_qdq(x.contiguous(), self.group_size)
+        quantized_x = nvfp4_e5m3_qdq(
+            x.contiguous(),
+            self.group_size,
+            trace_op_name="nvfp4_e5m3_moe_input",
+        )
         return fused_marlin_moe(
             hidden_states=quantized_x,
             w1=layer.w13_weight,

--- a/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/patch.py
+++ b/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/patch.py
@@ -20,7 +20,7 @@ def _is_mxfp4_marlin_weight(b_q_type, global_scale, scalar_types) -> bool:
     return b_q_type == scalar_types.float4_e2m1f and global_scale is None
 
 
-def _patch_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq, trace_qdq):
+def _patch_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq):
     """Patch ops.marlin_gemm with QDQ wrapper.
 
     Returns:
@@ -60,11 +60,9 @@ def _patch_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq, trace_qdq):
                 torch.bfloat16,
             )
         ):
-            trace_qdq("marlin_gemm", a.shape, a.dtype)
-            a = mxfp4_qdq(a, group_size=32)
+            a = mxfp4_qdq(a, group_size=32, trace_op_name="marlin_gemm")
         elif b_q_type == scalar_types.float8_e4m3fn and a.dim() == 2 and a.dtype in (torch.float16, torch.bfloat16):
-            trace_qdq("marlin_gemm", a.shape, a.dtype)
-            a = mxfp8_qdq(a, group_size=32)
+            a = mxfp8_qdq(a, group_size=32, trace_op_name="marlin_gemm")
 
         return _orig(
             a,
@@ -92,7 +90,7 @@ def _patch_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq, trace_qdq):
     return ("marlin_gemm", _orig, _patched)
 
 
-def _patch_moe_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq, trace_qdq):
+def _patch_moe_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq):
     """Patch ops.moe_wna16_marlin_gemm with QDQ wrapper.
 
     Returns:
@@ -134,14 +132,11 @@ def _patch_moe_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq, trace_qdq):
         blocks_per_sm: int = -1,
     ) -> torch.Tensor:
         if input.dim() == 2 and envs.VLLM_MARLIN_MOE_QDQ_MODE == "FORCE_MXFP4":
-            trace_qdq("moe_wna16_marlin_gemm", input.shape, input.dtype)
-            input = mxfp4_qdq(input, group_size=32)
+            input = mxfp4_qdq(input, group_size=32, trace_op_name="moe_wna16_marlin_gemm")
         elif _is_mxfp4_marlin_weight(b_q_type, global_scale, scalar_types) and input.dim() == 2:
-            trace_qdq("moe_wna16_marlin_gemm", input.shape, input.dtype)
-            input = mxfp4_qdq(input, group_size=32)
+            input = mxfp4_qdq(input, group_size=32, trace_op_name="moe_wna16_marlin_gemm")
         elif b_q_type == scalar_types.float8_e4m3fn and input.dim() == 2:
-            trace_qdq("moe_wna16_marlin_gemm", input.shape, input.dtype)
-            input = mxfp8_qdq(input, group_size=32)
+            input = mxfp8_qdq(input, group_size=32, trace_op_name="moe_wna16_marlin_gemm")
 
         return _orig(
             input,
@@ -234,13 +229,12 @@ def apply_patches():
 
     from .qdq.mxfp4 import mxfp4_qdq
     from .qdq.mxfp8 import mxfp8_qdq
-    from .trace import trace_qdq
 
     _patch_mla_kv_b_proj_dtype()
 
     patches = [
-        _patch_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq, trace_qdq),
-        _patch_moe_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq, trace_qdq),
+        _patch_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq),
+        _patch_moe_marlin_gemm(ops, scalar_types, mxfp4_qdq, mxfp8_qdq),
     ]
 
     # Fix up any modules that imported these via

--- a/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/cute.py
+++ b/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/cute.py
@@ -10,6 +10,7 @@ import warnings
 
 import torch
 from vllm_qdq_plugin import envs
+from vllm_qdq_plugin.trace import trace_qdq
 
 _FALLBACK_WARNINGS_EMITTED: set[tuple[str, str]] = set()
 _CUTLASS_DSL_INSTALL_HINT = "install it with `pip install 'nvidia-cutlass-dsl>=4.6.0'`"
@@ -78,10 +79,17 @@ def _make_contiguous_for_cute(x: torch.Tensor, format_name: str) -> torch.Tensor
     return x.contiguous()
 
 
-def _reference_fallback(x: torch.Tensor, group_size: int, format_name: str, reason: str | None = None) -> torch.Tensor:
+def _reference_fallback(
+    x: torch.Tensor,
+    group_size: int,
+    format_name: str,
+    trace_op_name: str,
+    reason: str | None = None,
+) -> torch.Tensor:
     available, capability_reason = cute_qdq_status(x)
     status = reason or ("unsupported input" if available else capability_reason)
     warn_reference_fallback(format_name, status)
+    trace_qdq(trace_op_name, x.shape, x.dtype, backend="Reference", format_name=format_name)
 
     if format_name == "MXFP4":
         from .mxfp4 import _mxfp4_qdq_reference
@@ -93,17 +101,19 @@ def _reference_fallback(x: torch.Tensor, group_size: int, format_name: str, reas
     return _mxfp8_qdq_reference(x, group_size)
 
 
-def _run_cute_or_fallback(x: torch.Tensor, group_size: int, format_name: str) -> torch.Tensor:
+def _run_cute_or_fallback(x: torch.Tensor, group_size: int, format_name: str, trace_op_name: str) -> torch.Tensor:
     op = _mxfp4_qdq_cute_op if format_name == "MXFP4" else _mxfp8_qdq_cute_op
     if torch.compiler.is_compiling():
         if group_size != 32:
             raise ValueError(f"CuTe QDQ requires group_size=32, got {group_size}")
+        trace_qdq(trace_op_name, x.shape, x.dtype, backend="CuTe", format_name=format_name)
         return op(x)
 
     available, capability_reason = cute_qdq_status(x)
     if available and group_size == 32 and x.shape[-1] % group_size == 0:
         if not x.is_contiguous():
             x = _make_contiguous_for_cute(x, format_name)
+        trace_qdq(trace_op_name, x.shape, x.dtype, backend="CuTe", format_name=format_name)
         return op(x)
     if not available:
         reason = capability_reason
@@ -111,14 +121,24 @@ def _run_cute_or_fallback(x: torch.Tensor, group_size: int, format_name: str) ->
         reason = f"group_size={group_size} is unsupported"
     else:
         reason = f"K={x.shape[-1]} is not divisible by 32"
-    return _reference_fallback(x, group_size, format_name, reason)
+    return _reference_fallback(x, group_size, format_name, trace_op_name, reason)
 
 
-def mxfp4_qdq_cute(x: torch.Tensor, group_size: int = 32) -> torch.Tensor:
+def mxfp4_qdq_cute(
+    x: torch.Tensor,
+    group_size: int = 32,
+    *,
+    trace_op_name: str = "mxfp4_qdq",
+) -> torch.Tensor:
     """Run the MXFP4 CuTe backend, or the validated reference fallback."""
-    return _run_cute_or_fallback(x, group_size, "MXFP4")
+    return _run_cute_or_fallback(x, group_size, "MXFP4", trace_op_name)
 
 
-def mxfp8_qdq_cute(x: torch.Tensor, group_size: int = 32) -> torch.Tensor:
+def mxfp8_qdq_cute(
+    x: torch.Tensor,
+    group_size: int = 32,
+    *,
+    trace_op_name: str = "mxfp8_qdq",
+) -> torch.Tensor:
     """Run the MXFP8 CuTe backend, or the validated reference fallback."""
-    return _run_cute_or_fallback(x, group_size, "MXFP8")
+    return _run_cute_or_fallback(x, group_size, "MXFP8", trace_op_name)

--- a/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/mxfp4.py
+++ b/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/mxfp4.py
@@ -9,6 +9,7 @@ plugin does not depend on vLLM internals.
 import torch
 
 from .. import envs
+from ..trace import trace_qdq
 
 BFLOAT16_EXP_BIAS = 127
 BFLOAT16_MANTISSA_BITS = 7
@@ -142,10 +143,11 @@ def _mxfp4_qdq_reference(x: torch.Tensor, group_size: int = 32) -> torch.Tensor:
     return x_fp4.reshape(m, -1)[:, :k].to(orig_dtype)
 
 
-def mxfp4_qdq(x: torch.Tensor, group_size: int = 32) -> torch.Tensor:
+def mxfp4_qdq(x: torch.Tensor, group_size: int = 32, *, trace_op_name: str = "mxfp4_qdq") -> torch.Tensor:
     """Quantize-dequantize input to MXFP4 (E2M1 + E8M0 scales)."""
     if envs.VLLM_QDQ_CUTE:
         from .cute import mxfp4_qdq_cute
 
-        return mxfp4_qdq_cute(x, group_size)
+        return mxfp4_qdq_cute(x, group_size, trace_op_name=trace_op_name)
+    trace_qdq(trace_op_name, x.shape, x.dtype, backend="Reference", format_name="MXFP4")
     return _mxfp4_qdq_reference(x, group_size)

--- a/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/mxfp8.py
+++ b/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/mxfp8.py
@@ -8,6 +8,7 @@ bias=7, max=448) with per-group E8M0 (power-of-2) scales of group_size elements.
 import torch
 
 from .. import envs
+from ..trace import trace_qdq
 
 FLOAT8_E8M0_MAX_EXP = 127
 
@@ -120,10 +121,11 @@ def _mxfp8_qdq_reference(x: torch.Tensor, group_size: int = 32) -> torch.Tensor:
     return x_fp8.reshape(m, -1)[:, :k]
 
 
-def mxfp8_qdq(x: torch.Tensor, group_size: int = 32) -> torch.Tensor:
+def mxfp8_qdq(x: torch.Tensor, group_size: int = 32, *, trace_op_name: str = "mxfp8_qdq") -> torch.Tensor:
     """Quantize-dequantize input to MXFP8 (E4M3 + E8M0 scales)."""
     if envs.VLLM_QDQ_CUTE:
         from .cute import mxfp8_qdq_cute
 
-        return mxfp8_qdq_cute(x, group_size)
+        return mxfp8_qdq_cute(x, group_size, trace_op_name=trace_op_name)
+    trace_qdq(trace_op_name, x.shape, x.dtype, backend="Reference", format_name="MXFP8")
     return _mxfp8_qdq_reference(x, group_size)

--- a/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/nvfp4_e5m3.py
+++ b/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/qdq/nvfp4_e5m3.py
@@ -2,6 +2,7 @@
 
 import torch
 from vllm_qdq_plugin import envs
+from vllm_qdq_plugin.trace import trace_qdq
 
 
 def decode_ue5m3(scale_bits: torch.Tensor) -> torch.Tensor:
@@ -66,7 +67,12 @@ def _nvfp4_e5m3_qdq_reference(x: torch.Tensor, group_size: int = 16) -> torch.Te
     return (quantized * scales.unsqueeze(-1)).reshape(rows, -1)[:, :width].to(original_dtype)
 
 
-def nvfp4_e5m3_qdq(x: torch.Tensor, group_size: int = 16) -> torch.Tensor:
+def nvfp4_e5m3_qdq(
+    x: torch.Tensor,
+    group_size: int = 16,
+    *,
+    trace_op_name: str = "nvfp4_e5m3_qdq",
+) -> torch.Tensor:
     """Quantize-dequantize BF16/FP16 activations using E2M1 and UE5M3 scales."""
     if x.dim() != 2:
         raise ValueError(f"nvfp4_e5m3_qdq expects a 2D tensor, got {x.dim()}D")
@@ -75,10 +81,12 @@ def nvfp4_e5m3_qdq(x: torch.Tensor, group_size: int = 16) -> torch.Tensor:
     if group_size not in (16, 32):
         raise ValueError(f"nvfp4_e5m3_qdq requires group_size 16 or 32, got {group_size}")
     if not envs.VLLM_QDQ_CUTE:
+        trace_qdq(trace_op_name, x.shape, x.dtype, backend="Reference", format_name="NVFP4_E5M3")
         return _nvfp4_e5m3_qdq_reference(x, group_size)
     if torch.compiler.is_compiling() and x.is_cuda:
         from .nvfp4_e5m3_cute import nvfp4_e5m3_qdq_cute
 
+        trace_qdq(trace_op_name, x.shape, x.dtype, backend="CuTe", format_name="NVFP4_E5M3")
         return nvfp4_e5m3_qdq_cute(x, group_size)
     from .cute import cute_qdq_status, warn_reference_fallback
 
@@ -86,10 +94,12 @@ def nvfp4_e5m3_qdq(x: torch.Tensor, group_size: int = 16) -> torch.Tensor:
     if available and x.is_contiguous() and x.shape[1] % group_size == 0:
         from .nvfp4_e5m3_cute import nvfp4_e5m3_qdq_cute
 
+        trace_qdq(trace_op_name, x.shape, x.dtype, backend="CuTe", format_name="NVFP4_E5M3")
         return nvfp4_e5m3_qdq_cute(x, group_size)
     if available and not x.is_contiguous():
         reason = "input is not contiguous"
     elif available:
         reason = f"K={x.shape[1]} is not divisible by group_size={group_size}"
     warn_reference_fallback("NVFP4_E5M3", reason)
+    trace_qdq(trace_op_name, x.shape, x.dtype, backend="Reference", format_name="NVFP4_E5M3")
     return _nvfp4_e5m3_qdq_reference(x, group_size)

--- a/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/trace.py
+++ b/benchmark/vllm-qdq-plugin/src/vllm_qdq_plugin/trace.py
@@ -9,11 +9,11 @@ from . import envs
 _call_count = 0
 
 
-def trace_qdq(op_name: str, shape, dtype):
+def trace_qdq(op_name: str, shape, dtype, *, backend: str, format_name: str):
     """Print a trace line if tracing is enabled."""
     if not envs.VLLM_QDQ_TRACE:
         return
     global _call_count
     _call_count += 1
     if _call_count <= 200:
-        print(f"[QDQ] op={op_name} shape={shape} dtype={dtype}")
+        print(f"[QDQ] backend={backend} format={format_name} op={op_name} shape={shape} dtype={dtype}")

--- a/benchmark/vllm-qdq-plugin/tests/test_patch.py
+++ b/benchmark/vllm-qdq-plugin/tests/test_patch.py
@@ -78,9 +78,8 @@ class PatchMoeMarlinGemmTests(unittest.TestCase):
         _patch_marlin_gemm(
             ops,
             scalar_types,
-            lambda x, group_size=32: qdq_calls.append(group_size) or (x + 1),
+            lambda x, group_size=32, **kwargs: qdq_calls.append(group_size) or (x + 1),
             lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected MXFP8 QDQ")),
-            lambda *args, **kwargs: None,
         )
         input_tensor = torch.zeros((2, 64), dtype=torch.bfloat16)
         output = _call_marlin_gemm(
@@ -114,9 +113,8 @@ class PatchMoeMarlinGemmTests(unittest.TestCase):
         _patch_moe_marlin_gemm(
             ops,
             scalar_types,
-            lambda x, group_size=32: qdq_calls.append(group_size) or (x + 1),
+            lambda x, group_size=32, **kwargs: qdq_calls.append(group_size) or (x + 1),
             lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected MXFP8 QDQ")),
-            lambda *args, **kwargs: None,
         )
         input_tensor = torch.zeros((2, 64), dtype=torch.bfloat16)
         output = _call_moe_marlin_gemm(
@@ -142,15 +140,16 @@ class PatchMoeMarlinGemmTests(unittest.TestCase):
             float8_e4m3fn=object(),
         )
         qdq_calls: list[int] = []
-        trace_calls: list[tuple[str, torch.Size, torch.dtype]] = []
+        trace_op_names: list[str | None] = []
 
         def orig(*args, **kwargs):
             return args[0]
 
         ops = types.SimpleNamespace(moe_wna16_marlin_gemm=orig)
 
-        def mxfp4_qdq(x: torch.Tensor, group_size: int = 32) -> torch.Tensor:
+        def mxfp4_qdq(x: torch.Tensor, group_size: int = 32, **kwargs) -> torch.Tensor:
             qdq_calls.append(group_size)
+            trace_op_names.append(kwargs.get("trace_op_name"))
             return x + 1
 
         with mock.patch.dict(
@@ -163,7 +162,6 @@ class PatchMoeMarlinGemmTests(unittest.TestCase):
                 scalar_types,
                 mxfp4_qdq,
                 lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected MXFP8 QDQ")),
-                lambda op_name, shape, dtype: trace_calls.append((op_name, shape, dtype)),
             )
             input_tensor = torch.zeros((2, 64), dtype=torch.float16)
             output = _call_moe_marlin_gemm(
@@ -173,10 +171,7 @@ class PatchMoeMarlinGemmTests(unittest.TestCase):
             )
 
         self.assertEqual(qdq_calls, [32])
-        self.assertEqual(
-            trace_calls,
-            [("moe_wna16_marlin_gemm", input_tensor.shape, input_tensor.dtype)],
-        )
+        self.assertEqual(trace_op_names, ["moe_wna16_marlin_gemm"])
         self.assertTrue(torch.equal(output, input_tensor + 1))
 
     def test_force_mxfp4_mode_skips_non_2d_inputs(self) -> None:
@@ -199,9 +194,8 @@ class PatchMoeMarlinGemmTests(unittest.TestCase):
             _patch_moe_marlin_gemm(
                 ops,
                 scalar_types,
-                lambda x, group_size=32: qdq_calls.append(group_size) or (x + 1),
+                lambda x, group_size=32, **kwargs: qdq_calls.append(group_size) or (x + 1),
                 lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected MXFP8 QDQ")),
-                lambda *args, **kwargs: None,
             )
             input_tensor = torch.zeros((1, 2, 64), dtype=torch.float16)
             output = _call_moe_marlin_gemm(

--- a/benchmark/vllm-qdq-plugin/tests/test_trace.py
+++ b/benchmark/vllm-qdq-plugin/tests/test_trace.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from vllm_qdq_plugin import trace
+from vllm_qdq_plugin.qdq.mxfp8 import mxfp8_qdq
+from vllm_qdq_plugin.qdq.nvfp4_e5m3 import nvfp4_e5m3_qdq
+
+
+class TraceQDQTests(unittest.TestCase):
+    def setUp(self) -> None:
+        trace._call_count = 0
+
+    def test_trace_includes_backend_and_format(self) -> None:
+        with mock.patch.object(trace.envs, "VLLM_QDQ_TRACE", True), mock.patch("builtins.print") as print_mock:
+            trace.trace_qdq(
+                "marlin_gemm",
+                torch.Size((2, 32)),
+                torch.bfloat16,
+                backend="CuTe",
+                format_name="MXFP8",
+            )
+
+        print_mock.assert_called_once_with(
+            "[QDQ] backend=CuTe format=MXFP8 op=marlin_gemm shape=torch.Size([2, 32]) dtype=torch.bfloat16"
+        )
+
+    def test_trace_is_silent_when_disabled(self) -> None:
+        with mock.patch.object(trace.envs, "VLLM_QDQ_TRACE", False), mock.patch("builtins.print") as print_mock:
+            trace.trace_qdq(
+                "nvfp4_e5m3_qdq",
+                torch.Size((2, 16)),
+                torch.float16,
+                backend="Reference",
+                format_name="NVFP4_E5M3",
+            )
+
+        print_mock.assert_not_called()
+
+    def test_reference_route_reports_actual_backend_and_format(self) -> None:
+        input_tensor = torch.zeros((2, 32), dtype=torch.bfloat16)
+        with mock.patch.object(trace.envs, "VLLM_QDQ_TRACE", True), mock.patch.object(
+            trace.envs, "VLLM_QDQ_CUTE", False
+        ), mock.patch("builtins.print") as print_mock:
+            mxfp8_qdq(input_tensor, trace_op_name="marlin_gemm")
+
+        message = print_mock.call_args.args[0]
+        self.assertIn("backend=Reference format=MXFP8 op=marlin_gemm", message)
+
+    def test_cute_route_reports_actual_backend_and_format(self) -> None:
+        from vllm_qdq_plugin.qdq import cute
+
+        input_tensor = torch.zeros((2, 32), dtype=torch.bfloat16)
+        with mock.patch.object(trace.envs, "VLLM_QDQ_TRACE", True), mock.patch.object(
+            cute, "cute_qdq_status", return_value=(True, "CuTe DSL is available")
+        ), mock.patch.object(cute, "_mxfp8_qdq_cute_op", side_effect=lambda value: value), mock.patch(
+            "builtins.print"
+        ) as print_mock:
+            cute.mxfp8_qdq_cute(input_tensor, trace_op_name="marlin_gemm")
+
+        message = print_mock.call_args.args[0]
+        self.assertIn("backend=CuTe format=MXFP8 op=marlin_gemm", message)
+
+    def test_nvfp4_reference_route_reports_format(self) -> None:
+        input_tensor = torch.zeros((2, 16), dtype=torch.float16)
+        with mock.patch.object(trace.envs, "VLLM_QDQ_TRACE", True), mock.patch.object(
+            trace.envs, "VLLM_QDQ_CUTE", False
+        ), mock.patch("builtins.print") as print_mock:
+            nvfp4_e5m3_qdq(input_tensor)
+
+        message = print_mock.call_args.args[0]
+        self.assertIn("backend=Reference format=NVFP4_E5M3 op=nvfp4_e5m3_qdq", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/vllm-qdq-plugin/tests/test_trace.py
+++ b/benchmark/vllm-qdq-plugin/tests/test_trace.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 
 import torch
-
 from vllm_qdq_plugin import trace
 from vllm_qdq_plugin.qdq.mxfp8 import mxfp8_qdq
 from vllm_qdq_plugin.qdq.nvfp4_e5m3 import nvfp4_e5m3_qdq


### PR DESCRIPTION
…ated functions

## Type of Change

Log enhancement



## Description

`VLLM_QDQ_TRACE=1`  + `--enforce_eager`

```
(Worker_TP3 pid=934596) [QDQ] backend=CuTe format=NVFP4_E5M3 op=nvfp4_e5m3_moe_input shape=torch.Size([3200, 7168]) dtype=torch.bfloat16                                               
(Worker_TP3 pid=934596) [QDQ] backend=CuTe format=NVFP4_E5M3 op=nvfp4_e5m3_moe_activation shape=torch.Size([25600, 512]) dtype=torch.bfloat16                                          
(Worker_TP3 pid=934596) [QDQ] backend=CuTe format=MXFP8 op=marlin_gemm shape=torch.Size([3200, 7168]) dtype=torch.bfloat16                                                             
(Worker_TP3 pid=934596) [QDQ] backend=CuTe format=MXFP8 op=marlin_gemm shape=torch.Size([3200, 1536]) dtype=torch.bfloat16                                                             
(Worker_TP3 pid=934596) [QDQ] backend=CuTe format=MXFP8 op=marlin_gemm shape=torch.Size([3200, 4096]) dtype=torch.bfloat16                                                             
(Worker_TP3 pid=934596) [QDQ] backend=CuTe format=MXFP8 op=marlin_gemm shape=torch.Size([3200, 7168]) dtype=torch.bfloat16                                                             
(Worker_TP3 pid=934596) [QDQ] backend=CuTe format=MXFP8 op=marlin_gemm shape=torch.Size([3200, 512]) dtype=torch.bfloat16 

```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
